### PR TITLE
fix: storage key handling

### DIFF
--- a/effect/atoms/StorageKey.ts
+++ b/effect/atoms/StorageKey.ts
@@ -4,7 +4,7 @@ import { atomFactory } from "../sys/Atom.ts";
 
 export const storageKey = atomFactory(
   "StorageKey",
-  ($storageKey: $.Codec<unknown>, ...keys: unknown[]) => {
-    return U.hex.encode($storageKey.encode(keys.length === 1 ? keys[0] : keys)) as U.HexString;
+  ($storageKey: $.Codec<unknown[]>, ...keys: unknown[]) => {
+    return U.hex.encode($storageKey.encode(keys)) as U.HexString;
   },
 );

--- a/frame_metadata/Key.test.ts
+++ b/frame_metadata/Key.test.ts
@@ -15,14 +15,14 @@ Deno.test("System Accounts Key", async () => {
     pallet,
     storageEntry,
   });
-  const keyEncoded = $key.encode(t.alice.publicKey);
-  const encoded = U.hex.encode(keyEncoded);
+  const key = [t.alice.publicKey];
+  const encoded = $key.encode(key);
   assertEquals(
-    encoded,
+    U.hex.encode(encoded),
     "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
   );
-  const decoded = $key.decode(keyEncoded);
-  assertEquals(decoded, t.alice.publicKey);
+  const decoded = $key.decode(encoded);
+  assertEquals(decoded, key);
 });
 
 Deno.test("Auction Winning Key", async () => {
@@ -34,7 +34,7 @@ Deno.test("Auction Winning Key", async () => {
     pallet,
     storageEntry,
   });
-  const key = 5;
+  const key = [5];
   const encoded = $key.encode(key);
   assertEquals(
     U.hex.encode(encoded),


### PR DESCRIPTION
Fixes #193.

This changes `$storageKey` to deal with keys in a tuple form (`[]`/`[A]`/`[A,B,...]`), rather than a collapsed form (`null`/`A`/`[A,B,...]`). The collapsed form was never being used in user code, so this just resulted in unnecessary extra work.

It also fixes the bug behavior of `$storageKey` for multi-part keys described in <https://github.com/paritytech/capi/issues/193#issuecomment-1231675617>.