### PR TITLE
feat: effects can spawn new runs, key page and block reads

### DIFF
--- a/effect/atoms/Codec.ts
+++ b/effect/atoms/Codec.ts
@@ -2,7 +2,6 @@ import * as M from "../../frame_metadata/mod.ts";
 import { atom } from "../sys/Atom.ts";
 import { Val } from "../sys/Effect.ts";
 
-export type Codec = ReturnType<typeof codec>;
 export function codec<
   DeriveCodec extends Val<M.DeriveCodec>,
   TypeI extends Val<number>,

--- a/effect/atoms/Decoded.ts
+++ b/effect/atoms/Decoded.ts
@@ -3,7 +3,6 @@ import * as U from "../../util/mod.ts";
 import { atom } from "../sys/Atom.ts";
 import { T_, Val } from "../sys/Effect.ts";
 
-export type Decoded = ReturnType<typeof decoded>;
 export function decoded<
   Codec extends Val<$.Codec<any>>,
   Encoded extends Val<U.HexString>,

--- a/effect/atoms/DeriveCodec.ts
+++ b/effect/atoms/DeriveCodec.ts
@@ -2,7 +2,6 @@ import * as M from "../../frame_metadata/mod.ts";
 import { atom } from "../sys/Atom.ts";
 import { Val } from "../sys/Effect.ts";
 
-export type DeriveCodec = ReturnType<typeof deriveCodec>;
 export function deriveCodec<Metadata extends Val<M.Metadata>>(metadata: Metadata) {
   return atom(
     "DeriveCodec",

--- a/effect/atoms/ExtrinsicCodec.ts
+++ b/effect/atoms/ExtrinsicCodec.ts
@@ -1,0 +1,27 @@
+import * as M from "../../frame_metadata/mod.ts";
+import { Hashers } from "../../hashers/mod.ts";
+import { atom } from "../sys/Atom.ts";
+import { Val } from "../sys/Effect.ts";
+
+export function extrinsicCodec<
+  DeriveCodec extends Val<M.DeriveCodec>,
+  Metadata extends Val<M.Metadata>,
+  Rest extends [sign?: Val<M.SignExtrinsic>],
+>(
+  deriveCodec: DeriveCodec,
+  metadata: Metadata,
+  ...[sign]: Rest
+) {
+  return atom(
+    "KeyCodec",
+    [deriveCodec, metadata, sign],
+    async (deriveCodec, metadata, sign) => {
+      return M.$extrinsic({
+        deriveCodec,
+        hashers: await Hashers(),
+        metadata,
+        sign: sign!,
+      });
+    },
+  );
+}

--- a/effect/atoms/KeyCodec.ts
+++ b/effect/atoms/KeyCodec.ts
@@ -1,0 +1,27 @@
+import * as M from "../../frame_metadata/mod.ts";
+import { Hashers } from "../../hashers/mod.ts";
+import { atom } from "../sys/Atom.ts";
+import { Val } from "../sys/Effect.ts";
+
+export function keyCodec<
+  DeriveCodec extends Val<M.DeriveCodec>,
+  PalletMetadata extends Val<M.Pallet>,
+  StorageEntryMetadata extends Val<M.StorageEntry>,
+>(
+  deriveCodec: DeriveCodec,
+  palletMetadata: PalletMetadata,
+  storageEntryMetadata: StorageEntryMetadata,
+) {
+  return atom(
+    "KeyCodec",
+    [deriveCodec, palletMetadata, storageEntryMetadata],
+    async (deriveCodec, pallet, storageEntry) => {
+      return M.$storageKey({
+        deriveCodec,
+        hashers: await Hashers(),
+        pallet,
+        storageEntry,
+      });
+    },
+  );
+}

--- a/effect/atoms/Metadata.ts
+++ b/effect/atoms/Metadata.ts
@@ -6,7 +6,6 @@ import { atom } from "../sys/Atom.ts";
 import { Val } from "../sys/Effect.ts";
 import { rpcCall } from "./RpcCall.ts";
 
-export type Metadata = ReturnType<typeof metadata>;
 export function metadata<
   C extends Config<string, Pick<KnownRpcMethods, "state_getMetadata">>,
   Rest extends [blockHash?: Val<U.HashHexString | undefined>],
@@ -27,7 +26,6 @@ export function metadata<
 export class MetadataRetrievalError extends U.ErrorCtor("MetadataRetrieval") {}
 export class MetadataDecodeError extends U.ErrorCtor("MetadataDecode") {}
 
-export type PalletMetadata = ReturnType<typeof palletMetadata>;
 export function palletMetadata<
   Metadata extends Val<M.Metadata>,
   PalletName extends Val<string>,
@@ -38,7 +36,6 @@ export function palletMetadata<
   return atom("PalletMetadata", [metadata, palletName], M.getPallet);
 }
 
-export type EntryMetadata = ReturnType<typeof entryMetadata>;
 export function entryMetadata<
   PalletMetadata extends Val<M.Pallet>,
   EntryName extends Val<string>,

--- a/effect/atoms/RpcCall.ts
+++ b/effect/atoms/RpcCall.ts
@@ -5,7 +5,6 @@ import { atom } from "../sys/Atom.ts";
 import { T_, Val, ValCollection } from "../sys/Effect.ts";
 import { rpcClient } from "./RpcClient.ts";
 
-export type RpcCall = ReturnType<typeof rpcCall>;
 export function rpcCall<
   Methods extends rpc.ProviderMethods,
   MethodName extends Val<U.AssertT<keyof Methods, string>>,
@@ -18,7 +17,7 @@ export function rpcCall<
   return atom(
     "RpcCall",
     [rpcClient(config), methodName, ...params],
-    async (client, methodName, ...params) => {
+    async function(client, methodName, ...params) {
       const result = await client.call(methodName, params as Parameters<Methods[T_<MethodName>]>);
       if (result.error) {
         return new RpcError();

--- a/effect/atoms/RpcClient.ts
+++ b/effect/atoms/RpcClient.ts
@@ -2,7 +2,6 @@ import { Config } from "../../config/mod.ts";
 import * as rpc from "../../rpc/mod.ts";
 import { atom } from "../sys/Atom.ts";
 
-export type RpcClient = ReturnType<typeof rpcClient>;
 export function rpcClient<C extends Config<string>>(config: C) {
   return atom("RpcClient", [config], (config) => {
     return rpc.stdClient<Config.GetRpcProviderMethods<C>>(config.discoveryValue);

--- a/effect/atoms/Select.ts
+++ b/effect/atoms/Select.ts
@@ -1,7 +1,6 @@
 import * as U from "../../util/mod.ts";
 import * as sys from "../sys/mod.ts";
 
-export type Select = ReturnType<typeof select>;
 export function select<T, Field extends sys.Val<keyof sys.T_<T>>>(val: T, field: Field) {
   return sys.atom(
     "Select",

--- a/effect/atoms/StorageKey.ts
+++ b/effect/atoms/StorageKey.ts
@@ -4,7 +4,6 @@ import * as U from "../../util/mod.ts";
 import { atom } from "../sys/Atom.ts";
 import { Val } from "../sys/Effect.ts";
 
-export type StorageKey = ReturnType<typeof storageKey>;
 export function storageKey<
   DeriveCodec extends Val<M.DeriveCodec>,
   PalletMetadata extends Val<M.Pallet>,

--- a/effect/atoms/Wrap.ts
+++ b/effect/atoms/Wrap.ts
@@ -1,6 +1,5 @@
 import { atom, T_, Val } from "../sys/mod.ts";
 
-export type Wrap = ReturnType<typeof wrap>;
 export function wrap<T, K extends Val<PropertyKey>>(target: T, key: K) {
   return atom("Wrap", [target, key], (target, key): Record<T_<K>, T_<T>> => {
     return { [key]: target } as any;

--- a/effect/atoms/mod.ts
+++ b/effect/atoms/mod.ts
@@ -1,29 +1,8 @@
-import { Codec } from "./Codec.ts";
-import { Decoded } from "./Decoded.ts";
-import { DeriveCodec } from "./DeriveCodec.ts";
-import { EntryMetadata, Metadata, PalletMetadata } from "./Metadata.ts";
-import { RpcCall } from "./RpcCall.ts";
-import { RpcClient } from "./RpcClient.ts";
-import { Select } from "./Select.ts";
-import { StorageKey } from "./StorageKey.ts";
-import { Wrap } from "./Wrap.ts";
-
-export type CapiAtom =
-  | Metadata
-  | EntryMetadata
-  | PalletMetadata
-  | RpcClient
-  | DeriveCodec
-  | StorageKey
-  | RpcCall
-  | Codec
-  | Select
-  | Decoded
-  | Wrap;
-
 export * from "./Codec.ts";
 export * from "./Decoded.ts";
 export * from "./DeriveCodec.ts";
+export * from "./ExtrinsicCodec.ts";
+export * from "./KeyCodec.ts";
 export * from "./Metadata.ts";
 export * from "./RpcCall.ts";
 export * from "./RpcClient.ts";

--- a/effect/examples/block.ts
+++ b/effect/examples/block.ts
@@ -1,10 +1,8 @@
-import * as t from "../../test-util/mod.ts";
+import * as C from "../../known/mod.ts";
 import * as U from "../../util/mod.ts";
 import { run } from "../run.ts";
 import { readBlock } from "../std/block/read.ts";
 
-t.ctx(async (config) => {
-  const read_ = readBlock(config);
-  const result = U.throwIfError(await run(read_));
-  console.log(result.block);
-});
+const read_ = readBlock(C.polkadot);
+const result = U.throwIfError(await run(read_));
+console.log(result.block);

--- a/effect/examples/first_ten_keys.ts
+++ b/effect/examples/first_ten_keys.ts
@@ -1,10 +1,10 @@
 import * as t from "../../test-util/mod.ts";
 import * as U from "../../util/mod.ts";
 import { run } from "../run.ts";
-import { readKeys } from "../std/keys/read.ts";
+import { readKeyPage } from "../std/keyPage/read.ts";
 
 t.ctx(async (config) => {
-  const read_ = readKeys(config, "System", "Account", 10);
+  const read_ = readKeyPage(config, "System", "Account", 10);
   const result = U.throwIfError(await run(read_));
   console.log(result.keys);
 });

--- a/effect/run.ts
+++ b/effect/run.ts
@@ -1,6 +1,4 @@
-import { CapiAtom } from "./atoms/mod.ts";
 import { Run } from "./sys/mod.ts";
 
-export const run = Run<CapiAtom>((atom) => {
-  return atom;
-});
+// Capi's global effect executor
+export const run = Run();

--- a/effect/std/keyPage/read.ts
+++ b/effect/std/keyPage/read.ts
@@ -4,7 +4,7 @@ import * as U from "../../../util/mod.ts";
 import * as a from "../../atoms/mod.ts";
 import * as sys from "../../sys/mod.ts";
 
-export function readKeys<
+export function readKeyPage<
   C extends Config<string, Pick<KnownRpcMethods, "state_getMetadata" | "state_getKeysPaged">>,
   PalletName extends sys.Val<string>,
   EntryName extends sys.Val<string>,

--- a/effect/sys/Atom.ts
+++ b/effect/sys/Atom.ts
@@ -1,4 +1,5 @@
 import { E_, Effect, Resolved } from "./Effect.ts";
+import { RunContext } from "./Run.ts";
 
 export function atom<N extends string, A extends unknown[], R>(
   fqn: N,
@@ -24,7 +25,10 @@ export class Atom<N extends string, A extends unknown[], R>
 
 export type AnyAtom = Atom<string, any[], any>;
 
-export type Impl<A extends unknown[], R> = (...args: Resolved<A>) => R | Promise<R>;
+export type Impl<A extends unknown[], R> = (
+  this: RunContext,
+  ...args: Resolved<A>
+) => R | Promise<R>;
 
 // TODO: type the possibility of exit errors
 export type Exit<R> = (resolved: Exclude<R, Error>) => void | Promise<void>;

--- a/effect/sys/mod.ts
+++ b/effect/sys/mod.ts
@@ -1,3 +1,3 @@
-export { atom } from "./Atom.ts";
-export { type E_, type T_, type Val, type ValCollection } from "./Effect.ts";
-export { Run } from "./Run.ts";
+export * from "./Atom.ts";
+export * from "./Effect.ts";
+export * from "./Run.ts";

--- a/examples/first_ten_keys.ts
+++ b/examples/first_ten_keys.ts
@@ -1,11 +1,14 @@
-import { polkadot } from "../known/mod.ts";
-import * as C from "../mod.ts";
+import * as t from "../test-util/mod.ts";
 
-const result = await C
-  .chain(polkadot)
+const node = await t.node();
+
+const result = await t
+  .chain(node)
   .pallet("System")
   .entry("Account")
   .keyPage(10)
   .read();
 
 console.log({ result });
+
+node.close();

--- a/frame_metadata/Extrinsic.ts
+++ b/frame_metadata/Extrinsic.ts
@@ -20,6 +20,8 @@ interface Signature {
   value: Uint8Array;
 }
 
+export type SignExtrinsic = (value: Uint8Array) => Signature;
+
 export interface Extrinsic {
   protocolVersion: number;
   signature?:
@@ -37,7 +39,7 @@ interface ExtrinsicCodecProps {
   metadata: Metadata;
   deriveCodec: DeriveCodec;
   hashers: HasherLookup;
-  sign: (value: Uint8Array) => Signature;
+  sign: SignExtrinsic;
 }
 
 export function $extrinsic(props: ExtrinsicCodecProps): $.Codec<Extrinsic> {


### PR DESCRIPTION
Let's say you have the following effect:

```ts
 const decoded = sys.atom(
  "Anonymous",
  [$key, keysEncoded],
  (keyCodec, keysEncoded) => {
    return keysEncoded.map((keyEncoded) => {
      return keyCodec.decode(U.hex.decode(keyEncoded));
    });
  },
);
```

You can refactor the impl to a function function...

```diff
 const decoded = sys.atom(
  "Anonymous",
  [$key, keysEncoded],
- (keyCodec, keysEncoded) => {
+ function(keyCodec, keysEncoded) {
    return keysEncoded.map((keyEncoded) => {
      return keyCodec.decode(U.hex.decode(keyEncoded));
    });
  },
);
```

... which gives access to the executor via `this`:

```diff
const decoded = sys.atom(
  "Anonymous",
  [$key, keysEncoded],
  function(keyCodec, keysEncoded) {
+   this.run(anotherEffect); // would likely––in practice––await and use the result
    return keysEncoded.map((keyEncoded) => {
      return keyCodec.decode(U.hex.decode(keyEncoded));
    });
  },
);
```

Additionally, this PR cleans up the key page and block read effects with appropriate decoding.