### PR TITLE
chore: update ci to use env files instead of `set-output`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Retrieve Version
         if: startsWith(github.ref, 'refs/tags/')
         id: get_tag_version
-        run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "tag_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - name: Build NPM Package
-        run: deno task dnt ${{steps.get_tag_version.outputs.TAG_VERSION}}
+        run: deno task dnt ${{env.tag_version}}
       - run: npm pack
         working-directory: "./target/npm"
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Retrieve Version
         if: startsWith(github.ref, 'refs/tags/')
         id: get_tag_version
-        run: echo "tag_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: echo "tag_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - name: Build NPM Package
-        run: deno task dnt ${{env.tag_version}}
+        run: deno task dnt ${{steps.get_tag_version.outputs.tag_version}}
       - run: npm pack
         working-directory: "./target/npm"
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Retrieve commit sha
         id: commit
         run: |
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Set commit status with pending
         uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: "Basic tests"
           state: "pending"
-          sha: ${{ steps.commit.outputs.sha }}
+          sha: ${{ env.sha }}
       - name: Set commit status with outcome
         uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
         with:
@@ -51,4 +51,4 @@ jobs:
           context: "Basic tests"
           description: "To run other CI actions close/reopen this PR"
           state: ${{ steps.test.outcome }}
-          sha: ${{ steps.commit.outputs.sha }}
+          sha: ${{ env.sha }}

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Retrieve commit sha
         id: commit
         run: |
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Set commit status with pending
         uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: "Basic tests"
           state: "pending"
-          sha: ${{ env.sha }}
+          sha: ${{ steps.commit.outputs.sha }}
       - name: Set commit status with outcome
         uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
         with:
@@ -51,4 +51,4 @@ jobs:
           context: "Basic tests"
           description: "To run other CI actions close/reopen this PR"
           state: ${{ steps.test.outcome }}
-          sha: ${{ env.sha }}
+          sha: ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

