### PR TITLE
feat: add example GH action

### DIFF
--- a/.github/actions/setup-polkadot/action.yml
+++ b/.github/actions/setup-polkadot/action.yml
@@ -1,0 +1,23 @@
+name: "Setup Polkadot"
+description: "Setup Polkadot"
+inputs:
+  polkadot-version:
+    description: "Polkadot version"
+    required: true
+    default: v0.9.28
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Polkadot
+      uses: actions/cache@v3
+      id: cache-polkadot
+      with:
+        path: |
+          /usr/local/bin/polkadot
+        key: polkadot-${{ inputs.polkadot-version }}
+    - if: ${{ steps.cache-polkadot.outputs.cache-hit != 'true' }}
+      name: Download Polkadot
+      run: |
+        curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/${{ inputs.polkadot-version }}/polkadot
+        chmod +x /usr/local/bin/polkadot
+      shell: bash

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,21 @@
+name: Run example
+on:
+  workflow_dispatch:
+    inputs:
+      example_path:
+        type: text
+        required: true
+jobs:
+  run_example:
+    name: Run example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
+        with:
+          deno-version: v1.x
+      - name: Download polkadot
+        run: |
+          curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.28/polkadot
+          chmod +x /usr/local/bin/polkadot
+      - run: deno task run test_ctx.ts deno task run ${{ github.event.inputs.example_path }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -10,7 +10,6 @@ on:
       example_paths:
         type: string
         required: true
-  push:
 jobs:
   run_example:
     name: Run example

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example_path: ${{ fromJSON(github.event.inputs.example_paths) }}
+        example_path: ${{ fromJSON(inputs.example_paths) }}
     steps:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -31,4 +31,4 @@ jobs:
           key: ${{ runner.os }}-deno-${{ hashFiles('lock.json', 'deps/**/*.ts') }}
       - name: Setup Polkadot
         uses: ./.github/actions/setup-polkadot
-      - run: deno task run test_ctx.ts deno task run ${{ matrix.example_path }}
+      - run: deno task run ${{ matrix.example_path }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -26,8 +26,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
+            ~/.deno
             ~/.cache/deno
-          key: ${{ runner.os }}-build-${{ hashFiles('lock.json', 'deps/**/*.ts') }}
+          key: ${{ runner.os }}-deno-${{ hashFiles('lock.json', 'deps/**/*.ts') }}
       - name: Setup Polkadot
         uses: ./.github/actions/setup-polkadot
       - run: deno task run test_ctx.ts deno task run ${{ matrix.example_path }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -2,13 +2,22 @@ name: Run example
 on:
   workflow_dispatch:
     inputs:
-      example_path:
-        type: text
+      example_paths:
+        type: string
         required: true
+  workflow_call:
+    inputs:
+      example_paths:
+        type: string
+        required: true
+  push:
 jobs:
   run_example:
     name: Run example
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example_path: ${{ fromJSON(github.event.inputs.example_paths) }}
     steps:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
@@ -18,4 +27,4 @@ jobs:
         run: |
           curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.28/polkadot
           chmod +x /usr/local/bin/polkadot
-      - run: deno task run test_ctx.ts deno task run ${{ github.event.inputs.example_path }}
+      - run: deno task run test_ctx.ts deno task run ${{ matrix.example_path }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -19,7 +19,7 @@ jobs:
         example_path: ${{ fromJSON(inputs.example_paths) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
+      - uses: denoland/setup-deno@9db7f66e8e16b5699a514448ce994936c63f0d54 # v1.1.0
         with:
           deno-version: v1.x
       - name: Cache Deno dependencies

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -22,6 +22,12 @@ jobs:
       - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
         with:
           deno-version: v1.x
+      - name: Cache Deno dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/deno
+          key: ${{ runner.os }}-build-${{ hashFiles('lock.json', 'deps/**/*.ts') }}
       - name: Download polkadot
         run: |
           curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.28/polkadot

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -28,8 +28,6 @@ jobs:
           path: |
             ~/.cache/deno
           key: ${{ runner.os }}-build-${{ hashFiles('lock.json', 'deps/**/*.ts') }}
-      - name: Download polkadot
-        run: |
-          curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.28/polkadot
-          chmod +x /usr/local/bin/polkadot
+      - name: Setup Polkadot
+        uses: ./.github/actions/setup-polkadot
       - run: deno task run test_ctx.ts deno task run ${{ matrix.example_path }}

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -10,14 +10,11 @@ jobs:
       example_paths: ${{ steps.generate_examples.outputs.example_paths }}
     steps:
       - uses: actions/checkout@v3
-      # - run: |
-      #     find ./examples -type f -print0 \
-      #     | xargs -0 -n1 -P 0 -t -I {} gh workflow run --ref feat/examples-gh-action example.yml -f example_path={}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: generate_examples
         run: |
-          echo 'example_paths=["./examples/metadata.ts","./examples/balance.ts"]' >> $GITHUB_OUTPUT
+          find ./examples -type f -print0 | jq -Rnc '(input | split("\u0000"))' > example_paths.json
+          example_paths=`cat example_paths.json`
+          echo "example_paths=$example_paths" >> $GITHUB_OUTPUT
 
   call_example_workflow:
     needs: spawn_examples

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -3,21 +3,21 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  spawn_examples:
-    name: Spawn examples
+  generate_example_paths:
+    name: Generate example paths
     runs-on: ubuntu-latest
     outputs:
-      example_paths: ${{ steps.generate_examples.outputs.example_paths }}
+      example_paths: ${{ steps.generate_example_paths.outputs.example_paths }}
     steps:
       - uses: actions/checkout@v3
-      - id: generate_examples
+      - id: generate_example_paths
         run: |
           find ./examples -type f -print0 | jq -Rnc '(input | split("\u0000"))' > example_paths.json
           example_paths=`cat example_paths.json`
           echo "example_paths=$example_paths" >> $GITHUB_OUTPUT
-
-  call_example_workflow:
-    needs: spawn_examples
+  run_example_workflow:
+    needs: generate_example_paths
+    name: Run examples
     uses: ./.github/workflows/example.yml
     with:
-      example_paths: ${{ needs.spawn_examples.outputs.example_paths }}
+      example_paths: ${{ needs.generate_example_paths.outputs.example_paths }}

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -1,0 +1,20 @@
+name: Spawn examples
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  spawn_examples:
+    name: Spawn examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # - run: |
+      #     find ./examples -type f -print0 \
+      #     | xargs -0 -n1 -P 0 -t -I {} gh workflow run --ref feat/examples-gh-action example.yml -f example_path={}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  call_example_workflow:
+    uses: ./.github/workflows/example.yml
+    with:
+      example_paths: '["./examples/metadata.ts","./examples/balance.ts"]'

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -6,6 +6,8 @@ jobs:
   spawn_examples:
     name: Spawn examples
     runs-on: ubuntu-latest
+    outputs:
+      example_paths: ${{ steps.generate_examples.outputs.example_paths }}
     steps:
       - uses: actions/checkout@v3
       # - run: |
@@ -13,8 +15,12 @@ jobs:
       #     | xargs -0 -n1 -P 0 -t -I {} gh workflow run --ref feat/examples-gh-action example.yml -f example_path={}
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - id: generate_examples
+        run: |
+          echo 'example_paths=["./examples/metadata.ts","./examples/balance.ts"]' >> $GITHUB_OUTPUT
 
   call_example_workflow:
+    needs: spawn_examples
     uses: ./.github/workflows/example.yml
     with:
-      example_paths: '["./examples/metadata.ts","./examples/balance.ts"]'
+      example_paths: ${{ needs.spawn_examples.outputs.example_paths }}

--- a/effect/std/watchEntry.ts
+++ b/effect/std/watchEntry.ts
@@ -30,7 +30,9 @@ export function watchEntry<
   const $storageKey = a.$storageKey(deriveCodec_, palletMetadata_, entryMetadata_);
   const entryValueTypeI = a.select(entryMetadata_, "value");
   const $entry = a.codec(deriveCodec_, entryValueTypeI);
-  const storageKeys = sys.anon([a.storageKey($storageKey, keys)], (v) => [v]);
+  const storageKeys = keys.length === 0
+    ? sys.anon([a.storageKey($storageKey)], (v) => [v])
+    : sys.anon([a.storageKey($storageKey, keys)], (v) => [v]);
   return sys.into([$entry], ($entryCodec) => {
     const watchInit = U.mapCreateWatchHandler(
       createWatchHandler,

--- a/examples/ticker.ts
+++ b/examples/ticker.ts
@@ -2,11 +2,14 @@ import * as C from "../mod.ts";
 import * as T from "../test_util/mod.ts";
 import * as U from "../util/mod.ts";
 
-const root = C.watchEntry(T.polkadot, "Timestamp", "Now", [], () => {
+const root = C.watchEntry(T.polkadot, "Timestamp", "Now", [], (stop) => {
   let i = 0;
   return (m) => {
-    console.log({ [i]: m });
     i++;
+    console.log({ [i]: m });
+    if (i === 5) {
+      stop();
+    }
   };
 });
 

--- a/words.txt
+++ b/words.txt
@@ -176,3 +176,4 @@ tailaiw
 trufflehog
 amannn
 multisigs
+tostring


### PR DESCRIPTION
Resolves #299 

- [x] There is an associated issue (**required**)
- [x] The change is described in detail
- [x] There are new or updated tests validating the change (if applicable)

## Description

Run examples in parallel using reusable workflows.
The caller workflow `spawn_examples.yml` generates the list of example paths and calls the `example.yml` reusable workflow.
The `example.yml` workflow uses a marix strategy to create a job for each example file.

Also, this PR adds a `setup-polkadot` composite action that caches and downloads the polkadot binary.
I'd like to get some feedback on the composite action before integrating it in other workflows