### PR TITLE
feat: add extrinsic integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
       - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
         with:
           deno-version: v1.x
+      - name: Download polkadot
+        run: |
+          docker run -d --entrypoint /bin/sh --rm -it --name tmp parity/polkadot:latest
+          docker cp tmp:/usr/bin/polkadot /usr/local/bin
+          docker stop tmp
       - run: deno task lint
       - run: deno task star
       - run: deno task test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,8 @@ jobs:
           deno-version: v1.x
       - name: Download polkadot
         run: |
-          docker run -d --entrypoint /bin/sh --rm -it --name tmp parity/polkadot:latest
-          docker cp tmp:/usr/bin/polkadot /usr/local/bin
-          docker stop tmp
+          curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.28/polkadot
+          chmod +x /usr/local/bin/polkadot
       - run: deno task lint
       - run: deno task star
       - run: deno task test

--- a/effect/extrinsic.test.ts
+++ b/effect/extrinsic.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals, assertObjectMatch } from "../deps/std/testing/asserts.ts";
+import * as C from "../mod.ts";
+import * as t from "../test-util/mod.ts";
+import * as U from "../util/mod.ts";
+
+Deno.test({
+  name: "transfer",
+  fn: async (ctx) => {
+    const config = await t.config({ altRuntime: "westend" });
+
+    await ctx.step("extrinsic events", async () => {
+      const extrinsicEvents: string[] = [];
+
+      const root = C.sendAndWatchExtrinsic({
+        config,
+        sender: {
+          type: "Id",
+          value: t.alice.publicKey,
+        },
+        palletName: "Balances",
+        methodName: "transfer",
+        args: {
+          value: 12345n,
+          dest: {
+            type: "Id",
+            value: t.bob.publicKey,
+          },
+        },
+        sign(message) {
+          return {
+            type: "Sr25519",
+            value: t.alice.sign(message),
+          };
+        },
+        createWatchHandler(stop) {
+          return (event) => {
+            if (typeof event.params.result === "string") {
+              extrinsicEvents.push(event.params.result);
+            } else {
+              if (event.params.result.inBlock) {
+                extrinsicEvents.push("inBlock");
+              } else if (event.params.result.finalized) {
+                extrinsicEvents.push("finalized");
+                stop();
+              } else {
+                stop();
+              }
+            }
+          };
+        },
+      });
+
+      U.throwIfError(await root.run());
+
+      assertEquals(extrinsicEvents, ["ready", "inBlock", "finalized"]);
+    });
+
+    await ctx.step({
+      name: "account balance",
+      ignore: true,
+      fn: async () => {
+        const root = C.readEntry(config, "System", "Account", [t.bob.publicKey]);
+
+        const state = U.throwIfError(await root.run());
+
+        assertObjectMatch(state, { value: { data: { free: 12345n } } });
+      },
+    });
+
+    config.close();
+  },
+});

--- a/effect/extrinsic.test.ts
+++ b/effect/extrinsic.test.ts
@@ -1,56 +1,31 @@
+import type { KeyringPair } from "https://deno.land/x/polkadot@0.0.8/keyring/types.ts";
 import { assertEquals, assertObjectMatch } from "../deps/std/testing/asserts.ts";
 import * as C from "../mod.ts";
 import * as t from "../test-util/mod.ts";
 import * as U from "../util/mod.ts";
+import { SendAndWatchExtrinsicProps } from "./mod.ts";
 
 Deno.test({
-  name: "transfer",
+  name: "Balances.transfer",
   fn: async (ctx) => {
     const config = await t.config({ altRuntime: "westend" });
 
     await ctx.step("extrinsic events", async () => {
-      const extrinsicEvents: string[] = [];
-
-      const root = C.sendAndWatchExtrinsic({
-        config,
-        sender: {
-          type: "Id",
-          value: t.alice.publicKey,
-        },
-        palletName: "Balances",
-        methodName: "transfer",
-        args: {
-          value: 12345n,
-          dest: {
-            type: "Id",
-            value: t.bob.publicKey,
+      const extrinsicEvents: string[] = await collectExtrinsicEvents(
+        {
+          config,
+          palletName: "Balances",
+          methodName: "transfer",
+          args: {
+            value: 12345n,
+            dest: {
+              type: "Id",
+              value: t.bob.publicKey,
+            },
           },
         },
-        sign(message) {
-          return {
-            type: "Sr25519",
-            value: t.alice.sign(message),
-          };
-        },
-        createWatchHandler(stop) {
-          return (event) => {
-            if (typeof event.params.result === "string") {
-              extrinsicEvents.push(event.params.result);
-            } else {
-              if (event.params.result.inBlock) {
-                extrinsicEvents.push("inBlock");
-              } else if (event.params.result.finalized) {
-                extrinsicEvents.push("finalized");
-                stop();
-              } else {
-                stop();
-              }
-            }
-          };
-        },
-      });
-
-      U.throwIfError(await root.run());
+        t.alice,
+      );
 
       assertEquals(extrinsicEvents, ["ready", "inBlock", "finalized"]);
     });
@@ -70,3 +45,107 @@ Deno.test({
     config.close();
   },
 });
+
+Deno.test({
+  name: "Treasury.propose_spend",
+  fn: async (ctx) => {
+    const config = await t.config({ altRuntime: "westend" });
+
+    await ctx.step("extrinsic events", async () => {
+      const extrinsicEvents: string[] = await collectExtrinsicEvents(
+        {
+          config,
+          palletName: "Treasury",
+          methodName: "propose_spend",
+          args: {
+            value: 200n,
+            beneficiary: {
+              type: "Id",
+              value: t.bob.publicKey,
+            },
+          },
+        },
+        t.alice,
+      );
+
+      assertEquals(extrinsicEvents, ["ready", "inBlock", "finalized"]);
+    });
+
+    config.close();
+  },
+});
+
+Deno.test({
+  name: "Democracy.propose",
+  fn: async (ctx) => {
+    const config = await t.config({ altRuntime: "westend" });
+
+    await ctx.step("extrinsic events", async () => {
+      const extrinsicEvents: string[] = await collectExtrinsicEvents(
+        {
+          config,
+          palletName: "Democracy",
+          methodName: "propose",
+          args: {
+            proposal_hash: U.hex.decode(
+              "0x123450000000000000000000000000000000000000000000000000000000000",
+            ),
+            value: 2000000000000n,
+          },
+        },
+        t.alice,
+      );
+
+      assertEquals(extrinsicEvents, ["ready", "inBlock", "finalized"]);
+    });
+
+    config.close();
+  },
+});
+
+async function collectExtrinsicEvents(
+  { config, palletName, methodName, args }: Pick<
+    SendAndWatchExtrinsicProps,
+    "config" | "palletName" | "methodName" | "args"
+  >,
+  sender: KeyringPair,
+): Promise<string[]> {
+  const extrinsicEvents: string[] = [];
+
+  const root = C.sendAndWatchExtrinsic({
+    config,
+    sender: {
+      type: "Id",
+      value: sender.publicKey,
+    },
+    palletName,
+    methodName,
+    args,
+    sign(message) {
+      return {
+        type: "Sr25519",
+        value: sender.sign(message),
+      };
+    },
+    createWatchHandler(stop) {
+      return (event) => {
+        if (typeof event.params.result === "string") {
+          extrinsicEvents.push(event.params.result);
+        } else {
+          if (event.params.result.inBlock) {
+            extrinsicEvents.push("inBlock");
+          } else if (event.params.result.finalized) {
+            extrinsicEvents.push("finalized");
+            stop();
+          } else {
+            stop();
+          }
+        }
+      };
+    },
+  });
+
+  await U.throwIfError(await root.run());
+
+  return extrinsicEvents;
+}

--- a/effect/extrinsic.test.ts
+++ b/effect/extrinsic.test.ts
@@ -31,14 +31,13 @@ Deno.test({
     });
 
     await ctx.step({
-      name: "account balance",
-      ignore: true,
+      name: "account balance updated",
       fn: async () => {
         const root = C.readEntry(config, "System", "Account", [t.bob.publicKey]);
 
         const state = U.throwIfError(await root.run());
 
-        assertObjectMatch(state, { value: { data: { free: 12345n } } });
+        assertObjectMatch(state, { value: { data: { free: 10000000000012345n } } });
       },
     });
 

--- a/effect/extrinsic.test.ts
+++ b/effect/extrinsic.test.ts
@@ -3,7 +3,6 @@ import { assertEquals, assertObjectMatch } from "../deps/std/testing/asserts.ts"
 import * as C from "../mod.ts";
 import * as t from "../test-util/mod.ts";
 import * as U from "../util/mod.ts";
-import { SendAndWatchExtrinsicProps } from "./mod.ts";
 
 Deno.test({
   name: "Balances.transfer",
@@ -104,7 +103,7 @@ Deno.test({
 
 async function collectExtrinsicEvents(
   { config, palletName, methodName, args }: Pick<
-    SendAndWatchExtrinsicProps,
+    C.SendAndWatchExtrinsicProps,
     "config" | "palletName" | "methodName" | "args"
   >,
   sender: KeyringPair,
@@ -144,7 +143,7 @@ async function collectExtrinsicEvents(
     },
   });
 
-  await U.throwIfError(await root.run());
+  await root.run();
 
   return extrinsicEvents;
 }

--- a/effect/sys/run.ts
+++ b/effect/sys/run.ts
@@ -65,6 +65,7 @@ export const { run } = (new class Runtime implements RunContext {
         if (val.exit) {
           const applied = () => val.exit!(resolved);
           cleanup.set(val, applied);
+          this.#cache.delete(k);
         }
         return resolved;
       })();

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -53,10 +53,8 @@ export async function config(props?: NodeProps): Promise<Config> {
       ],
       stderr: "piped",
     });
-
     // For some reason, logs come in through `stderr`
     console.log(blue(`Piping node logs:`));
-
     for await (const log of process.stderr.readable) {
       await Deno.stdout.write(log);
       if (new TextDecoder().decode(log).includes(" Running JSON-RPC WS server")) {
@@ -65,7 +63,6 @@ export async function config(props?: NodeProps): Promise<Config> {
         break;
       }
     }
-
     return new Config(port, process.close.bind(process), props?.altRuntime);
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) {

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -63,7 +63,14 @@ export async function config(props?: NodeProps): Promise<Config> {
         break;
       }
     }
-    return new Config(port, process.close.bind(process), props?.altRuntime);
+    return new Config(
+      port,
+      () => {
+        process.kill("SIGKILL");
+        process.close();
+      },
+      props?.altRuntime,
+    );
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) {
       fail("Must have Polkadot installed locally. Visit https://github.com/paritytech/polkadot.");

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -106,7 +106,7 @@ async function waitForPort(
   connectOptions: Deno.ConnectOptions,
   options?: WaitForPortOptions,
 ): Promise<void> {
-  let attempts = options?.attempts ?? 20;
+  let attempts = options?.attempts ?? 60;
   const delayBetweenAttempts = options?.delayBetweenAttempts ?? 500;
 
   while (attempts > 0) {

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -31,16 +31,14 @@ export class Config
 
 export async function config(props?: NodeProps): Promise<Config> {
   if ("_browserShim" in Deno) return new Config(9944, () => {});
-  let port = 9944;
+  let port;
   if (props?.port) {
     if (!isPortAvailable(props.port)) {
       fail(`Port ${props.port} is unavailable`);
     }
     port = props.port;
   } else {
-    while (!isPortAvailable(port)) {
-      port++;
-    }
+    port = getRandomPort();
   }
   try {
     const process = Deno.run({
@@ -94,4 +92,14 @@ function isPortAvailable(port: number): boolean {
     }
     throw error;
   }
+}
+
+function getRandomPort(min = 49152, max = 65534): number {
+  let randomPort;
+
+  do {
+    randomPort = Math.floor(Math.random() * (max - min + 1) + min);
+  } while (!isPortAvailable(randomPort));
+
+  return randomPort;
 }

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -30,7 +30,7 @@ export class Config
 
 export async function config(props?: NodeProps): Promise<Config> {
   if ("_browserShim" in Deno) return new Config(9944, () => {});
-  let port;
+  let port: number;
   if (props?.port) {
     if (!isPortAvailable(props.port)) {
       fail(`Port ${props.port} is unavailable`);
@@ -88,7 +88,7 @@ function isPortAvailable(port: number): boolean {
 }
 
 function getRandomPort(min = 49152, max = 65534): number {
-  let randomPort;
+  let randomPort: number;
 
   do {
     randomPort = Math.floor(Math.random() * (max - min + 1) + min);

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -37,6 +37,11 @@ export async function config(props?: NodeProps): Promise<Config> {
     }
     port = props.port;
   } else {
+    // TODO: improve port allocation for parallel testing.
+    // This is a temporary solution for concurrent tests that need a fresh
+    // polkadot node.
+    // This might fail because another process could start to listen on the
+    // port before the polkadot process starts to listen on the configured port.
     port = getRandomPort();
   }
   try {
@@ -97,17 +102,11 @@ function getRandomPort(min = 49152, max = 65534): number {
   return randomPort;
 }
 
-interface WaitForPortOptions {
-  attempts: number;
-  delayBetweenAttempts: number;
-}
-
 async function waitForPort(
   connectOptions: Deno.ConnectOptions,
-  options?: WaitForPortOptions,
 ): Promise<void> {
-  let attempts = options?.attempts ?? 60;
-  const delayBetweenAttempts = options?.delayBetweenAttempts ?? 500;
+  let attempts = 60;
+  const delayBetweenAttempts = 500;
 
   while (attempts > 0) {
     attempts--;

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -52,18 +52,21 @@ export async function config(props?: NodeProps): Promise<Config> {
         ...props?.altRuntime ? [`--force-${props.altRuntime}`] : [],
       ],
       stderr: "piped",
-      stdout: "piped",
     });
+
     // For some reason, logs come in through `stderr`
     console.log(blue(`Piping node logs:`));
+
+    const encoder = new TextDecoder();
     for await (const log of process.stderr.readable) {
       await Deno.stdout.write(log);
-      if (new TextDecoder().decode(log).includes(" Running JSON-RPC WS server")) {
+      if (encoder.decode(log).includes(" Running JSON-RPC WS server")) {
         console.log(blue("Chain and RPC server initialized"));
         console.log(blue(`Suspending node logs`));
         break;
       }
     }
+
     return new Config(port, process.close.bind(process), props?.altRuntime);
   } catch (e) {
     if (e instanceof Deno.errors.NotFound) {

--- a/test-util/config.ts
+++ b/test-util/config.ts
@@ -57,10 +57,9 @@ export async function config(props?: NodeProps): Promise<Config> {
     // For some reason, logs come in through `stderr`
     console.log(blue(`Piping node logs:`));
 
-    const encoder = new TextDecoder();
     for await (const log of process.stderr.readable) {
       await Deno.stdout.write(log);
-      if (encoder.decode(log).includes(" Running JSON-RPC WS server")) {
+      if (new TextDecoder().decode(log).includes(" Running JSON-RPC WS server")) {
         console.log(blue("Chain and RPC server initialized"));
         console.log(blue(`Suspending node logs`));
         break;


### PR DESCRIPTION
**Description**

Add a simple extrinsic integration test that depends on the `polkadot` binary.

The `polkadot` binary is copied from the polkadot docker image.

**How Has This Been Tested?**

- validate that the test workflow action has run the `effect/extrinsic.test.ts` test
- check the test workflow logs to validate that the `polkadot` node was started during the test

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1209171/188971191-c95bb46b-ddce-4655-8f6c-7938fd4f26d3.png">

