### PR TITLE
chore: fix star task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env
+_star.ts
 benches.json
 target
 examples/generated

--- a/_tasks/star.ts
+++ b/_tasks/star.ts
@@ -8,9 +8,9 @@ for await (
     skip: [/^target\//],
   })
 ) {
-  generated += `import ${JSON.stringify(`../${entry.path}`)};\n`;
+  generated += `import ${JSON.stringify(`./${entry.path}`)};\n`;
 }
 
-const dest = path.join(Deno.cwd(), "target", "star.ts");
+const dest = path.join(Deno.cwd(), "_star.ts");
 console.log(`Writing "star" file to "${dest}".`);
 await Deno.writeTextFile(dest, generated);

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,7 +30,7 @@
     "build_sr25519_wasm": "deno task build_wasm bindings/sr25519 --features sr25519",
     "build_ss58_wasm": "deno task build_wasm bindings/ss58 --features ss58",
     "build_all_wasm": "deno task build_hashers_wasm && deno task build_sr25519_wasm && deno task build_ss58_wasm",
-    "star": "deno run -A --no-check=remote _tasks/star.ts && deno cache --no-check=remote target/star.ts",
+    "star": "deno run -A --no-check=remote _tasks/star.ts && deno cache --no-check=remote _star.ts",
     "build_npm_pkg": "deno run -A --no-check=remote _tasks/build_npm_pkg.ts",
     "lock": "deno task star --lock=lock.json --lock-write",
     "example:metadata": "deno run -A --no-check examples/metadata.ts",


### PR DESCRIPTION
`deno task star` on fresh repos was causing a failure, since we no longer require a bootstrap step (which previously created a now-non-existent `target` dir). Caused a dir-not-found err.