### PR TITLE
chore: fix failing RPC test

### DIFF
--- a/rpc/providers/proxy.test.ts
+++ b/rpc/providers/proxy.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "../../deps/std/testing/asserts.ts";
-import { polkadot } from "../../known/mod.ts";
+import { config as testConfig } from "../../test_util/mod.ts";
 import * as U from "../../util/mod.ts";
 import * as msg from "../messages.ts";
 import { proxyClient } from "./proxy.ts";
@@ -8,9 +8,9 @@ Deno.test({
   name: "Proxy RPC Client",
   sanitizeResources: false,
   sanitizeOps: false,
-  ignore: true,
   async fn(t) {
-    const client = U.throwIfError(await proxyClient(polkadot));
+    const config = await testConfig();
+    const client = U.throwIfError(await proxyClient(config));
 
     await t.step("call", async () => {
       const raw = await client.call("state_getMetadata", []);
@@ -18,7 +18,7 @@ Deno.test({
     });
 
     await t.step("subscribe", async () => {
-      const result: msg.NotifMessage<typeof polkadot, "chain_subscribeAllHeads">[] = [];
+      const result: msg.NotifMessage<typeof config, "chain_subscribeAllHeads">[] = [];
       let i = 1;
       await client.subscribe("chain_subscribeAllHeads", [], (stop) => {
         return (message) => {
@@ -35,5 +35,6 @@ Deno.test({
     });
 
     await client.close();
+    config.close();
   },
 });

--- a/rpc/providers/proxy.test.ts
+++ b/rpc/providers/proxy.test.ts
@@ -8,6 +8,7 @@ Deno.test({
   name: "Proxy RPC Client",
   sanitizeResources: false,
   sanitizeOps: false,
+  ignore: true,
   async fn(t) {
     const client = U.throwIfError(await proxyClient(polkadot));
 


### PR DESCRIPTION
The RPC test was failing. This is likely due to the fact that it made use of a remote RPC node, which may rate limit / is sometimes unavailable. This PR changes the test to utilize a local node instead.