### PR TITLE
feat: add select to atom

### DIFF
--- a/effect/sys/Atom.ts
+++ b/effect/sys/Atom.ts
@@ -1,4 +1,5 @@
-import { E_, Effect, Resolved, T_, ValCollection } from "./Effect.ts";
+import { select } from "../atoms/Select.ts";
+import { E_, Effect, Resolved, T_, Val, ValCollection } from "./Effect.ts";
 import { key } from "./key.ts";
 import { run, RunContext, RunResult } from "./run.ts";
 
@@ -21,6 +22,10 @@ export class Atom<N extends string, A extends unknown[], R>
     readonly exit?: Exit<R>,
   ) {
     super(fqn);
+  }
+
+  select(field: Val<keyof T_<this>>) {
+    return select(this, field);
   }
 
   run(): RunResult<this> {

--- a/examples/those_of_subxt/read_era_rewards.ts
+++ b/examples/those_of_subxt/read_era_rewards.ts
@@ -1,8 +1,10 @@
 import * as C from "../../mod.ts";
 import * as U from "../../util/mod.ts";
 
-const activeEra = C.readEntry(C.polkadot, "Staking", "ActiveEra", []);
-const activeEraIndex = C.select(C.select(activeEra, "value"), "index");
-const eraRewardPoints = C.readEntry(C.polkadot, "Staking", "ErasRewardPoints", [activeEraIndex]);
+const idx = C
+  .readEntry(C.polkadot, "Staking", "ActiveEra", [])
+  .select("value")
+  .select("index");
+const eraRewardPoints = C.readEntry(C.polkadot, "Staking", "ErasRewardPoints", [idx]);
 
 console.log(U.throwIfError(await eraRewardPoints.run()));


### PR DESCRIPTION
Enables the following, for instance:

```ts
const idx = C
  .readEntry(C.polkadot, "Staking", "ActiveEra", [])
  .select("value")
  .select("index");
```

Cleaner than...

```ts
const idx = C.select(
  C.select(
    C.readEntry(C.polkadot, "Staking", "ActiveEra", []),
    "value"
  ),
  "index",
);
```