### PR TITLE
Fix bug in `_runAsyncNode`

### DIFF
--- a/effect/Effect.ts
+++ b/effect/Effect.ts
@@ -205,7 +205,7 @@ function _runAsyncNode(node: _Node) {
     let value: unknown;
     while (nodes.length) {
       const node = nodes.pop()!;
-      if (!node.deps.every((x) => x.resolved)) break;
+      if (!node.deps.every((x) => x.resolved)) return;
       if (node.kind === "syncFunc") {
         value = node.fn(...node.deps.map((x) => x.value));
         node.resolved = true;


### PR DESCRIPTION
Fixes `examples:balance` to return the actual balance instead of a function. One line fix!