### PR TITLE
fix: filter .ts files for spawn_examples GH action

### DIFF
--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: generate_example_paths
         run: |
-          find ./examples -type f -print0 | jq -Rnc '(input | split("\u0000"))' > example_paths.json
+          find ./examples -type f -name "*.ts" -print0 | jq -Rnc '(input | split("\u0000"))' > example_paths.json
           example_paths=`cat example_paths.json`
           echo "example_paths=$example_paths" >> $GITHUB_OUTPUT
   run_example_workflow:


### PR DESCRIPTION
Filter `*.ts` files in `spawn_example` workflow