### PR TITLE
feat: recursive metadata structure

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -23,9 +23,9 @@ await Promise.all([
     }],
     outDir,
     mappings: {
-      "https://deno.land/x/scale@v0.5.3/mod.ts": {
+      "https://deno.land/x/scale@v0.6.0/mod.ts": {
         name: "parity-scale-codec",
-        version: "^0.5.3",
+        version: "^0.6.0",
       },
       "deps/smoldot_phantom.ts": {
         name: "@substrate/smoldot-light",

--- a/codegen/codecVisitor.ts
+++ b/codegen/codecVisitor.ts
@@ -130,14 +130,14 @@ export function createCodecVisitor(
         ],
       );
     },
-    uint8array(ty) {
-      return addCodecDecl(ty, "$.uint8array");
+    uint8Array(ty) {
+      return addCodecDecl(ty, "$.uint8Array");
     },
     array(ty) {
       return addCodecDecl(ty, ["$.array(", this.visit(ty.typeParam), ")"]);
     },
     sizedUint8Array(ty) {
-      return addCodecDecl(ty, `$.sizedUint8array(${ty.len})`);
+      return addCodecDecl(ty, `$.sizedUint8Array(${ty.len})`);
     },
     sizedArray(ty) {
       return addCodecDecl(ty, ["$.sizedArray(", this.visit(ty.typeParam), ",", ty.len, ")"]);

--- a/codegen/genMetadata.ts
+++ b/codegen/genMetadata.ts
@@ -56,17 +56,17 @@ export function genMetadata(metadata: M.Metadata, decls: Decl[]) {
               "key",
               entry.type === "Map"
                 ? entry.hashers.length === 1
-                  ? ["$.tuple(", getRawCodecPath(tys[entry.key]!), ")"]
-                  : getRawCodecPath(tys[entry.key]!)
+                  ? ["$.tuple(", getRawCodecPath(entry.key), ")"]
+                  : getRawCodecPath(entry.key)
                 : "[]",
             ],
-            ["value", getRawCodecPath(tys[entry.value]!)],
+            ["value", getRawCodecPath(entry.value)],
           ),
         ],
       });
     }
     if (pallet.calls) {
-      const ty = tys[pallet.calls.ty]! as M.Ty & M.UnionTyDef;
+      const ty = pallet.calls as M.Ty & M.UnionTyDef;
       const isStringUnion = ty.members.every((x) => !x.fields.length);
       for (const call of ty.members) {
         const typeName = isStringUnion ? S.string(call.name) : getPath(tys, ty)! + "." + call.name;
@@ -99,9 +99,9 @@ export function genMetadata(metadata: M.Metadata, decls: Decl[]) {
     code: "export const types = _codec._all",
   });
 
-  function getExtrasCodec(xs: [string, number][]) {
+  function getExtrasCodec(xs: [string, M.Ty][]) {
     return S.array(
-      xs.filter((x) => !isUnitVisitor.visit(x[1])).map((x) => getRawCodecPath(tys[x[1]]!)),
+      xs.filter((x) => !isUnitVisitor.visit(x[1])).map((x) => getRawCodecPath(x[1])),
     );
   }
 }

--- a/codegen/typeVisitor.ts
+++ b/codegen/typeVisitor.ts
@@ -78,7 +78,7 @@ export function createTypeVisitor(tys: M.Ty[], decls: Decl[]) {
       });
       return path;
     },
-    uint8array(ty) {
+    uint8Array(ty) {
       return addTypeDecl(ty, "Uint8Array");
     },
     array(ty) {

--- a/codegen/utils.ts
+++ b/codegen/utils.ts
@@ -48,7 +48,7 @@ export function getPath(tys: M.Ty[], ty: M.Ty): string | null {
       if (tys.every((x) => x.path.join(".") !== baseName || x.params[i]!.ty === p.ty)) {
         return "";
       }
-      return ".$$" + (_getName(tys[p.ty!]!) ?? p.ty);
+      return ".$$" + (_getName(p.ty) ?? p.ty);
     }).join("");
   }
 }

--- a/deps/scale.ts
+++ b/deps/scale.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/scale@v0.5.3/mod.ts";
+export * from "https://deno.land/x/scale@v0.6.0/mod.ts";

--- a/deps/std/testing/asserts.ts
+++ b/deps/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.127.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.158.0/testing/asserts.ts";

--- a/deps/std/testing/snapshot.ts
+++ b/deps/std/testing/snapshot.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.136.0/testing/snapshot.ts";
+export * from "https://deno.land/std@0.158.0/testing/snapshot.ts";

--- a/effect/atoms/Codec.ts
+++ b/effect/atoms/Codec.ts
@@ -3,7 +3,7 @@ import { atomFactory } from "../sys/Atom.ts";
 
 export const codec = atomFactory("Codec", (
   deriveCodec: M.DeriveCodec,
-  typeI: number,
+  ty: number | M.Ty,
 ) => {
-  return deriveCodec(typeI);
+  return deriveCodec(ty);
 });

--- a/frame_metadata/Codec.test.ts
+++ b/frame_metadata/Codec.test.ts
@@ -83,7 +83,7 @@ Deno.test("Derive Result codec", async () => {
   const [metadata, deriveCodec] = await setup("polkadot");
   const ty = metadata.tys.find((x) =>
     x.path[0] === "Result"
-    && metadata.tys[x.params[1]!.ty!]!.path.join("::") === "sp_runtime::DispatchError"
+    && x.params[1]!.ty!.path.join("::") === "sp_runtime::DispatchError"
   )!;
   const codec = deriveCodec(ty.id);
   const ok = null;

--- a/frame_metadata/Codec.ts
+++ b/frame_metadata/Codec.ts
@@ -70,14 +70,14 @@ export function DeriveCodec(tys: M.Ty[]): DeriveCodec {
       }
       return $.taggedUnion("type", members);
     },
-    uint8array() {
-      return $.uint8array;
+    uint8Array() {
+      return $.uint8Array;
     },
     array(ty) {
       return $.array(this.visit(ty.typeParam));
     },
     sizedUint8Array(ty) {
-      return $.sizedUint8array(ty.len);
+      return $.sizedUint8Array(ty.len);
     },
     sizedArray(ty) {
       return $.sizedArray(this.visit(ty.typeParam), ty.len);

--- a/frame_metadata/Codec.ts
+++ b/frame_metadata/Codec.ts
@@ -3,7 +3,7 @@ import { $era } from "./Era.ts";
 import type * as M from "./mod.ts";
 import { TyVisitor } from "./TyVisitor.ts";
 
-export type DeriveCodec = (typeI: number) => $.Codec<unknown>;
+export type DeriveCodec = (typeI: number | M.Ty) => $.Codec<unknown>;
 
 /**
  * All derived codecs for ZSTs will use this exact codec,
@@ -107,7 +107,7 @@ export function DeriveCodec(tys: M.Ty[]): DeriveCodec {
     },
   });
 
-  return (i: number) => visitor.visit(i);
+  return (ty) => visitor.visit(ty);
 }
 
 export class ChainError<T> extends Error {

--- a/frame_metadata/Extrinsic.ts
+++ b/frame_metadata/Extrinsic.ts
@@ -51,10 +51,9 @@ export function $extrinsic(props: ExtrinsicCodecProps): $.Codec<Extrinsic> {
   const $sig = deriveCodec(findExtrinsicTypeParam("Signature")!) as $.Codec<Signature>;
   const $sigPromise = $.promise($sig);
   const $address = deriveCodec(findExtrinsicTypeParam("Address")!);
-  const callTyI = findExtrinsicTypeParam("Call")!;
-  const callTy = props.metadata.tys[callTyI];
+  const callTy = findExtrinsicTypeParam("Call")!;
   assert(callTy?.type === "Union");
-  const $call = deriveCodec(callTyI);
+  const $call = deriveCodec(callTy);
   const [$extra, extraPjsInfo] = getExtensionInfo(pjsExtraKeyMap, "ty");
   const [$additional, additionalPjsInfo] = getExtensionInfo(
     pjsAdditionalKeyMap,
@@ -187,7 +186,7 @@ export function $extrinsic(props: ExtrinsicCodecProps): $.Codec<Extrinsic> {
   });
 
   function findExtrinsicTypeParam(name: string) {
-    return metadata.tys[metadata.extrinsic.ty]?.params.find((x) => x.name === name)?.ty;
+    return metadata.extrinsic.ty.params.find((x) => x.name === name)?.ty;
   }
   function getExtensionInfo(
     keyMap: Record<string, string | undefined>,

--- a/frame_metadata/Metadata.test.ts
+++ b/frame_metadata/Metadata.test.ts
@@ -1,5 +1,8 @@
+import { _format } from "https://deno.land/std@0.158.0/path/_util.ts";
 import { assertSnapshot } from "../deps/std/testing/snapshot.ts";
 import { setup } from "./test-common.ts";
+
+const kInspect = Symbol.for("Deno.customInspect");
 
 for (
   const name of [
@@ -14,6 +17,34 @@ for (
 ) {
   Deno.test(name, async (t) => {
     const [metadata] = await setup(name);
+    let shouldAbbrev = true;
+    // @ts-ignore .
+    metadata.tys[kInspect] = (inspect: any, args: any) => {
+      shouldAbbrev = false;
+      const x = inspect([...metadata.tys], args);
+      shouldAbbrev = true;
+      return x;
+    };
+    for (const ty of metadata.tys) {
+      const abbrev = `Ty#${ty.id}` + (ty.path?.length
+        ? ` (${ty.path.join("::")})`
+        : ty.type === "Primitive"
+        ? ` (${ty.kind})`
+        : "");
+      // @ts-ignore .
+      ty[kInspect] = (inspect: any, args: any) => {
+        if (shouldAbbrev) {
+          return abbrev;
+        }
+        shouldAbbrev = true;
+        const ty2 = { __proto__: { [Symbol.toStringTag]: abbrev }, ...ty };
+        // @ts-ignore .
+        delete ty2[kInspect];
+        const x = inspect(ty2, args);
+        shouldAbbrev = false;
+        return x;
+      };
+    }
     await assertSnapshot(t, metadata);
   });
 }

--- a/frame_metadata/Metadata.test.ts
+++ b/frame_metadata/Metadata.test.ts
@@ -1,5 +1,6 @@
 import { _format } from "https://deno.land/std@0.158.0/path/_util.ts";
 import { assertSnapshot } from "../deps/std/testing/snapshot.ts";
+import { Metadata } from "./Metadata.ts";
 import { setup } from "./test-common.ts";
 
 const kInspect = Symbol.for("Deno.customInspect");
@@ -17,34 +18,41 @@ for (
 ) {
   Deno.test(name, async (t) => {
     const [metadata] = await setup(name);
-    let shouldAbbrev = true;
-    // @ts-ignore .
-    metadata.tys[kInspect] = (inspect: any, args: any) => {
-      shouldAbbrev = false;
-      const x = inspect([...metadata.tys], args);
-      shouldAbbrev = true;
-      return x;
-    };
-    for (const ty of metadata.tys) {
-      const abbrev = `Ty#${ty.id}` + (ty.path?.length
-        ? ` (${ty.path.join("::")})`
-        : ty.type === "Primitive"
-        ? ` (${ty.kind})`
-        : "");
-      // @ts-ignore .
-      ty[kInspect] = (inspect: any, args: any) => {
-        if (shouldAbbrev) {
-          return abbrev;
-        }
-        shouldAbbrev = true;
-        const ty2 = { __proto__: { [Symbol.toStringTag]: abbrev }, ...ty };
-        // @ts-ignore .
-        delete ty2[kInspect];
-        const x = inspect(ty2, args);
-        shouldAbbrev = false;
-        return x;
-      };
-    }
-    await assertSnapshot(t, metadata);
+    await assertSnapshot(t, serializeMetadata(metadata));
   });
+}
+
+// Logging the metadata directly yields a finite but pathologically large string.
+// This inspect logic shows the expanded form of types only in the top level of the tys array.
+// In all other places, it uses an abbreviated form with the id and when applicable the type name.
+function serializeMetadata(metadata: Metadata): Metadata {
+  let shouldAbbrev = true;
+  // @ts-ignore .
+  metadata.tys[kInspect] = (inspect: any, args: any) => {
+    shouldAbbrev = false;
+    const result = inspect([...metadata.tys], args);
+    shouldAbbrev = true;
+    return result;
+  };
+  for (const ty of metadata.tys) {
+    const abbrev = `Ty#${ty.id}` + (ty.path?.length
+      ? ` (${ty.path.join("::")})`
+      : ty.type === "Primitive"
+      ? ` (${ty.kind})`
+      : "");
+    // @ts-ignore .
+    ty[kInspect] = (inspect: any, args: any) => {
+      if (shouldAbbrev) {
+        return abbrev;
+      }
+      shouldAbbrev = true;
+      const ty2 = { __proto__: { [Symbol.toStringTag]: abbrev }, ...ty };
+      // @ts-ignore .
+      delete ty2[kInspect];
+      const result = inspect(ty2, args);
+      shouldAbbrev = false;
+      return result;
+    };
+  }
+  return metadata;
 }

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -82,7 +82,7 @@ export interface Constant {
 export const $constant: $.Codec<Constant> = $.object(
   ["name", $.str],
   ["ty", $.compactU32],
-  ["value", $.uint8array],
+  ["value", $.uint8Array],
   ["docs", $.array($.str)],
 );
 

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -1,6 +1,6 @@
 import * as $ from "../deps/scale.ts";
 import * as U from "../util/mod.ts";
-import { $ty, Ty } from "./scale_info.ts";
+import { $tyId, $tys, Ty } from "./scale_info.ts";
 
 export type HasherKind = $.Native<typeof $hasherKind>;
 const $hasherKind = $.stringUnion([
@@ -21,25 +21,25 @@ export const $storageEntryModifier = $.stringUnion([
 
 export interface PlainStorageEntryType {
   type: "Plain";
-  value: number;
+  value: Ty;
 }
 
 export interface MapStorageEntryType {
   type: "Map";
   hashers: HasherKind[];
-  key: number;
-  value: number;
+  key: Ty;
+  value: Ty;
 }
 
 export type StorageEntryType = PlainStorageEntryType | MapStorageEntryType;
 
 export const $storageEntryType: $.Codec<StorageEntryType> = $.taggedUnion("type", [
-  ["Plain", ["value", $.compactU32]],
+  ["Plain", ["value", $tyId]],
   [
     "Map",
     ["hashers", $.array($hasherKind)],
-    ["key", $.compactU32],
-    ["value", $.compactU32],
+    ["key", $tyId],
+    ["value", $tyId],
   ],
 ]);
 
@@ -75,57 +75,54 @@ export const $storage: $.Codec<Storage> = $.object(
 
 export interface Constant {
   name: string;
-  ty: number;
+  ty: Ty;
   value: Uint8Array;
   docs: string[];
 }
 export const $constant: $.Codec<Constant> = $.object(
   ["name", $.str],
-  ["ty", $.compactU32],
+  ["ty", $tyId],
   ["value", $.uint8Array],
   ["docs", $.array($.str)],
 );
 
-type OptionalTypeBearer = $.Native<typeof optionalTypeBearer>;
-const optionalTypeBearer = $.option($.object(["ty", $.compactU32]));
-
 export interface Pallet {
   name: string;
   storage: Storage | undefined;
-  calls: OptionalTypeBearer;
-  event: OptionalTypeBearer;
+  calls: Ty | undefined;
+  event: Ty | undefined;
   constants: Constant[];
-  error: OptionalTypeBearer;
+  error: Ty | undefined;
   i: number;
 }
 export const $pallet: $.Codec<Pallet> = $.object(
   ["name", $.str],
   ["storage", $.option($storage)],
-  ["calls", optionalTypeBearer],
-  ["event", optionalTypeBearer],
+  ["calls", $.option($tyId)],
+  ["event", $.option($tyId)],
   ["constants", $.array($constant)],
-  ["error", optionalTypeBearer],
+  ["error", $.option($tyId)],
   ["i", $.u8],
 );
 
 export interface SignedExtensionMetadata {
   ident: string;
-  ty: number;
-  additionalSigned: number;
+  ty: Ty;
+  additionalSigned: Ty;
 }
 export const $signedExtensionMetadata: $.Codec<SignedExtensionMetadata> = $.object(
   ["ident", $.str],
-  ["ty", $.compactU32],
-  ["additionalSigned", $.compactU32],
+  ["ty", $tyId],
+  ["additionalSigned", $tyId],
 );
 
 export interface ExtrinsicDef {
-  ty: number;
+  ty: Ty;
   version: number;
   signedExtensions: SignedExtensionMetadata[];
 }
 export const $extrinsicDef: $.Codec<ExtrinsicDef> = $.object(
-  ["ty", $.compactU32],
+  ["ty", $tyId],
   ["version", $.u8],
   ["signedExtensions", $.array($signedExtensionMetadata)],
 );
@@ -143,7 +140,7 @@ export interface Metadata {
 export const $metadata: $.Codec<Metadata> = $.object(
   ["magicNumber", $.constantPattern(magicNumber, $.u32)],
   ["version", $.constantPattern(14, $.u8)],
-  ["tys", $.array($ty)],
+  ["tys", $tys],
   ["pallets", $.array($pallet)],
   ["extrinsic", $extrinsicDef],
 );

--- a/frame_metadata/TyVisitor.ts
+++ b/frame_metadata/TyVisitor.ts
@@ -22,7 +22,7 @@ export interface TyVisitorMethods<T> {
   stringUnion(ty: Ty & UnionTyDef): T;
   taggedUnion(ty: Ty & UnionTyDef): T;
 
-  uint8array?(ty: Ty & SequenceTyDef): T;
+  uint8Array?(ty: Ty & SequenceTyDef): T;
   array(ty: Ty & SequenceTyDef): T;
 
   sizedUint8Array?(ty: Ty & SizedArrayTyDef): T;
@@ -109,8 +109,8 @@ export class TyVisitor<T> {
         return this.taggedUnion(ty);
       }
     } else if (ty.type === "Sequence") {
-      if (this.uint8array && this._isU8(ty.typeParam)) {
-        return this.uint8array(ty);
+      if (this.uint8Array && this._isU8(ty.typeParam)) {
+        return this.uint8Array(ty);
       } else {
         return this.array(ty);
       }

--- a/frame_metadata/TyVisitor.ts
+++ b/frame_metadata/TyVisitor.ts
@@ -71,16 +71,16 @@ export class TyVisitor<T> {
   _visit(ty: Ty) {
     if (ty.type === "Struct") {
       if (this.map && ty.path[0] === "BTreeMap") {
-        return this.map(ty, this.tys[ty.params[0]!.ty!]!, this.tys[ty.params[1]!.ty!]!);
+        return this.map(ty, ty.params[0]!.ty!, ty.params[1]!.ty!);
       } else if (this.set && ty.path[0] === "BTreeSet") {
-        return this.set(ty, this.tys[ty.params[0]!.ty!]!);
+        return this.set(ty, ty.params[0]!.ty!);
       } else if (ty.fields.length === 0) {
         return this.unitStruct(ty);
       } else if (ty.fields[0]!.name === undefined) {
         if (ty.fields.length === 1) {
-          return this.wrapperStruct(ty, this.tys[ty.fields[0]!.ty]!);
+          return this.wrapperStruct(ty, ty.fields[0]!.ty);
         } else {
-          return this.tupleStruct(ty, ty.fields.map((x) => this.tys[x.ty]!));
+          return this.tupleStruct(ty, ty.fields.map((x) => x.ty));
         }
       } else {
         return this.objectStruct(ty);
@@ -89,16 +89,16 @@ export class TyVisitor<T> {
       if (ty.fields.length === 0) {
         return this.unitStruct(ty);
       } else if (ty.fields.length === 1) {
-        return this.wrapperStruct(ty, this.tys[ty.fields[0]!]!);
+        return this.wrapperStruct(ty, ty.fields[0]!);
       } else {
-        return this.tupleStruct(ty, ty.fields.map((i) => this.tys[i]!));
+        return this.tupleStruct(ty, ty.fields);
       }
     } else if (ty.type === "Union") {
       // TODO: revisit Option and Result
       if (ty.path[0] === "Option") {
-        return this.option(ty, this.tys[ty.params[0]!.ty!]!);
+        return this.option(ty, ty.params[0]!.ty!);
       } else if (ty.path[0] === "Result") {
-        return this.result(ty, this.tys[ty.params[0]!.ty!]!, this.tys[ty.params[1]!.ty!]!);
+        return this.result(ty, ty.params[0]!.ty!, ty.params[1]!.ty!);
       } else if (this.era && ty.path.at(-1) === "Era") {
         return this.era(ty);
       } else if (ty.members.length === 0) {
@@ -109,13 +109,13 @@ export class TyVisitor<T> {
         return this.taggedUnion(ty);
       }
     } else if (ty.type === "Sequence") {
-      if (this.uint8Array && this._isU8(ty.typeParam)) {
+      if (this.uint8Array && _isU8(ty.typeParam)) {
         return this.uint8Array(ty);
       } else {
         return this.array(ty);
       }
     } else if (ty.type === "SizedArray") {
-      if (this.sizedUint8Array && this._isU8(ty.typeParam)) {
+      if (this.sizedUint8Array && _isU8(ty.typeParam)) {
         return this.sizedUint8Array(ty);
       } else {
         return this.sizedArray(ty);
@@ -130,9 +130,8 @@ export class TyVisitor<T> {
       throw new Error("unreachable");
     }
   }
+}
 
-  private _isU8(i: number) {
-    const ty = this.tys[i]!;
-    return ty.type === "Primitive" && ty.kind === "u8";
-  }
+function _isU8(ty: Ty) {
+  return ty.type === "Primitive" && ty.kind === "u8";
 }

--- a/hashers/mod.test.ts
+++ b/hashers/mod.test.ts
@@ -12,7 +12,7 @@ interface Foo {
 }
 
 const $foo: $.Codec<Foo> = $.object(
-  ["a", $.uint8array],
+  ["a", $.uint8Array],
   ["b", $.array($.bool)],
   ["c", $.promise($.str)],
   ["d", $.option($.deferred(() => $foo))],


### PR DESCRIPTION
Resolves #284 

- [X] There is an associated issue (**required**)
- [X] The change is described in detail
- [X] There are new or updated tests validating the change (if applicable)

## Description

This changes the structure of the metadata to be recursive; where before compound types would reference other types via indices, they now reference the type object itself directly. This uses the new context api in scale v0.6.0 to decode directly into this structure, without any need for post-processing.

This eliminates almost all cases where one would need to index into the `metadata.tys` array, cleaning up the code significantly.

The only part that became more complicated was `Metadata.test.ts`. Though Deno's snapshot serializer *does* support circular references, it only uses references to parent objects in the circularity. This meant that it produced a – though finite – pathologically large string, as each type was written in expanded form potentially hundreds of times. To resolve this, `Metadata.test.ts` now has custom logic to serialize the metadata in a less pathological way. It's currently not exported anywhere, but it could be in the future – though I don't think this would necessarily be of value anywhere else.

If one decodes with the `$ty` codec standalone (i.e. not by way of `$tys` or `$metadata`), it will not have a way to get the types references by the indices in the buffer, so it will instead decode them as dummy objects with an appropriate `id` field. Though this is not type-safe, I think this is the best middleground.