### PR TITLE
chore: cleanup to metadata and extrinsic effect apis

### DIFF
--- a/effect/EntryRead.ts
+++ b/effect/EntryRead.ts
@@ -6,7 +6,7 @@ import { codec } from "./core/codec.ts";
 import { decoded } from "./core/decoded.ts";
 import { deriveCodec } from "./core/deriveCodec.ts";
 import { storageKey } from "./core/storageKey.ts";
-import { entryMetadata, Metadata, palletMetadata } from "./Metadata.ts";
+import { Metadata } from "./Metadata.ts";
 import { RpcCall } from "./RpcCall.ts";
 
 export class EntryRead<
@@ -27,8 +27,8 @@ export class EntryRead<
     super();
     const metadata_ = new Metadata(config, blockHash);
     const deriveCodec_ = deriveCodec(metadata_);
-    const palletMetadata_ = palletMetadata(metadata_, palletName);
-    const entryMetadata_ = entryMetadata(palletMetadata_, entryName);
+    const palletMetadata_ = metadata_.pallet(palletName);
+    const entryMetadata_ = palletMetadata_.entry(entryName);
     const $storageKey_ = $storageKey(deriveCodec_, palletMetadata_, entryMetadata_);
     const storageKey_ = storageKey($storageKey_, ...keys);
     const storageCall = new RpcCall(config, "state_getStorage", [storageKey_, blockHash]);

--- a/effect/EntryWatch.ts
+++ b/effect/EntryWatch.ts
@@ -6,7 +6,7 @@ import { $storageKey } from "./core/$storageKey.ts";
 import { codec } from "./core/codec.ts";
 import { deriveCodec } from "./core/deriveCodec.ts";
 import { storageKey } from "./core/storageKey.ts";
-import { entryMetadata, Metadata, palletMetadata } from "./Metadata.ts";
+import { Metadata } from "./Metadata.ts";
 import { RpcCall } from "./RpcCall.ts";
 import { RpcSubscription } from "./RpcSubscription.ts";
 
@@ -29,8 +29,8 @@ export class EntryWatch<
     super();
     const metadata_ = new Metadata(config);
     const deriveCodec_ = deriveCodec(metadata_);
-    const palletMetadata_ = palletMetadata(metadata_, palletName);
-    const entryMetadata_ = entryMetadata(palletMetadata_, entryName);
+    const palletMetadata_ = metadata_.pallet(palletName);
+    const entryMetadata_ = palletMetadata_.entry(entryName);
     const $storageKey_ = $storageKey(deriveCodec_, palletMetadata_, entryMetadata_);
     const entryValueTypeI = Z.sel(entryMetadata_, "value");
     const $entry = codec(deriveCodec_, entryValueTypeI);

--- a/effect/Extrinsic.ts
+++ b/effect/Extrinsic.ts
@@ -131,6 +131,10 @@ export class SignedExtrinsic<
   >(watchHandler: WatchHandler): SignedExtrinsicWatch<this, WatchHandler> {
     return new SignedExtrinsicWatch(this.config, this, watchHandler);
   }
+
+  get sent(): SignedExtrinsicSent<this> {
+    return new SignedExtrinsicSent(this.config, this);
+  }
 }
 
 // TODO: is this really required? Why not use the RPC call effect directly?
@@ -154,5 +158,17 @@ export class SignedExtrinsicWatch<
       // TODO: use effect system for cbs such as this
       (ok) => new RpcCall(config, "author_unwatchExtrinsic", [ok.result]),
     );
+  }
+}
+
+export class SignedExtrinsicSent<SignedExtrinsic extends Z.$<U.Hex>> extends Z.Name {
+  root;
+
+  constructor(
+    readonly config: Config,
+    readonly signedExtrinsic: SignedExtrinsic,
+  ) {
+    super();
+    this.root = new RpcCall(config, "author_submitExtrinsic", [signedExtrinsic]);
   }
 }

--- a/effect/Extrinsic.ts
+++ b/effect/Extrinsic.ts
@@ -1,8 +1,8 @@
 import { unimplemented } from "../deps/std/testing/asserts.ts";
 import * as Z from "../deps/zones.ts";
 import * as M from "../frame_metadata/mod.ts";
+import * as author from "../known/rpc/author.ts";
 import { Config } from "../mod.ts";
-import * as rpc from "../rpc/mod.ts";
 import * as ss58 from "../ss58/mod.ts";
 import * as U from "../util/mod.ts";
 import { $extrinsic } from "./core/$extrinsic.ts";
@@ -12,7 +12,7 @@ import { Metadata } from "./Metadata.ts";
 import { RpcCall } from "./RpcCall.ts";
 import { RpcSubscription } from "./RpcSubscription.ts";
 
-export interface SendAndWatchExtrinsicProps {
+export interface ExtrinsicProps {
   sender: M.MultiAddress;
   palletName: string;
   methodName: string;
@@ -21,22 +21,35 @@ export interface SendAndWatchExtrinsicProps {
   mortality?: [period: bigint, phase: bigint];
   nonce?: string;
   tip?: bigint;
-  sign: M.SignExtrinsic;
-  createWatchHandler: U.CreateWatchHandler<rpc.NotifMessage>;
 }
 
-export class ExtrinsicSentWatch<Props extends Z.Rec$<SendAndWatchExtrinsicProps>> extends Z.Name {
+export class Extrinsic<Props extends Z.Rec$<ExtrinsicProps>> {
+  constructor(
+    readonly config: Config,
+    readonly props: Props,
+  ) {}
+
+  signed<Sign extends Z.$<M.SignExtrinsic>>(sign: Sign): SignedExtrinsic<Props, Sign> {
+    return new SignedExtrinsic(this.config, this.props, sign);
+  }
+}
+
+export class SignedExtrinsic<
+  Props extends Z.Rec$<ExtrinsicProps>,
+  Sign extends Z.$<M.SignExtrinsic>,
+> extends Z.Name {
   root;
 
   constructor(
     readonly config: Config,
     readonly props_: Props,
+    readonly sign: Sign,
   ) {
     super();
     const props = props_ as Z.Rec$Access<Props>;
     const metadata_ = new Metadata(config);
     const deriveCodec_ = deriveCodec(metadata_);
-    const $extrinsic_ = $extrinsic(deriveCodec_, metadata_, props.sign, config.addressPrefix);
+    const $extrinsic_ = $extrinsic(deriveCodec_, metadata_, this.sign, config.addressPrefix);
     const runtimeVersion = new RpcCall(config, "state_getRuntimeVersion", []);
     const senderSs58 = Z.call(props.sender, function senderSs58(sender) {
       return ((): string => {
@@ -52,13 +65,15 @@ export class ExtrinsicSentWatch<Props extends Z.Rec$<SendAndWatchExtrinsicProps>
       })();
     });
     const accountNextIndex = new RpcCall(config, "system_accountNextIndex", [senderSs58]);
-    const genesisHash = hexDecode(Z.sel(new RpcCall(config, "chain_getBlockHash", [0]), "result"));
+    const genesisHash = hexDecode(
+      Z.sel(new RpcCall(config, "chain_getBlockHash", [0]), "result"),
+    );
     const checkpointHash = props.checkpoint
       ? Z.call(props.checkpoint, function checkpointOrUndef(v) {
         return v ? U.hex.decode(v) : v;
       })
       : genesisHash;
-    const extrinsicHex = Z.call(
+    this.root = Z.call(
       Z.ls(
         $extrinsic_,
         props.sender,
@@ -108,11 +123,33 @@ export class ExtrinsicSentWatch<Props extends Z.Rec$<SendAndWatchExtrinsicProps>
         return U.hex.encode(extrinsicBytes);
       },
     );
+  }
+
+  watch<
+    WatchHandler extends U.CreateWatchHandler<author.TransactionStatus>,
+  >(watchHandler: WatchHandler): SignedExtrinsicWatch<this, WatchHandler> {
+    return new SignedExtrinsicWatch(this.config, this, watchHandler);
+  }
+}
+
+// TODO: is this really required? Why not use the RPC call effect directly?
+export class SignedExtrinsicWatch<
+  SignedExtrinsic extends Z.$<U.Hex>,
+  WatchHandler extends U.CreateWatchHandler<author.TransactionStatus>,
+> extends Z.Name {
+  root;
+
+  constructor(
+    readonly config: Config,
+    readonly signedExtrinsic: SignedExtrinsic,
+    readonly watchHandler: WatchHandler,
+  ) {
+    super();
     this.root = new RpcSubscription(
       config,
       "author_submitAndWatchExtrinsic",
-      [extrinsicHex],
-      props.createWatchHandler,
+      [signedExtrinsic],
+      watchHandler,
       // TODO: use effect system for cbs such as this
       (ok) => new RpcCall(config, "author_unwatchExtrinsic", [ok.result]),
     );

--- a/effect/Extrinsic.ts
+++ b/effect/Extrinsic.ts
@@ -3,6 +3,7 @@ import * as Z from "../deps/zones.ts";
 import * as M from "../frame_metadata/mod.ts";
 import * as author from "../known/rpc/author.ts";
 import { Config } from "../mod.ts";
+import { NotifMessage } from "../rpc/mod.ts";
 import * as ss58 from "../ss58/mod.ts";
 import * as U from "../util/mod.ts";
 import { $extrinsic } from "./core/$extrinsic.ts";
@@ -126,7 +127,7 @@ export class SignedExtrinsic<
   }
 
   watch<
-    WatchHandler extends U.CreateWatchHandler<author.TransactionStatus>,
+    WatchHandler extends U.CreateWatchHandler<NotifMessage<author.TransactionStatus>>,
   >(watchHandler: WatchHandler): SignedExtrinsicWatch<this, WatchHandler> {
     return new SignedExtrinsicWatch(this.config, this, watchHandler);
   }
@@ -135,7 +136,7 @@ export class SignedExtrinsic<
 // TODO: is this really required? Why not use the RPC call effect directly?
 export class SignedExtrinsicWatch<
   SignedExtrinsic extends Z.$<U.Hex>,
-  WatchHandler extends U.CreateWatchHandler<author.TransactionStatus>,
+  WatchHandler extends U.CreateWatchHandler<NotifMessage<author.TransactionStatus>>,
 > extends Z.Name {
   root;
 

--- a/effect/KeyPageRead.ts
+++ b/effect/KeyPageRead.ts
@@ -5,7 +5,7 @@ import { $key } from "./core/$key.ts";
 import { $storageKey } from "./core/$storageKey.ts";
 import { deriveCodec } from "./core/deriveCodec.ts";
 import { storageKey } from "./core/storageKey.ts";
-import { entryMetadata, Metadata, palletMetadata } from "./Metadata.ts";
+import { Metadata } from "./Metadata.ts";
 import { RpcCall } from "./RpcCall.ts";
 
 export class KeyPageRead<
@@ -26,9 +26,9 @@ export class KeyPageRead<
     super();
     const metadata_ = new Metadata(config, blockHash as Rest[1]);
     const deriveCodec_ = deriveCodec(metadata_);
-    const palletMetadata_ = palletMetadata(metadata_, palletName);
+    const palletMetadata_ = metadata_.pallet(palletName);
     const entryMetadata_ = Z.call(
-      entryMetadata(palletMetadata_, entryName),
+      palletMetadata_.entry(entryName),
       function assertIsMap(entryMetadata) {
         if (entryMetadata.type !== "Map") {
           return new ReadingKeysOfNonMapError();

--- a/effect/Metadata.ts
+++ b/effect/Metadata.ts
@@ -1,3 +1,4 @@
+import * as $ from "../deps/scale.ts";
 import * as Z from "../deps/zones.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { Config } from "../mod.ts";
@@ -15,19 +16,55 @@ export class Metadata<Rest extends [blockHash?: Z.$<U.HexHash | undefined>]> ext
         try {
           return M.fromPrefixedHex(call.result);
         } catch (e) {
-          return new MetadataDecodeError(e);
+          return e as $.CodecError;
         }
       },
     );
   }
+
+  pallet = <PalletName extends Z.$<string>>(palletName: PalletName) => {
+    return new PalletMetadata(this, palletName);
+  };
 }
 
-export const palletMetadata = Z.call.fac(M.getPallet);
-export const entryMetadata = Z.call.fac(M.getEntry);
+export class PalletMetadata<Metadata extends Z.$<M.Metadata>, PalletName extends Z.$<string>>
+  extends Z.Name
+{
+  root;
 
-export class MetadataDecodeError extends U.ErrorCtor("MetadataDecode") {
-  // TODO: replace with internal scale error & ensure appropriate trace info
-  constructor(readonly scaleError: unknown) {
+  constructor(
+    readonly metadata: Metadata,
+    readonly palletName: PalletName,
+  ) {
     super();
+    this.root = Z.call(
+      Z.ls(metadata, palletName),
+      function palletMetadataImpl([metadata, palletName]) {
+        return M.getPallet(metadata, palletName);
+      },
+    );
+  }
+
+  entry = <EntryName extends Z.$<string>>(entryName: EntryName) => {
+    return new EntryMetadata(this, entryName);
+  };
+}
+
+export class EntryMetadata<PalletMetadata extends Z.$<M.Pallet>, EntryName extends Z.$<string>>
+  extends Z.Name
+{
+  root;
+
+  constructor(
+    readonly palletMetadata: PalletMetadata,
+    readonly entryName: EntryName,
+  ) {
+    super();
+    this.root = Z.call(
+      Z.ls(palletMetadata, entryName),
+      function entryMetadataImpl([palletMetadata, entryName]) {
+        return M.getEntry(palletMetadata, entryName);
+      },
+    );
   }
 }

--- a/effect/mod.ts
+++ b/effect/mod.ts
@@ -2,7 +2,7 @@ export * from "./BlockRead.ts";
 export * from "./BlockWatch.ts";
 export * from "./EntryRead.ts";
 export * from "./EntryWatch.ts";
-export * from "./ExtrinsicSentWatch.ts";
+export * from "./Extrinsic.ts";
 export * from "./KeyPageRead.ts";
 export * from "./Metadata.ts";
 export * from "./RpcCall.ts";

--- a/examples/polkadot_js_signer.ts
+++ b/examples/polkadot_js_signer.ts
@@ -3,7 +3,7 @@ import * as C from "../mod.ts";
 import * as T from "../test_util/mod.ts";
 import * as U from "../util/mod.ts";
 
-const root = new C.ExtrinsicSentWatch(T.westend, {
+const root = new C.Extrinsic(T.westend, {
   sender: {
     type: "Id",
     value: T.alice.publicKey,
@@ -17,7 +17,8 @@ const root = new C.ExtrinsicSentWatch(T.westend, {
       value: T.bob.publicKey,
     },
   },
-  sign: {
+})
+  .signed({
     signPayload(payload) {
       const tr = new TypeRegistry();
       tr.setSignedExtensions(payload.signedExtensions);
@@ -27,8 +28,8 @@ const root = new C.ExtrinsicSentWatch(T.westend, {
           .sign(T.alice),
       );
     },
-  },
-  createWatchHandler(stop) {
+  })
+  .watch((stop) => {
     return (event) => {
       if (typeof event.params.result === "string") {
         console.log("Extrinsic", event.params.result);
@@ -44,7 +45,6 @@ const root = new C.ExtrinsicSentWatch(T.westend, {
         }
       }
     };
-  },
-});
+  });
 
 U.throwIfError(await C.run(root));

--- a/examples/transfer.ts
+++ b/examples/transfer.ts
@@ -2,7 +2,7 @@ import * as C from "../mod.ts";
 import * as T from "../test_util/mod.ts";
 import * as U from "../util/mod.ts";
 
-const root = new C.ExtrinsicSentWatch(T.westend, {
+const root = new C.Extrinsic(T.westend, {
   sender: {
     type: "Id",
     value: T.alice.publicKey,
@@ -16,13 +16,14 @@ const root = new C.ExtrinsicSentWatch(T.westend, {
       value: T.bob.publicKey,
     },
   },
-  sign(message) {
+})
+  .signed((message) => {
     return {
       type: "Sr25519",
       value: T.alice.sign(message),
     };
-  },
-  createWatchHandler(stop) {
+  })
+  .watch((stop) => {
     return (event) => {
       if (typeof event.params.result === "string") {
         console.log("Extrinsic", event.params.result);
@@ -38,7 +39,6 @@ const root = new C.ExtrinsicSentWatch(T.westend, {
         }
       }
     };
-  },
-});
+  });
 
 U.throwIfError(await C.run(root));

--- a/examples/transfer.ts
+++ b/examples/transfer.ts
@@ -17,12 +17,10 @@ const root = new C.Extrinsic(T.westend, {
     },
   },
 })
-  .signed((message) => {
-    return {
-      type: "Sr25519",
-      value: T.alice.sign(message),
-    };
-  })
+  .signed((message) => ({
+    type: "Sr25519",
+    value: T.alice.sign(message),
+  }))
   .watch((stop) => {
     return (event) => {
       if (typeof event.params.result === "string") {

--- a/rpc/Base.ts
+++ b/rpc/Base.ts
@@ -85,19 +85,19 @@ export abstract class Client<
   call = (
     methodName: string,
     params: unknown[],
-  ): Promise<msg.IngressMessage> => {
+  ): Promise<msg.OkMessage | msg.ErrMessage> => {
     const init = <msg.InitMessage> {
       jsonrpc: "2.0",
       id: this.uid(),
       method: methodName,
       params,
     };
-    const ingressMessagePending = deferred<msg.IngressMessage>();
+    const ingressMessagePending = deferred<msg.OkMessage | msg.ErrMessage>();
     this.listen((stopListening) => {
       return (res) => {
         if (res.id === init.id) {
           stopListening();
-          ingressMessagePending.resolve(res as msg.IngressMessage);
+          ingressMessagePending.resolve(res);
         }
       };
     });

--- a/rpc/messages.ts
+++ b/rpc/messages.ts
@@ -7,27 +7,25 @@ interface JsonRpcVersionBearer {
   jsonrpc: "2.0";
 }
 
-export interface InitMessage extends JsonRpcVersionBearer {
+export interface InitMessage<Params extends unknown[] = any[]> extends JsonRpcVersionBearer {
   method: string;
   id: string;
-  params: unknown[];
+  params: Params;
 }
 
-export interface OkMessage extends JsonRpcVersionBearer {
+export interface OkMessage<Result = any> extends JsonRpcVersionBearer {
   id: string;
-  // TODO
-  result: any;
+  result: Result;
   params?: never;
   error?: never;
 }
 
-export interface NotifMessage extends JsonRpcVersionBearer {
+export interface NotifMessage<Result = any> extends JsonRpcVersionBearer {
   method: string;
   id?: never;
   params: {
     subscription: string;
-    // TODO
-    result: any;
+    result: Result;
   };
   result?: never;
   error?: never;


### PR DESCRIPTION
Now that various effects utilize `Z.Name`, we can attach methods to simplify their APIs.

Metadata:

```ts
const entryMetadata = new C.Metadata(T.polkadot)
  .pallet("Balances")
  .entry("Account");
```

Extrinsics:

```ts
const root = new C.Extrinsic(T.westend, {
  sender: {
    type: "Id",
    value: T.alice.publicKey,
  },
  palletName: "Balances",
  methodName: "transfer",
  args: {
    value: 12345n,
    dest: {
      type: "Id",
      value: T.bob.publicKey,
    },
  },
})
  .signed((message) => ({
    type: "Sr25519",
    value: T.alice.sign(message),
  }))
  .watch((stop) => {
    return (event) => {
      // ...
    };
  });
```

^ this paves the way for the non-watched counterpart.