### PR TITLE
feat: encode narrow RPC methods in beacon, propagate to messages

### DIFF
--- a/_tasks/download_frame_metadata.ts
+++ b/_tasks/download_frame_metadata.ts
@@ -16,7 +16,7 @@ await Promise.all(
     subsocial: known.SUBSOCIAL_PROXY_WS_URL,
     westend: known.WESTEND_PROXY_WS_URL,
   }).map(async ([name, url]) => {
-    const client = await rpc.rpcClient(url);
+    const client = await rpc.client(rpc.beacon([url]));
     assert(!(client instanceof Error));
     try {
       const metadata = await client.call("state_getMetadata", []);

--- a/examples/balance.ts
+++ b/examples/balance.ts
@@ -1,9 +1,9 @@
 import { assert } from "../_deps/asserts.ts";
 import { polkadotBeacon } from "../known/mod.ts";
 import * as C from "../mod.ts";
-import { rpcClient } from "../rpc/mod.ts";
+import * as rpc from "../rpc/mod.ts";
 
-const client = await rpcClient(...polkadotBeacon);
+const client = await rpc.client(rpc.beacon(polkadotBeacon));
 assert(!(client instanceof Error));
 const ss58 = C.ss58FromText("13SceNt2ELz3ti4rnQbY1snpYH4XE4fLFsW8ph9rpwJd6HFC");
 const pubKey = C.pubKeyFromSs58(ss58);
@@ -12,7 +12,5 @@ const pallet = C.pallet(client, "System");
 const map = C.map(pallet, "Account");
 const entry = C.mapEntry(map, accountId32);
 const result = await C.read(entry).run();
-
 console.log({ result });
-
 client.close();

--- a/examples/events.ts
+++ b/examples/events.ts
@@ -1,9 +1,9 @@
 import { assert } from "../_deps/asserts.ts";
 import { westendBeacon } from "../known/mod.ts";
 import * as C from "../mod.ts";
-import { rpcClient } from "../rpc/mod.ts";
+import * as rpc from "../rpc/mod.ts";
 
-const client = await rpcClient(...westendBeacon);
+const client = await rpc.client(rpc.beacon(westendBeacon));
 assert(!(client instanceof Error));
 const $pallet = C.pallet(client, "System");
 const $entry = C.entry($pallet, "Events");

--- a/examples/first_ten_keys.ts
+++ b/examples/first_ten_keys.ts
@@ -1,14 +1,12 @@
 import { assert } from "../_deps/asserts.ts";
 import { polkadotBeacon } from "../known/mod.ts";
 import * as C from "../mod.ts";
-import { rpcClient } from "../rpc/mod.ts";
+import * as rpc from "../rpc/mod.ts";
 
-const client = await rpcClient(...polkadotBeacon);
+const client = await rpc.client(rpc.beacon(polkadotBeacon));
 assert(!(client instanceof Error));
 const pallet = C.pallet(client, "System");
 const map = C.map(pallet, "Account");
 const result = await C.mapKeys(map, 10).run();
-
 console.log({ result });
-
 client.close();

--- a/examples/metadata.ts
+++ b/examples/metadata.ts
@@ -1,9 +1,9 @@
 import { assert } from "../_deps/asserts.ts";
 import { polkadotBeacon } from "../known/mod.ts";
 import * as C from "../mod.ts";
-import { rpcClient } from "../rpc/mod.ts";
+import * as rpc from "../rpc/mod.ts";
 
-const client = await rpcClient(...polkadotBeacon);
+const client = await rpc.client(rpc.beacon(polkadotBeacon));
 assert(!(client instanceof Error));
 const $metadata = C.metadata(client);
 const result = await $metadata.run();

--- a/examples/rpc/call.ts
+++ b/examples/rpc/call.ts
@@ -1,8 +1,8 @@
 import { assert } from "../../_deps/asserts.ts";
 import { polkadotBeacon } from "../../known/mod.ts";
-import { rpcClient } from "../../rpc/mod.ts";
+import * as rpc from "../../rpc/mod.ts";
 
-const client = await rpcClient(...polkadotBeacon);
+const client = await rpc.client(rpc.beacon(polkadotBeacon));
 assert(!(client instanceof Error));
 const result = await client.call("state_getMetadata", []);
 console.log(result);

--- a/examples/rpc/subscription.ts
+++ b/examples/rpc/subscription.ts
@@ -1,8 +1,8 @@
 import { assert } from "../../_deps/asserts.ts";
 import { polkadotBeacon } from "../../known/mod.ts";
-import { rpcClient } from "../../rpc/mod.ts";
+import * as rpc from "../../rpc/mod.ts";
 
-const client = await rpcClient(...polkadotBeacon);
+const client = await rpc.client(rpc.beacon(polkadotBeacon));
 assert(!(client instanceof Error));
 const stop = await client.subscribe("chain_subscribeAllHeads", [], (message) => {
   console.log(message.params.result);

--- a/examples/transfer.ts
+++ b/examples/transfer.ts
@@ -3,11 +3,11 @@ import { Hashers, Sr25519 } from "../bindings/mod.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { westendBeacon } from "../known/mod.ts";
 import * as C from "../mod.ts";
-import { rpcClient } from "../rpc/mod.ts";
+import * as rpc from "../rpc/mod.ts";
 import * as U from "../util/mod.ts";
 
 const [client, sr25519, hashers] = await Promise.all([
-  rpcClient(...westendBeacon),
+  rpc.client(rpc.beacon(westendBeacon)),
   Sr25519(),
   Hashers(),
 ]);

--- a/rpc/auto.ts
+++ b/rpc/auto.ts
@@ -1,36 +1,47 @@
 import { ErrorCtor } from "../util/mod.ts";
+import * as M from "./messages.ts";
 import { FailedToAddChainError, FailedToStartSmoldotError, SmoldotClient } from "./smoldot.ts";
 import { FailedToOpenConnectionError, ProxyWsUrlClient } from "./ws.ts";
+
+type DiscoveryValues = readonly [string, ...string[]];
+// TODO: replace with better branded types
+type Beacon<Supported extends M.MethodName> = DiscoveryValues & {
+  _beacon: { supported: Supported };
+};
+export function beacon<Supported extends M.MethodName>(
+  discoveryValues: DiscoveryValues,
+): Beacon<Supported> {
+  return discoveryValues as Beacon<Supported>;
+}
 
 // TODO: use branded beacon types instead of string
 // TODO: dyn import smoldot and provider if chain spec is provided
 // TODO: handle retry
 // TODO: narrow to `[string, ...string[]]`
-export async function rpcClient<Beacons extends [string, ...string[]]>(
-  ...beacons: Beacons
-): Promise<
-  | SmoldotClient
-  | ProxyWsUrlClient
+export async function client<Supported extends M.MethodName>(beacon: Beacon<Supported>): Promise<
+  | SmoldotClient<Supported>
+  | ProxyWsUrlClient<Supported>
   | FailedToOpenConnectionError
   | FailedToStartSmoldotError
   | FailedToAddChainError
   | AllBeaconsErroredError
 > {
-  const [beacon, ...rest] = beacons;
+  const [e0, ...rest] = beacon;
   const result = await (async () => {
-    if (isWsUrl(beacon)) {
-      return ProxyWsUrlClient.open({ beacon });
+    if (isWsUrl(e0)) {
+      return ProxyWsUrlClient.open({ beacon: e0 });
     } else {
-      return SmoldotClient.open({ beacon });
+      return SmoldotClient.open({ beacon: e0 });
     }
   })();
   if (result instanceof Error) {
     if (rest.length > 0) {
-      return await rpcClient(...rest as [string, ...string[]]);
+      return await client(rest as unknown as Beacon<Supported>);
     }
     return new AllBeaconsErroredError();
   }
-  return result;
+  // TODO: fix
+  return result as any;
 }
 
 // TODO: validate chain spec as well

--- a/rpc/messages.ts
+++ b/rpc/messages.ts
@@ -1,27 +1,26 @@
 import { EnsureLookup } from "../util/mod.ts";
-import * as U from "../util/mod.ts";
-import * as T from "./types/mod.ts";
+import { SubscriptionIdString } from "../util/mod.ts";
+import { Methods, Subscription } from "./methods.ts";
 
-export type MethodName = keyof MethodLookup;
+export type MethodName = keyof Methods;
 
 export type InitMessageByMethodName = {
-  [N in MethodName]: InitMessageBase<N, Parameters<MethodLookup[N]>>;
+  [N in MethodName]: InitMessageBase<N, Parameters<Methods[N]>>;
 };
 export type InitMessage<N extends MethodName = MethodName> = InitMessageByMethodName[N];
 
 export type OkMessageByMethodName = {
   [N in MethodName]: OkResBase<
-    ReturnType<MethodLookup[N]> extends Subscription ? string : ReturnType<MethodLookup[N]>
+    ReturnType<Methods[N]> extends Subscription ? string : ReturnType<Methods[N]>
   >;
 };
 export type OkMessage<N extends MethodName = MethodName> = OkMessageByMethodName[N];
 
 export type NotifByMethodName = {
-  [N in MethodName as ReturnType<MethodLookup[N]> extends Subscription ? N : never]:
-    NotifMessageBase<
-      N,
-      ReturnType<MethodLookup[N]> extends Subscription<infer R> ? R : never
-    >;
+  [N in MethodName as ReturnType<Methods[N]> extends Subscription ? N : never]: NotifMessageBase<
+    N,
+    ReturnType<Methods[N]> extends Subscription<infer R> ? R : never
+  >;
 };
 export type SubscriptionMethodName = keyof NotifByMethodName;
 export type NotifMessage<N extends SubscriptionMethodName = SubscriptionMethodName> =
@@ -35,135 +34,10 @@ export type ErrMessageByName = {
 };
 export type ErrMessage<N extends ErrName = ErrName> = ErrMessageByName[N];
 
-export type IngressMessage = OkMessage | ErrMessage | NotifMessage;
-
-// TODO: attach type-level docs (draw from Substrate's source)
-/**
- * The following is modeled closely after the method definitions of Smoldot. This `Lookup` type serves as a source of
- * truth, from which we map to init, notification and ok response types. Error types are––unfortunately––not defined as
- * method-specific on the Rust side, although perhaps we could create represent them as such.
- *
- * @see https://github.com/paritytech/smoldot/blob/82836f4f2af4dd1716c57c14a4f591c7b1043950/src/json_rpc/methods.rs#L338-L479
- */
-type MethodLookup = EnsureLookup<string, (...args: any[]) => any, {
-  system_accountNextIndex(account: U.AccountIdString): number;
-  account_nextIndex: TODO_NARROW_METHOD_TYPE;
-  system_dryRun: TODO_NARROW_METHOD_TYPE;
-  system_dryRunAt: MethodLookup["system_dryRun"];
-  author_submitExtrinsic(transaction: U.HexString): U.HashHexString;
-  author_insertKey: TODO_NARROW_METHOD_TYPE;
-  author_rotateKeys(): U.HexString;
-  author_hasSessionKeys: TODO_NARROW_METHOD_TYPE;
-  author_hasKey(pubKey: string, keyType: string): string;
-  author_pendingExtrinsics(): U.HexString[];
-  author_removeExtrinsics: TODO_NARROW_METHOD_TYPE;
-  author_submitAndWatchExtrinsic(tx: string): Subscription<unknown>;
-  author_unwatchExtrinsic(subscriptionId: U.SubscriptionIdString): unknown;
-  babe_epochAuthorship(_: unknown): unknown;
-  chain_getBlock(hash?: U.HashHexString): T.Block;
-  chain_getBlockHash(height?: number): U.HashHexString;
-  chain_getHead: MethodLookup["chain_getBlockHash"];
-  chain_getFinalizedHead(): U.HashHexString;
-  chain_getFinalisedHead: MethodLookup["chain_getFinalizedHead"];
-  chain_getHeader(hash?: U.HashHexString): T.Header;
-  chain_subscribeAllHeads(): Subscription<T.Header>;
-  chain_subscribeFinalizedHeads(): Subscription<T.Header /* TODO: narrow to finalized? */>;
-  chain_subscribeFinalisedHeads: MethodLookup["chain_subscribeFinalizedHeads"];
-  chain_subscribeNewHeads(): Subscription<unknown>;
-  subscribe_newHead: MethodLookup["chain_subscribeNewHeads"];
-  chain_subscribeNewHead: MethodLookup["chain_subscribeNewHeads"];
-  chain_unsubscribeAllHeads(subscription: string): boolean;
-  chain_unsubscribeFinalizedHeads(subscription: string): boolean;
-  chain_unsubscribeFinalisedHeads: MethodLookup["chain_unsubscribeFinalizedHeads"];
-  chain_unsubscribeNewHeads(subscription: string): boolean;
-  unsubscribe_newHead: MethodLookup["chain_unsubscribeNewHeads"];
-  chain_unsubscribeNewHead: MethodLookup["chain_unsubscribeNewHeads"];
-  chainHead_unstable_follow(runtimeUpdates: boolean): Subscription<T.ChainHeadUnstableFollowEvent>;
-  childstate_getKeys: TODO_NARROW_METHOD_TYPE;
-  childstate_getStorage: TODO_NARROW_METHOD_TYPE;
-  childstate_getStorageHash: TODO_NARROW_METHOD_TYPE;
-  childstate_getStorageSize: TODO_NARROW_METHOD_TYPE;
-  grandpa_roundState: TODO_NARROW_METHOD_TYPE;
-  offchain_localStorageGet: TODO_NARROW_METHOD_TYPE;
-  offchain_localStorageSet: TODO_NARROW_METHOD_TYPE;
-  payment_queryInfo(extrinsic: U.HexString, hash?: U.HashHexString): T.RuntimeDispatchInfo;
-  rpc_methods(): T.RpcMethods;
-  state_call: TODO_NARROW_METHOD_TYPE;
-  state_callAt: MethodLookup["state_call"];
-  state_getKeys: TODO_NARROW_METHOD_TYPE;
-  state_getKeysPaged(
-    prefix: string | undefined,
-    count: number,
-    startKey?: U.HexString,
-    hash?: U.HashHexString,
-  ): U.HexString[];
-  state_getKeysPagedAt: MethodLookup["state_getKeysPaged"];
-  state_getMetadata(hash?: U.HashHexString): string;
-  state_getPairs: TODO_NARROW_METHOD_TYPE;
-  state_getReadProof: TODO_NARROW_METHOD_TYPE;
-  state_getRuntimeVersion(at?: U.HashHexString): T.RuntimeVersion;
-  chain_getRuntimeVersion: MethodLookup["state_getRuntimeVersion"];
-  state_getStorage(key: U.HexString, hash?: U.HashHexString): U.HexString;
-  state_getStorageHash: TODO_NARROW_METHOD_TYPE;
-  state_getStorageHashAt: MethodLookup["state_getStorageHash"];
-  state_getStorageSize: TODO_NARROW_METHOD_TYPE;
-  state_getStorageSizeAt: MethodLookup["state_getStorageSize"];
-  state_queryStorage: TODO_NARROW_METHOD_TYPE;
-  state_queryStorageAt(keys: U.HexString[], at?: U.HashHexString): T.StorageChangeSet;
-  state_subscribeRuntimeVersion: TODO_NARROW_METHOD_TYPE;
-  chain_subscribeRuntimeVersion: MethodLookup["state_subscribeRuntimeVersion"];
-  state_subscribeStorage(list: U.HexString[]): Subscription<"TODO">;
-  state_unsubscribeRuntimeVersion(subscription: string): boolean;
-  chain_unsubscribeRuntimeVersion: MethodLookup["state_unsubscribeRuntimeVersion"];
-  state_unsubscribeStorage(subscription: string): boolean;
-  system_addReservedPeer: TODO_NARROW_METHOD_TYPE;
-  system_chain(): string;
-  system_chainType(): T.SystemChainTypeKind;
-  system_health(): T.SystemHealth;
-  system_localListenAddresses(): string[];
-  system_localPeerId(): string;
-  system_name(): string;
-  system_networkState: TODO_NARROW_METHOD_TYPE;
-  system_nodeRoles: TODO_NARROW_METHOD_TYPE;
-  system_peers(): T.SystemPeer[];
-  system_properties: TODO_NARROW_METHOD_TYPE;
-  system_removeReservedPeer: TODO_NARROW_METHOD_TYPE;
-  system_version(): string;
-  chainHead_unstable_body(
-    followSubscription: U.HashHexString,
-    networkConfig?: T.NetworkConfig,
-  ): string;
-  chainHead_unstable_call(
-    hash: U.HashHexString | undefined,
-    fn: string,
-    callParameters: U.HexString,
-    networkConfig?: T.NetworkConfig,
-  ): string;
-  chainHead_unstable_genesisHash(): U.HashHexString;
-  chainHead_unstable_header(
-    followSubscription: string,
-    hash: U.HashHexString,
-  ): U.HexString | undefined;
-  chainHead_unstable_stopBody(subscription: string): void;
-  chainHead_unstable_stopCall(subscription: string): void;
-  chainHead_unstable_stopStorage(subscription: string): void;
-  chainHead_unstable_storage(
-    follow_subscription: U.SubscriptionIdString,
-    hash: U.HashHexString,
-    key: U.HexString,
-    childKey?: U.HexString,
-    networkConfig?: T.NetworkConfig,
-  ): string;
-  chainHead_unstable_unfollow(followSubscription: U.SubscriptionIdString): void;
-  chainHead_unstable_unpin(followSubscription: U.SubscriptionIdString, hash: U.HashHexString): void;
-  chainSpec_unstable_chainName(): string;
-  chainSpec_unstable_genesisHash(): string;
-  chainSpec_unstable_properties(): unknown;
-  sudo_unstable_p2pDiscover(multiaddr: U.MultiAddressString): void;
-  sudo_unstable_version(): string;
-  transaction_unstable_submitAndWatch(transaction: U.HexString): U.SubscriptionIdString;
-  transaction_unstable_unwatch(subscription: U.SubscriptionIdString): void;
-}>;
+export type IngressMessage<M extends MethodName = MethodName> =
+  | OkMessage<M>
+  | ErrMessage
+  | NotifMessage<Extract<M, SubscriptionMethodName>>;
 
 type ErrDetailLookup = EnsureLookup<string, [code: number, data?: any], {
   /**
@@ -223,16 +97,12 @@ export interface NotifMessageBase<Method extends MethodName, Result> extends Jso
   method: Method;
   id?: never;
   params: {
-    subscription: U.SubscriptionIdString;
+    subscription: SubscriptionIdString;
     result: Result;
   };
   result?: never;
   error?: never;
 }
-
-const _N: unique symbol = Symbol();
-type Subscription<NotificationResult = any> = { [_N]: NotificationResult };
-type TODO_NARROW_METHOD_TYPE = (...args: unknown[]) => unknown;
 
 interface ErrorMessageBase<
   Code extends number,

--- a/rpc/methods.ts
+++ b/rpc/methods.ts
@@ -1,0 +1,168 @@
+import * as U from "../util/mod.ts";
+import * as T from "./types/mod.ts";
+
+// Swap with branded type
+const _N: unique symbol = Symbol();
+export type Subscription<NotificationResult = any> = { [_N]: NotificationResult };
+type TODO_NARROW_METHOD_TYPE = (...args: unknown[]) => unknown;
+
+// TODO: attach type-level docs (draw from Substrate's source)
+/**
+ * The following is modeled closely after the method definitions of Smoldot. This `Lookup` type serves as a source of
+ * truth, from which we map to init, notification and ok response types. Error types are––unfortunately––not defined as
+ * method-specific on the Rust side, although perhaps we could create represent them as such.
+ *
+ * @see https://github.com/paritytech/smoldot/blob/82836f4f2af4dd1716c57c14a4f591c7b1043950/src/json_rpc/methods.rs#L338-L479
+ */
+export type Methods = Lookup<{
+  account: {
+    nextIndex: TODO_NARROW_METHOD_TYPE;
+  };
+  author: {
+    hasKey(pubKey: string, keyType: string): string;
+    hasSessionKeys: TODO_NARROW_METHOD_TYPE;
+    insertKey: TODO_NARROW_METHOD_TYPE;
+    pendingExtrinsics(): U.HexString[];
+    removeExtrinsics: TODO_NARROW_METHOD_TYPE;
+    rotateKeys(): U.HexString;
+    submitAndWatchExtrinsic(tx: string): Subscription<unknown>;
+    submitExtrinsic(transaction: U.HexString): U.HashHexString;
+    unwatchExtrinsic(subscriptionId: U.SubscriptionIdString): unknown;
+  };
+  babe: {
+    epochAuthorship(_: unknown): unknown;
+  };
+  chain: {
+    getBlock(hash?: U.HashHexString): T.Block;
+    getBlockHash(height?: number): U.HashHexString;
+    getFinalisedHead: Methods["chain_getFinalizedHead"];
+    getFinalizedHead(): U.HashHexString;
+    getHead: Methods["chain_getBlockHash"];
+    getHeader(hash?: U.HashHexString): T.Header;
+    getRuntimeVersion: Methods["state_getRuntimeVersion"];
+    subscribeAllHeads(): Subscription<T.Header>;
+    subscribeFinalisedHeads: Methods["chain_subscribeFinalizedHeads"];
+    subscribeFinalizedHeads(): Subscription<T.Header /* TODO: narrow to finalized? */>;
+    subscribeNewHead: Methods["chain_subscribeNewHeads"];
+    subscribeNewHeads(): Subscription<unknown>;
+    subscribeRuntimeVersion: Methods["state_subscribeRuntimeVersion"];
+    subscribe_newHead: Methods["chain_subscribeNewHeads"];
+    unsubscribeAllHeads(subscription: string): boolean;
+    unsubscribeFinalisedHeads: Methods["chain_unsubscribeFinalizedHeads"];
+    unsubscribeFinalizedHeads(subscription: string): boolean;
+    unsubscribeNewHead: Methods["chain_unsubscribeNewHeads"];
+    unsubscribeNewHeads(subscription: string): boolean;
+    unsubscribeRuntimeVersion: Methods["state_unsubscribeRuntimeVersion"];
+    unsubscribe_newHead: Methods["chain_unsubscribeNewHeads"];
+  };
+  chainHead: {
+    unstable_body(followSubscription: U.HashHexString, networkConfig?: T.NetworkConfig): string;
+    unstable_call(
+      hash: U.HashHexString | undefined,
+      fn: string,
+      callParameters: U.HexString,
+      networkConfig?: T.NetworkConfig,
+    ): string;
+    unstable_follow(runtimeUpdates: boolean): Subscription<T.ChainHeadUnstableFollowEvent>;
+    unstable_genesisHash(): U.HashHexString;
+    unstable_header(followSubscription: string, hash: U.HashHexString): U.HexString | undefined;
+    unstable_stopBody(subscription: string): void;
+    unstable_stopCall(subscription: string): void;
+    unstable_stopStorage(subscription: string): void;
+    unstable_storage(
+      follow_subscription: U.SubscriptionIdString,
+      hash: U.HashHexString,
+      key: U.HexString,
+      childKey?: U.HexString,
+      networkConfig?: T.NetworkConfig,
+    ): string;
+    unstable_unfollow(followSubscription: U.SubscriptionIdString): void;
+    unstable_unpin(followSubscription: U.SubscriptionIdString, hash: U.HashHexString): void;
+  };
+  childState: {
+    getKeys: TODO_NARROW_METHOD_TYPE;
+    getStorage: TODO_NARROW_METHOD_TYPE;
+    getStorageHash: TODO_NARROW_METHOD_TYPE;
+    getStorageSize: TODO_NARROW_METHOD_TYPE;
+  };
+  chainSpec: {
+    unstable_chainName(): string;
+    unstable_genesisHash(): string;
+    unstable_properties(): unknown;
+  };
+  grandpa: {
+    roundState: TODO_NARROW_METHOD_TYPE;
+  };
+  offchain: {
+    localStorageGet: TODO_NARROW_METHOD_TYPE;
+    localStorageSet: TODO_NARROW_METHOD_TYPE;
+  };
+  payment: {
+    queryInfo(extrinsic: U.HexString, hash?: U.HashHexString): T.RuntimeDispatchInfo;
+  };
+  rpc: {
+    methods(): T.RpcMethods;
+  };
+  state: {
+    call: TODO_NARROW_METHOD_TYPE;
+    callAt: Methods["state_call"];
+    getKeys: TODO_NARROW_METHOD_TYPE;
+    getKeysPagedAt: Methods["state_getKeysPaged"];
+    getMetadata(hash?: U.HashHexString): string;
+    getPairs: TODO_NARROW_METHOD_TYPE;
+    getReadProof: TODO_NARROW_METHOD_TYPE;
+    getRuntimeVersion(at?: U.HashHexString): T.RuntimeVersion;
+    getStorage(key: U.HexString, hash?: U.HashHexString): U.HexString;
+    getStorageHash: TODO_NARROW_METHOD_TYPE;
+    getStorageHashAt: Methods["state_getStorageHash"];
+    getStorageSize: TODO_NARROW_METHOD_TYPE;
+    getStorageSizeAt: Methods["state_getStorageSize"];
+    queryStorage: TODO_NARROW_METHOD_TYPE;
+    queryStorageAt(keys: U.HexString[], at?: U.HashHexString): T.StorageChangeSet;
+    subscribeRuntimeVersion: TODO_NARROW_METHOD_TYPE;
+    subscribeStorage(list: U.HexString[]): Subscription<"TODO">;
+    unsubscribeRuntimeVersion(subscription: string): boolean;
+    unsubscribeStorage(subscription: string): boolean;
+    getKeysPaged(
+      prefix: string | undefined,
+      count: number,
+      startKey?: U.HexString,
+      hash?: U.HashHexString,
+    ): U.HexString[];
+  };
+  sudo: {
+    unstable_p2pDiscover(multiaddr: U.MultiAddressString): void;
+    unstable_version(): string;
+  };
+  system: {
+    accountNextIndex(account: U.AccountIdString): number;
+    addReservedPeer: TODO_NARROW_METHOD_TYPE;
+    chain(): string;
+    chainType(): T.SystemChainTypeKind;
+    dryRun: TODO_NARROW_METHOD_TYPE;
+    dryRunAt: Methods["system_dryRun"];
+    health(): T.SystemHealth;
+    localListenAddresses(): string[];
+    localPeerId(): string;
+    name(): string;
+    networkState: TODO_NARROW_METHOD_TYPE;
+    nodeRoles: TODO_NARROW_METHOD_TYPE;
+    peers(): T.SystemPeer[];
+    properties: TODO_NARROW_METHOD_TYPE;
+    removeReservedPeer: TODO_NARROW_METHOD_TYPE;
+    version(): string;
+  };
+  transaction: {
+    unstable_submitAndWatch(transaction: U.HexString): U.SubscriptionIdString;
+    unstable_unwatch(subscription: U.SubscriptionIdString): void;
+  };
+}>;
+
+type Lookup<Lookup extends Record<string, Record<string, (...args: any[]) => any>>> = U.U2I<
+  {
+    [Prefix in keyof Lookup]: {
+      [M in keyof Lookup[Prefix] as `${Extract<Prefix, string>}_${Extract<M, string>}`]:
+        Lookup[Prefix][M];
+    };
+  }[keyof Lookup]
+>;

--- a/rpc/mod.ts
+++ b/rpc/mod.ts
@@ -1,7 +1,8 @@
+import { MethodName } from "./messages.ts";
 import { SmoldotClient } from "./smoldot.ts";
 import { ProxyWsUrlClient } from "./ws.ts";
 
-export type AnyClient = ProxyWsUrlClient | SmoldotClient;
+export type AnyClient = ProxyWsUrlClient<MethodName> | SmoldotClient<MethodName>;
 
 export * from "./auto.ts";
 export * from "./Base.ts";

--- a/rpc/smoldot.ts
+++ b/rpc/smoldot.ts
@@ -3,7 +3,9 @@ import { ErrorCtor } from "../util/mod.ts";
 import * as B from "./Base.ts";
 import * as M from "./messages.ts";
 
-export class SmoldotClient extends B.Client<string, string, unknown, SmoldotInternalError> {
+export class SmoldotClient<Supported extends M.MethodName>
+  extends B.Client<Supported, string, string, unknown, SmoldotInternalError>
+{
   static #innerClient?: smoldot.Client;
   #chain?: smoldot.Chain;
 
@@ -19,9 +21,9 @@ export class SmoldotClient extends B.Client<string, string, unknown, SmoldotInte
     return SmoldotClient.#innerClient;
   };
 
-  static async open(
-    props: B.ClientProps<string, SmoldotInternalError>,
-  ): Promise<SmoldotClient | FailedToStartSmoldotError | FailedToAddChainError> {
+  static async open<Supported extends M.MethodName>(
+    props: B.ClientProps<Supported, string, SmoldotInternalError>,
+  ): Promise<SmoldotClient<Supported> | FailedToStartSmoldotError | FailedToAddChainError> {
     const inner = await SmoldotClient.#ensureInstance();
     if (inner instanceof Error) {
       return inner;
@@ -59,7 +61,7 @@ export class SmoldotClient extends B.Client<string, string, unknown, SmoldotInte
 
   parseIngressMessage = (
     rawIngressMessage: string,
-  ): M.IngressMessage | B.ParseRawIngressMessageError => {
+  ): M.IngressMessage<Supported> | B.ParseRawIngressMessageError => {
     try {
       return JSON.parse(rawIngressMessage);
     } catch (_e) {


### PR DESCRIPTION
This PR changes the RPC interface.

We must now create a beacon, the type of which is encoded with supported methods.

The following is a beacon that only supports the `state_getMetadata` method.

```ts
import * as rpc from "capi/rpc";

const beacon = rpc.beacon<"state_getMetadata">([URL]);
```

We can allow all methods by simply omitting the type arg.

```ts
const beacon = rpc.beacon([URL]); // supports all methods
```

Now we can create the client:

```ts
const client = await rpc.client(beacon);
```

We'll get a type error if we attempt to utilize methods that are NOT encoded in the beacon as accessible.

```ts
// Allow only the `state_getStorage` method
const client = await rpc.client(rpc.beacon<"state_getStorage">(polkadotBeacon));

// Ensure that the client was successfully opened
assert(!(client instanceof Error));

// Attempt to call a different method
const result = await client.call("state_getMetadata", []);
//                                ~~~~~~~~~~~~~~~~~
//                                ^
//                                Argument of type '"state_getMetadata"' is not assignable to parameter of type '"state_getStorage"'.
                                  
```

Ultimately, we'll want to package chain-specific beacons in `known` in order to protect developers from utilizing methods that don't exist.