### PR TITLE
chore: update devcontainer docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,28 @@
       "**/.git/subtree-cache/**": true,
       "target/**": true
     },
-    "dprint.path": "/home/vscode/.dprint/bin/dprint"
+    "[jsonc]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[rust]": {
+      "editor.defaultFormatter": "rust-lang.rust-analyzer"
+    },
+    "[yaml]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "dprint.dprint"
+    },
+    "deno.codeLens.testArgs": ["--no-check=remote", "-A", "-L=info"],
+    "deno.config": "./deno.jsonc",
+    "deno.enable": true,
+    "deno.lint": true,
+    "editor.defaultFormatter": "dprint.dprint",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "prettier.printWidth": 100,
+    "rust-analyzer.diagnostics.disabled": ["incorrect-ident-case"],
+    "rust-analyzer.cargo.features": ["all"]
   },
   "extensions": [
     "EditorConfig.EditorConfig",
@@ -23,6 +44,6 @@
     "streetsidesoftware.code-spell-checker",
     "vadimcn.vscode-lldb"
   ],
-  "postCreateCommand": "deno task bootstrap",
+  "postCreateCommand": "deno task star",
   "remoteUser": "vscode"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,20 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
 RUN rustup target add wasm32-unknown-unknown
 
-ENV DENO_INSTALL=/usr/local
 # crates.io index update fails without this (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918854)
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-RUN curl -fsSL https://deno.land/x/install/install.sh | sh
-RUN curl -fsSL https://dprint.dev/install.sh | sh
+USER vscode
 
-RUN export PATH=/usr/local/cargo/bin:$PATH
-RUN export DPRINT_INSTALL="/home/vscode/.dprint"
-RUN export PATH="$DPRINT_INSTALL/bin:$PATH"
+RUN /bin/bash -c 'curl -fsSL https://deno.land/x/install/install.sh | sh \
+  && curl -fsSL https://dprint.dev/install.sh | sh \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
+  && export NVM_DIR=$HOME/.nvm \
+  && . $NVM_DIR/nvm.sh \
+  && nvm install --lts \
+  && npm -g install cspell@latest'
+
+ENV DENO_INSTALL=/home/vscode/.deno
+ENV PATH=$DENO_INSTALL/bin:$PATH
+ENV DPRINT_INSTALL=/home/vscode/.dprint
+ENV PATH=$DPRINT_INSTALL/bin:$PATH

--- a/words.txt
+++ b/words.txt
@@ -168,3 +168,4 @@ Lxkf
 Tpeyg
 getrandom
 Curto
+devcontainers


### PR DESCRIPTION
Related #41 

Updates devcontainer docker image to install the following tools as `vscode` user
- `deno`
- `dprint`
- `node` (needed for `cspell`)
- `cspell`

**Developer test plan**

Using VSCode, start the project in a container
- open a `.ts` file, and try go to Class/Interface definitions in other files using `F12` (or `command + click`)
- edit a `.ts` file, add many line breaks, and validate that `dprint` with the VSCode extension formats the text
- open the VSCode terminal and run `cspell "**/*"`