### PR TITLE
feat: add .ignore support for spawn_example workflow

### DIFF
--- a/.github/actions/setup-fd-find/action.yml
+++ b/.github/actions/setup-fd-find/action.yml
@@ -1,0 +1,23 @@
+name: "Setup fd-find"
+description: "Setup fd-find"
+inputs:
+  fd-find-version:
+    description: "fd-find version"
+    required: true
+    default: "8.4.0"
+runs:
+  using: "composite"
+  steps:
+    - name: Cache fd-find
+      uses: actions/cache@v3
+      id: cache-fd-find
+      with:
+        path: |
+          /usr/local/bin/fd
+        key: fd-find-test-${{ inputs.fd-find-version }}
+    - if: ${{ steps.cache-fd-find.outputs.cache-hit != 'true' }}
+      name: Install fd-find
+      run: |
+        cargo install --version ${{ inputs.fd-find-version }} fd-find
+        cp ~/.cargo/bin/fd /usr/local/bin/fd
+      shell: bash

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -10,11 +10,11 @@ jobs:
       example_paths: ${{ steps.generate_example_paths.outputs.example_paths }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup fd-find
+        uses: ./.github/actions/setup-fd-find
       - id: generate_example_paths
-        # FIXME: cache fd-find binary installation
         run: |
-          cargo install fd-find
-          ~/.cargo/bin/fd --print0 --glob "*.ts" ./examples | jq -Rnc '(input | split("\u0000"))' > example_paths.json
+          fd --print0 --glob "*.ts" ./examples | jq -Rnc '(input | split("\u0000"))' > example_paths.json
           example_paths=`cat example_paths.json`
           echo "example_paths=$example_paths" >> $GITHUB_OUTPUT
   run_example_workflow:

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: generate_example_paths
+        # FIXME: cache fd-find binary installation
         run: |
-          find ./examples -type f -name "*.ts" -print0 | jq -Rnc '(input | split("\u0000"))' > example_paths.json
+          cargo install fd-find
+          ~/.cargo/bin/fd --print0 --glob "*.ts" ./examples | jq -Rnc '(input | split("\u0000"))' > example_paths.json
           example_paths=`cat example_paths.json`
           echo "example_paths=$example_paths" >> $GITHUB_OUTPUT
   run_example_workflow:

--- a/examples/.ignore
+++ b/examples/.ignore
@@ -1,0 +1,1 @@
+derived.ts


### PR DESCRIPTION
Switch `find` with `fd-find` to support `.ignore` files inside `./examples`

https://github.com/sharkdp/fd#installation
