### PR TITLE
chore: bump smoldot-light to version 0.6.20

### DIFF
--- a/_deps/smoldot.ts
+++ b/_deps/smoldot.ts
@@ -1,3 +1,3 @@
 // Smoldot is a peer dependency; we only utilize its types, never its runtime.
-// @deno-types="https://esm.sh/@substrate/smoldot-light@0.6.19/dist/index.d.ts"
+// @deno-types="https://esm.sh/@substrate/smoldot-light@0.6.20/dist/index.d.ts"
 export * from "./smoldot_phantom.ts";

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -26,7 +26,7 @@ await Promise.all([
       },
       "_deps/smoldot_phantom.ts": {
         name: "@substrate/smoldot-light",
-        version: "0.6.19",
+        version: "0.6.20",
         peerDependency: true,
       },
     },


### PR DESCRIPTION
This version of smoldot contains adds `{type: "module"}` to the Web Worker in order to be supported for deno