### PR TITLE
chore: add VSCode debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -16,9 +13,6 @@
       "name": "Debug current file",
       "program": "${file}",
       "cwd": "${workspaceFolder}"
-      // "env": {
-      //   "PATH": "/path/to/polkadot/folder:${env:PATH}"
-      // }
     },
     {
       "type": "node",
@@ -29,9 +23,6 @@
       "program": "${file}",
       "cwd": "${workspaceFolder}",
       "attachSimplePort": 9229
-      // "env": {
-      //   "PATH": "/path/to/polkadot/folder:${env:PATH}"
-      // }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach debugger"
+    },
+    {
+      "type": "node",
+      "runtimeExecutable": "deno",
+      "request": "launch",
+      "name": "Debug current file",
+      "program": "${file}",
+      "cwd": "${workspaceFolder}"
+      // "env": {
+      //   "PATH": "/path/to/polkadot/folder:${env:PATH}"
+      // }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "deno",
+      "runtimeArgs": ["task", "test", "--inspect-brk"],
+      "name": "Debug current test file",
+      "program": "${file}",
+      "cwd": "${workspaceFolder}",
+      "attachSimplePort": 9229
+      // "env": {
+      //   "PATH": "/path/to/polkadot/folder:${env:PATH}"
+      // }
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

Configure VSCode `launch.json` for Deno scripts debugging

**How Has This Been Tested?**

- add a breakpoint to a `*.ts` file, run the `Debug current file` and validate that the VSCode debugger stops at the breakpoint
- add a breakpoint to a `*.test.ts` file, run the `Debug current test file` and validate that the VSCode debugger stops at the breakpoint