### PR TITLE
feat: utils for derived queries

### DIFF
--- a/effect/examples/derived.ts
+++ b/effect/examples/derived.ts
@@ -1,0 +1,15 @@
+import { polkadot } from "../../known/mod.ts";
+import * as U from "../../util/mod.ts";
+import { run } from "../run.ts";
+import { readEntry } from "../std/entry/read.ts";
+import { all, into } from "../sys/mod.ts";
+
+const parachainIds = readEntry(polkadot, "Paras", "Parachains", []);
+const parachainHeads = into([parachainIds], ({ value }) => {
+  const atoms = value.map((id: number) => {
+    return readEntry(polkadot, "Paras", "Heads", [id]);
+  });
+  return all(...atoms);
+});
+const result = U.throwIfError(await run(parachainHeads));
+console.log(result);

--- a/effect/sys/Run.ts
+++ b/effect/sys/Run.ts
@@ -1,5 +1,6 @@
 import { AnyAtom, Atom } from "./Atom.ts";
 import { AnyEffect, E_, T_ } from "./Effect.ts";
+import { key } from "./key.ts";
 
 // Eventually, we'll refactor this to contain any `V` / atom-specified runtime requirements
 export interface RunContext {
@@ -82,21 +83,4 @@ export function Run(transform?: (root: AnyAtom) => AnyEffect): Run {
     }
     return val as T;
   }
-}
-
-let i = 0; // TODO: make fqn optional
-const refKeys = new Map<unknown, string>();
-export function key(val: unknown): string {
-  let refKey = refKeys.get(val);
-  if (refKey) {
-    return refKey;
-  }
-  if (val instanceof Atom) {
-    refKey = `${val.fqn}(${(val.args as any[]).map(key)})`;
-    refKeys.set(val, refKey);
-    return refKey;
-  }
-  refKey = `_${i++}`;
-  refKeys.set(val, refKey);
-  return refKey;
 }

--- a/effect/sys/key.ts
+++ b/effect/sys/key.ts
@@ -1,0 +1,18 @@
+import { Atom } from "./Atom.ts";
+
+let i = 0; // TODO: make fqn optional
+const refKeys = new Map<unknown, string>();
+export function key(val: unknown): string {
+  let refKey = refKeys.get(val);
+  if (refKey) {
+    return refKey;
+  }
+  if (val instanceof Atom) {
+    refKey = `${val.fqn}(${(val.args as any[]).map(key)})`;
+    refKeys.set(val, refKey);
+    return refKey;
+  }
+  refKey = `_${i++}`;
+  refKeys.set(val, refKey);
+  return refKey;
+}


### PR DESCRIPTION
For example, let's read the list of parachain ids and then use these ids to read their heads.

```ts
// TODO: expose these with greater simplicity
import { polkadot } from "capi/known/mod.ts";
import { run } from "./capi.ts";
import { readEntry } from "../std/entry/read.ts";
import { all, into } from "../sys/mod.ts";

// 1. Read the Ids
const parachainIds = readEntry(polkadot, "Paras", "Parachains", []);

// 2. `Into` from `parachainIds` into a new effect
const parachainHeads = into([parachainIds], ({ value }) => {
  // Use each id in the `value` list to create a new read effect
  const atoms = value.map((id) => {
    return readEntry(polkadot, "Paras", "Heads", [id]);
  });
  // Can be thought of in a similar vein to `Promise.all`
  return all(...atoms);
});

// 3. Run it all at once!
const result = await run(parachainHeads);

console.log(result); // Either the list of heads, or a typed error instance
```