### PR TITLE
chore: simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,7 @@ Resolves #
 
 - [ ] There is an associated issue (**required**)
 - [ ] The change is described in detail
-- [ ] There are no merge conflicts
-- [ ] All CI checks pass
-- [ ] There are new or updated tests validating the change
+- [ ] There are new or updated tests validating the change (if applicable)
 - [ ] The title conforms to [the conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ## Description


### PR DESCRIPTION
Merge conflicts and failing checks block merges anyways. No reason to checkbox-ify them in the template. Also, new tests aren't always applicable (hence the `(if applicable)`).