### PR TITLE
feat: subscription iteration

### DIFF
--- a/examples/rpc/subscription_iter.ts
+++ b/examples/rpc/subscription_iter.ts
@@ -1,0 +1,7 @@
+import * as C from "../../mod.ts";
+
+const client = await C.wsRpcClient(C.POLKADOT_RPC_URL);
+const subscription = new C.Subscription(client, "chain_subscribeAllHeads", []);
+for await (const notif of subscription) {
+  console.log(notif);
+}

--- a/rpc/Subscription.ts
+++ b/rpc/Subscription.ts
@@ -1,0 +1,57 @@
+import { deferred } from "../_deps/async.ts";
+import { RpcClient, StopListening } from "./Base.ts";
+import { RpcError } from "./Error.ts";
+import * as M from "./messages.ts";
+
+export class Subscription<Method extends M.SubscriptionMethodName>
+  implements AsyncIterableIterator<M.NotifMessage<Method>>
+{
+  #queue: M.NotifMessage<Method>[] = [];
+  #cbs: ((value: IteratorYieldResult<M.NotifMessage<Method>>) => void)[] = [];
+  #stop?: StopListening;
+
+  constructor(
+    readonly client: RpcClient<RpcError>,
+    readonly method: Method,
+    readonly params: M.InitMessage<Method>["params"],
+  ) {}
+
+  #start = async () => {
+    this.#stop = await this.client.subscribe(this.method, this.params, (ingressMessage) => {
+      const cb = this.#cbs.shift();
+      if (cb) {
+        cb({ done: false, value: ingressMessage });
+      } else {
+        this.#queue.push(ingressMessage);
+      }
+    });
+  };
+
+  async next(): Promise<IteratorResult<M.NotifMessage<Method>, void>> {
+    if (!this.#stop) {
+      await this.#start();
+    }
+    if (this.#queue.length) {
+      return {
+        done: false,
+        value: this.#queue.shift()!,
+      };
+    }
+    const pending = deferred<IteratorYieldResult<M.NotifMessage<Method>>>();
+    this.#cbs.push(pending.resolve);
+    return pending;
+  }
+
+  async return(): Promise<IteratorReturnResult<void>> {
+    this.#stop!();
+    this.#stop = undefined;
+    return {
+      done: true,
+      value: undefined,
+    };
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}

--- a/rpc/mod.ts
+++ b/rpc/mod.ts
@@ -2,6 +2,7 @@ export * from "./Base.ts";
 export * from "./Error.ts";
 export * from "./messages.ts";
 export * from "./smoldot.ts";
+export * from "./Subscription.ts";
 export * from "./types/mod.ts";
 export * from "./util.ts";
 export * from "./ws.ts";


### PR DESCRIPTION
Resolves #10.

Desired end state (of raw RPC usage, not the effect equivalent):

```ts
import * as C from "capi";

const subscription = await C.client(C.POLKADOT_RPC_URL);

const subscription = client.subscription("chain_subscribeAllHeads", []);

for await (const notif of subscription) {
  console.log(notif);
  if (someCondition(notif)) {
    break; // Closes subscription
  }
}
```

Currently working:

```ts
import * as C from "capi";

const client = await C.wsRpcClient(C.POLKADOT_RPC_URL);

const subscription = new C.Subscription(client, "chain_subscribeAllHeads", []);

for await (const notif of subscription) {
  console.log(notif);
  if (someCondition(notif)) {
    break; // Closes subscription
  }
}
```