### PR TITLE
feat: decoding extrinsics within blocks

### DIFF
--- a/_deps/scale.ts
+++ b/_deps/scale.ts
@@ -1,1 +1,3 @@
-export * from "https://deno.land/x/scale@v0.2.1/mod.ts";
+export * from "https://raw.githubusercontent.com/paritytech/parity-scale-codec-ts/7b40cffaf930bf945b09b39a6a4196509d6cd262/mod.ts";
+// TODO: replace line above with line below (with new version) upon release with bit sequence codec
+// export * from "https://deno.land/x/scale@v0.2.1/mod.ts";

--- a/core/Block.ts
+++ b/core/Block.ts
@@ -1,3 +1,4 @@
+import { read } from "../runtime/mod.ts";
 import { HashHexString } from "../util/mod.ts";
 import { Chain } from "./Chain.ts";
 import { NodeBase } from "./common.ts";
@@ -8,5 +9,9 @@ export class Block<C extends Chain = Chain> extends NodeBase<"Block"> {
     readonly hash?: HashHexString,
   ) {
     super("Block");
+  }
+
+  read(): Promise<unknown> {
+    return read(this);
   }
 }

--- a/examples/block.ts
+++ b/examples/block.ts
@@ -1,0 +1,5 @@
+import { polkadot } from "../known/mod.ts";
+
+const result = await polkadot.block().read();
+
+console.log({ result });

--- a/frame_metadata/Codec.ts
+++ b/frame_metadata/Codec.ts
@@ -139,7 +139,7 @@ export function DeriveCodec(metadata: M.Metadata): DeriveCodec {
       return $.compact;
     },
     BitSequence: () => {
-      return $.never as unknown as $.Codec<any>;
+      return $.bitSequence;
     },
     visit: (i) => {
       if (cache[i]) {

--- a/frame_metadata/Extrinsic.ts
+++ b/frame_metadata/Extrinsic.ts
@@ -24,8 +24,8 @@ interface ExtrinsicCodecProps {
   sign: (value: Uint8Array) => Signature;
 }
 
-export function $extrinsic(args: ExtrinsicCodecProps): $.Codec<Extrinsic> {
-  const { metadata, sign, deriveCodec, hashers: { Blake2_256 } } = args;
+export function $extrinsic(props: ExtrinsicCodecProps): $.Codec<Extrinsic> {
+  const { metadata, sign, deriveCodec, hashers: { Blake2_256 } } = props;
   const { signedExtensions } = metadata.extrinsic;
   const $sig = deriveCodec(findExtrinsicTypeParam("Signature")!);
   const $address = deriveCodec(findExtrinsicTypeParam("Address")!);
@@ -97,7 +97,7 @@ export function $extrinsic(args: ExtrinsicCodecProps): $.Codec<Extrinsic> {
   });
 
   return $.createCodec({
-    _metadata: [$extrinsic, args],
+    _metadata: [$extrinsic, props],
     _staticSize: $.nCompact._staticSize,
     _encode(buffer, extrinsic) {
       const encoded = $baseExtrinsic.encode(extrinsic);


### PR DESCRIPTION
```ts
import { polkadot } from "capi/known";

const result = await polkadot.block().read();
```

`result.block.extrinsics` may look––for example––as follows:

```ts
[
  {
    protocolVersion: 4,
    signature: undefined,
    palletName: "Timestamp",
    methodName: "set",
    args: { now: 1656730165771 }
  },
  {
    protocolVersion: 4,
    signature: undefined,
    palletName: "ParaInherent",
    methodName: "enter",
    args: {
      data: {
        bitfields: [Array],
        backed_candidates: [Array],
        disputes: [Array],
        parent_header: [Object]
      }
    }
  }
]
```