### PR TITLE
chore: reworking CLI + import specifiers

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -11,7 +11,7 @@ const args = parse(Deno.args, {
   string: ["src", "out", "import"],
   boolean: ["help"],
   default: {
-    import: "deno",
+    import: "https://deno.land/x/capi/mod.ts",
   },
   alias: {
     src: ["s"],
@@ -25,11 +25,7 @@ if (!args.src) fail();
 if (!args.out) fail();
 
 await codegen({
-  importSpecifier: args.import === "npm"
-    ? "capi"
-    : args.import === "deno"
-    ? "https://deno.land/x/capi/mod.ts"
-    : args.import,
+  importSpecifier: args.import,
   metadata: await getMetadata(args.src),
   outDir: args.out,
 }).write();

--- a/codegen.ts
+++ b/codegen.ts
@@ -34,10 +34,6 @@ await codegen({
   outDir: args.out,
 }).write();
 
-// file:///Users/harrysolovay/Desktop/capi/frame_metadata/_downloaded/polkadot.scale
-// /Users/harrysolovay/Desktop/capi/frame_metadata/_downloaded/polkadot.scale
-// ./frame_metadata/_downloaded/polkadot.scale
-// frame_metadata/_downloaded/polkadot.scale
 async function getMetadata(src: string): Promise<M.Metadata> {
   if (src.startsWith("ws")) {
     const client = U.throwIfError(await proxyClient(new Config(() => src, undefined!)));
@@ -70,11 +66,12 @@ async function loadMetadata(src: string) {
   }
 }
 
+// TODO: error message + correct usage suggestion
 function fail(): never {
-  // TODO: error message + correct usage suggestion
   Deno.exit();
 }
 
+// TODO: do we handle help differently depending on what flags were specified?
 function help(): never {
   console.log("Usage: codegen --metadata <file> --output <dir>");
   Deno.exit();

--- a/codegen.ts
+++ b/codegen.ts
@@ -73,6 +73,6 @@ function fail(): never {
 
 // TODO: do we handle help differently depending on what flags were specified?
 function help(): never {
-  console.log("Usage: codegen --metadata <file> --output <dir>");
+  console.log("Usage: codegen -s=<scale_file|chain_spec|ws_url> -o=<dir>");
   Deno.exit();
 }

--- a/codegen.ts
+++ b/codegen.ts
@@ -25,7 +25,11 @@ if (!args.src) fail();
 if (!args.out) fail();
 
 await codegen({
-  importSpecifier: args.import,
+  importSpecifier: args.import === "npm"
+    ? "capi"
+    : args.import === "deno"
+    ? "https://deno.land/x/capi/mod.ts"
+    : args.import,
   metadata: await getMetadata(args.src),
   outDir: args.out,
 }).write();

--- a/codegen.ts
+++ b/codegen.ts
@@ -1,22 +1,77 @@
-import { run } from "./codegen/mod.ts";
+import { codegen } from "./codegen/mod.ts";
+import { Config } from "./config/mod.ts";
 import { parse } from "./deps/std/flags.ts";
+import * as path from "./deps/std/path.ts";
+import { unimplemented } from "./deps/std/testing/asserts.ts";
+import * as M from "./frame_metadata/mod.ts";
+import { proxyClient } from "./rpc/providers/proxy.ts";
+import * as U from "./util/mod.ts";
 
 const args = parse(Deno.args, {
-  string: ["metadata", "output"],
+  string: ["src", "out", "import"],
   boolean: ["help"],
+  default: {
+    import: "deno",
+  },
   alias: {
-    metadata: ["m"],
-    output: ["out", "o"],
+    src: ["s"],
+    out: ["o"],
     help: ["h", "?"],
   },
 });
 
-if (args.help) {
-  console.log("Usage: codegen --metadata <file> --output <dir>");
-  Deno.exit(0);
+if (args.help) help();
+if (!args.src) fail();
+if (!args.out) fail();
+
+await codegen({
+  importSpecifier: args.import,
+  metadata: await getMetadata(args.src),
+  outDir: args.out,
+}).write();
+
+// file:///Users/harrysolovay/Desktop/capi/frame_metadata/_downloaded/polkadot.scale
+// /Users/harrysolovay/Desktop/capi/frame_metadata/_downloaded/polkadot.scale
+// ./frame_metadata/_downloaded/polkadot.scale
+// frame_metadata/_downloaded/polkadot.scale
+async function getMetadata(src: string): Promise<M.Metadata> {
+  if (src.startsWith("ws")) {
+    const client = U.throwIfError(await proxyClient(new Config(() => src, undefined!)));
+    const metadata = U.throwIfError(await client.call("state_getMetadata", []));
+    U.throwIfError(await client.close());
+    if (metadata.error) fail();
+    return M.fromPrefixedHex(metadata.result);
+  } else if (path.isAbsolute(src)) {
+    return await loadMetadata(src);
+  } else {
+    try {
+      return await loadMetadata(path.fromFileUrl(src));
+    } catch (_e) {
+      unimplemented();
+    }
+  }
 }
 
-if (!args.metadata) throw new Error("Must specify metadata file");
-if (!args.output) throw new Error("Must specify output dir");
+async function loadMetadata(src: string) {
+  const ext = path.extname(src);
+  switch (ext) {
+    case ".scale": {
+      return M.fromPrefixedHex(await Deno.readTextFile(src));
+    }
+    case ".json": {
+      return unimplemented();
+    }
+    default:
+      fail();
+  }
+}
 
-run(args.metadata, args.output);
+function fail(): never {
+  // TODO: error message + correct usage suggestion
+  Deno.exit();
+}
+
+function help(): never {
+  console.log("Usage: codegen --metadata <file> --output <dir>");
+  Deno.exit();
+}

--- a/codegen.ts
+++ b/codegen.ts
@@ -27,8 +27,7 @@ if (!args.out) fail();
 await codegen({
   importSpecifier: args.import,
   metadata: await getMetadata(args.src),
-  outDir: args.out,
-}).write();
+}).write(args.out);
 
 async function getMetadata(src: string): Promise<M.Metadata> {
   if (src.startsWith("ws")) {

--- a/codegen.ts
+++ b/codegen.ts
@@ -68,7 +68,7 @@ async function loadMetadata(src: string) {
 
 // TODO: error message + correct usage suggestion
 function fail(): never {
-  Deno.exit();
+  Deno.exit(1);
 }
 
 // TODO: do we handle help differently depending on what flags were specified?

--- a/codegen/Files.ts
+++ b/codegen/Files.ts
@@ -1,0 +1,37 @@
+import { tsFormatter } from "../deps/dprint.ts";
+import * as path from "../deps/std/path.ts";
+import { S } from "./utils.ts";
+
+export type File = { getContent: () => S };
+export class Files extends Map<string, File> {
+  constructor(readonly outDir: string) {
+    super();
+  }
+
+  write = async () => {
+    const outDir = path.join(Deno.cwd(), this.outDir);
+    const errors = [];
+    try {
+      await Deno.remove(outDir, { recursive: true });
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        throw e;
+      }
+    }
+    await Deno.mkdir(outDir, { recursive: true });
+    for (const [relativePath, file] of this.entries()) {
+      const outputPath = path.join(outDir, relativePath);
+      const content = S.toString(file.getContent());
+      try {
+        const formatted = tsFormatter.formatText("gen.ts", content);
+        await Deno.writeTextFile(outputPath, formatted);
+      } catch (e) {
+        await Deno.writeTextFile(outputPath, content);
+        errors.push(e);
+      }
+    }
+    if (errors.length) {
+      throw errors;
+    }
+  };
+}

--- a/codegen/Files.ts
+++ b/codegen/Files.ts
@@ -4,22 +4,18 @@ import { S } from "./utils.ts";
 
 export type File = { getContent: () => S };
 export class Files extends Map<string, File> {
-  constructor(readonly outDir: string) {
-    super();
-  }
-
-  async write() {
+  async write(outDir: string) {
     const errors = [];
     try {
-      await Deno.remove(this.outDir, { recursive: true });
+      await Deno.remove(outDir, { recursive: true });
     } catch (e) {
       if (!(e instanceof Deno.errors.NotFound)) {
         throw e;
       }
     }
-    await Deno.mkdir(this.outDir, { recursive: true });
+    await Deno.mkdir(outDir, { recursive: true });
     for (const [relativePath, file] of this.entries()) {
-      const outputPath = path.join(this.outDir, relativePath);
+      const outputPath = path.join(outDir, relativePath);
       const content = S.toString(file.getContent());
       try {
         const formatted = tsFormatter.formatText("gen.ts", content);

--- a/codegen/Files.ts
+++ b/codegen/Files.ts
@@ -9,18 +9,17 @@ export class Files extends Map<string, File> {
   }
 
   write = async () => {
-    const outDir = path.join(Deno.cwd(), this.outDir);
     const errors = [];
     try {
-      await Deno.remove(outDir, { recursive: true });
+      await Deno.remove(this.outDir, { recursive: true });
     } catch (e) {
       if (!(e instanceof Deno.errors.NotFound)) {
         throw e;
       }
     }
-    await Deno.mkdir(outDir, { recursive: true });
+    await Deno.mkdir(this.outDir, { recursive: true });
     for (const [relativePath, file] of this.entries()) {
-      const outputPath = path.join(outDir, relativePath);
+      const outputPath = path.join(this.outDir, relativePath);
       const content = S.toString(file.getContent());
       try {
         const formatted = tsFormatter.formatText("gen.ts", content);

--- a/codegen/Files.ts
+++ b/codegen/Files.ts
@@ -8,7 +8,7 @@ export class Files extends Map<string, File> {
     super();
   }
 
-  write = async () => {
+  async write() {
     const errors = [];
     try {
       await Deno.remove(this.outDir, { recursive: true });
@@ -32,5 +32,5 @@ export class Files extends Map<string, File> {
     if (errors.length) {
       throw errors;
     }
-  };
+  }
 }

--- a/codegen/codecVisitor.ts
+++ b/codegen/codecVisitor.ts
@@ -1,28 +1,29 @@
 import * as M from "../frame_metadata/mod.ts";
-import { Decl, Files, getCodecPath, getName, getRawCodecPath, importSource, S } from "./utils.ts";
+import { Files } from "./Files.ts";
+import { CodegenProps } from "./mod.ts";
+import { Decl, getCodecPath, getName, getRawCodecPath, S } from "./utils.ts";
 
 export function createCodecVisitor(
-  tys: M.Ty[],
+  props: CodegenProps,
   decls: Decl[],
   typeVisitor: M.TyVisitor<S>,
   files: Files,
 ) {
-  ["import { $, $null, $era } from", S.string(importSource)];
+  const { tys } = props.metadata;
   const namespaceImports = new Set<string>();
   const codecs: S[] = [];
-
   files.set("codecs.ts", {
     getContent: () => [
       "\n",
       [
         "import { ChainError, BitSequence, Era, $, $era, $null } from",
-        S.string(importSource),
+        S.string(props.importSpecifier),
       ],
       [`import type * as t from "./mod.ts"`],
       ...codecs,
       [
         "export const _all: $.AnyCodec[] =",
-        S.array(tys.map((ty) => getName(getRawCodecPath(ty)))),
+        S.array(props.metadata.tys.map((ty) => getName(getRawCodecPath(ty)))),
       ],
     ],
   });

--- a/codegen/codecVisitor.ts
+++ b/codegen/codecVisitor.ts
@@ -1,4 +1,3 @@
-import * as path from "../deps/std/path.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { Files } from "./Files.ts";
 import { CodegenProps } from "./mod.ts";
@@ -18,7 +17,7 @@ export function createCodecVisitor(
       "\n",
       [
         "import { ChainError, BitSequence, Era, $, $era, $null } from",
-        S.string(path.relative(props.outDir, props.importSpecifier)),
+        S.string(props.importSpecifier),
       ],
       [`import type * as t from "./mod.ts"`],
       ...codecs,

--- a/codegen/codecVisitor.ts
+++ b/codegen/codecVisitor.ts
@@ -1,3 +1,4 @@
+import * as path from "../deps/std/path.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { Files } from "./Files.ts";
 import { CodegenProps } from "./mod.ts";
@@ -17,7 +18,7 @@ export function createCodecVisitor(
       "\n",
       [
         "import { ChainError, BitSequence, Era, $, $era, $null } from",
-        S.string(props.importSpecifier),
+        S.string(path.relative(props.outDir, props.importSpecifier)),
       ],
       [`import type * as t from "./mod.ts"`],
       ...codecs,

--- a/codegen/mod.ts
+++ b/codegen/mod.ts
@@ -21,7 +21,7 @@ export function codegen(props: CodegenProps): Files {
       "\n",
       [
         "import { ChainError, BitSequence, Era, $ } from",
-        S.string(path.relative(Deno.cwd(), props.importSpecifier)),
+        S.string(path.relative(props.outDir, props.importSpecifier)),
       ],
       [`import * as _codec from "./codecs.ts"`],
       [`export { _metadata }`],

--- a/codegen/mod.ts
+++ b/codegen/mod.ts
@@ -1,71 +1,41 @@
-import { tsFormatter } from "../deps/dprint.ts";
 import * as path from "../deps/std/path.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { createCodecVisitor } from "./codecVisitor.ts";
+import { Files } from "./Files.ts";
 import { genMetadata } from "./genMetadata.ts";
 import { createTypeVisitor } from "./typeVisitor.ts";
-import { Decl, Files, importSource, printDecls, S } from "./utils.ts";
+import { Decl, printDecls, S } from "./utils.ts";
 
-export async function run(metadataFile: string, outputDir: string) {
-  const metadata = M.fromPrefixedHex(await Deno.readTextFile(metadataFile));
-  const output = codegen(metadata);
-  await writeOutput(outputDir, output);
+export interface CodegenProps {
+  metadata: M.Metadata;
+  importSpecifier: string;
+  outDir: string;
 }
 
-export async function writeOutput(outputDir: string, output: Files) {
-  const errors = [];
-  try {
-    await Deno.remove(outputDir, { recursive: true });
-  } catch (e) {
-    if (!(e instanceof Deno.errors.NotFound)) {
-      throw e;
-    }
-  }
-  await Deno.mkdir(outputDir, { recursive: true });
-  for (const [relativePath, file] of output.entries()) {
-    const outputPath = path.join(outputDir, relativePath);
-    const content = S.toString(file.getContent());
-    try {
-      const formatted = tsFormatter.formatText("gen.ts", content);
-      await Deno.writeTextFile(outputPath, formatted);
-    } catch (e) {
-      await Deno.writeTextFile(outputPath, content);
-      errors.push(e);
-    }
-  }
-  if (errors.length) {
-    throw errors;
-  }
-}
-
-export function codegen(metadata: M.Metadata): Files {
+export function codegen(props: CodegenProps): Files {
   const decls: Decl[] = [];
-
-  const { tys } = metadata;
-
-  const files: Files = new Map();
-
+  const files = new Files(props.outDir);
   decls.push({
     path: "_",
     code: [
       "\n",
-      ["import { ChainError, BitSequence, Era, $ } from", S.string(importSource)],
+      [
+        "import { ChainError, BitSequence, Era, $ } from",
+        S.string(path.relative(Deno.cwd(), props.importSpecifier)),
+      ],
       [`import * as _codec from "./codecs.ts"`],
       [`export { _metadata }`],
     ],
   });
-
-  const typeVisitor = createTypeVisitor(tys, decls);
-  const codecVisitor = createCodecVisitor(tys, decls, typeVisitor, files);
-
-  for (const ty of metadata.tys) {
+  const typeVisitor = createTypeVisitor(props, decls);
+  const codecVisitor = createCodecVisitor(props, decls, typeVisitor, files);
+  for (const ty of props.metadata.tys) {
     typeVisitor.visit(ty);
     codecVisitor.visit(ty);
   }
-
-  genMetadata(metadata, decls);
-
-  files.set("mod.ts", { getContent: () => printDecls(decls) });
-
+  genMetadata(props.metadata, decls);
+  files.set("mod.ts", {
+    getContent: () => printDecls(decls),
+  });
   return files;
 }

--- a/codegen/mod.ts
+++ b/codegen/mod.ts
@@ -1,4 +1,3 @@
-import * as path from "../deps/std/path.ts";
 import * as M from "../frame_metadata/mod.ts";
 import { createCodecVisitor } from "./codecVisitor.ts";
 import { Files } from "./Files.ts";
@@ -21,7 +20,7 @@ export function codegen(props: CodegenProps): Files {
       "\n",
       [
         "import { ChainError, BitSequence, Era, $ } from",
-        S.string(path.relative(props.outDir, props.importSpecifier)),
+        S.string(props.importSpecifier),
       ],
       [`import * as _codec from "./codecs.ts"`],
       [`export { _metadata }`],

--- a/codegen/mod.ts
+++ b/codegen/mod.ts
@@ -8,12 +8,11 @@ import { Decl, printDecls, S } from "./utils.ts";
 export interface CodegenProps {
   metadata: M.Metadata;
   importSpecifier: string;
-  outDir: string;
 }
 
 export function codegen(props: CodegenProps): Files {
   const decls: Decl[] = [];
-  const files = new Files(props.outDir);
+  const files = new Files();
   decls.push({
     path: "_",
     code: [

--- a/codegen/typeVisitor.ts
+++ b/codegen/typeVisitor.ts
@@ -1,7 +1,9 @@
 import * as M from "../frame_metadata/mod.ts";
+import { CodegenProps } from "./mod.ts";
 import { Decl, getName, getPath, makeDocComment, S } from "./utils.ts";
 
-export function createTypeVisitor(tys: M.Ty[], decls: Decl[]) {
+export function createTypeVisitor(props: CodegenProps, decls: Decl[]) {
+  const { tys } = props.metadata;
   return new M.TyVisitor<S>(tys, {
     unitStruct(ty) {
       return addTypeDecl(ty, "null");

--- a/codegen/utils.ts
+++ b/codegen/utils.ts
@@ -1,10 +1,5 @@
 import * as M from "../frame_metadata/mod.ts";
 
-export const importSource = new URL("../mod.ts", import.meta.url).toString();
-
-export type File = { getContent: () => S };
-export type Files = Map<string, File>;
-
 export type S = string | number | S[];
 
 export namespace S {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,7 +9,7 @@
   },
   "lint": {
     "files": {
-      "exclude": ["**/mod.generated.js", "target"],
+      "exclude": ["target"],
       "include": ["."]
     },
     "rules": {
@@ -37,7 +37,6 @@
     "test": "deno task run test_ctx.ts deno test -A --no-check=remote -L=info --ignore=target --parallel",
     "test:update": "deno task test -- -- --update",
     "mdbook:watch": "mdbook watch -o",
-    "bench": "deno bench -A --no-check=remote --unstable",
-    "typegen": "deno task run typegen/typegen.ts"
+    "bench": "deno bench -A --no-check=remote --unstable"
   }
 }

--- a/test_util/codegen.ts
+++ b/test_util/codegen.ts
@@ -10,7 +10,8 @@ export function importCodegen(config: TestConfig) {
   return U.getOr(memo, config, async () => {
     const metadata = U.throwIfError(await C.run(C.metadata(config)));
     const outDir = path.join(
-      new URL("../target/codegen", import.meta.url).pathname,
+      path.dirname(path.fromFileUrl(import.meta.url)),
+      "../target/codegen",
       config.runtimeName,
     );
     await gen.codegen({

--- a/test_util/codegen.ts
+++ b/test_util/codegen.ts
@@ -15,7 +15,7 @@ export function importCodegen(config: TestConfig) {
       config.runtimeName,
     );
     await gen.codegen({
-      importSpecifier: import.meta.resolve("../mod.ts"),
+      importSpecifier: "./mod.ts",
       metadata,
       outDir,
     }).write();

--- a/test_util/codegen.ts
+++ b/test_util/codegen.ts
@@ -10,12 +10,11 @@ export function importCodegen(config: TestConfig) {
   return U.getOr(memo, config, async () => {
     const metadata = U.throwIfError(await C.run(C.metadata(config)));
     const outDir = path.join(
-      path.dirname(path.fromFileUrl(import.meta.url)),
-      "../target/codegen/",
+      new URL("../target/codegen", import.meta.url).pathname,
       config.runtimeName,
     );
     await gen.codegen({
-      importSpecifier: "./mod.ts",
+      importSpecifier: "../../../mod.ts",
       metadata,
       outDir,
     }).write();

--- a/test_util/codegen.ts
+++ b/test_util/codegen.ts
@@ -9,13 +9,16 @@ const memo = new Map<TestConfig, Promise<CodegenModule>>();
 export function importCodegen(config: TestConfig) {
   return U.getOr(memo, config, async () => {
     const metadata = U.throwIfError(await C.run(C.metadata(config)));
-    const outputDir = path.join(
+    const outDir = path.join(
       path.dirname(path.fromFileUrl(import.meta.url)),
       "../target/codegen/",
       config.runtimeName,
     );
-    const output = gen.codegen(metadata);
-    await gen.writeOutput(outputDir, output);
-    return await import(path.toFileUrl(path.join(outputDir, "mod.ts")).toString());
+    await gen.codegen({
+      importSpecifier: import.meta.resolve("../mod.ts"),
+      metadata,
+      outDir,
+    }).write();
+    return await import(path.toFileUrl(path.join(outDir, "mod.ts")).toString());
   });
 }

--- a/test_util/codegen.ts
+++ b/test_util/codegen.ts
@@ -16,8 +16,7 @@ export function importCodegen(config: TestConfig) {
     await gen.codegen({
       importSpecifier: "../../../mod.ts",
       metadata,
-      outDir,
-    }).write();
+    }).write(outDir);
     return await import(path.toFileUrl(path.join(outDir, "mod.ts")).toString());
   });
 }

--- a/words.txt
+++ b/words.txt
@@ -186,3 +186,4 @@ tostring
 framesystem
 statemigration
 xxhash
+chainspec


### PR DESCRIPTION
Resolved #258

This PR includes a variety of tweaks to the CLI:

- specify target chain via SCALE or chainspec file paths or WebSocket URL.
- choose the Capi import specifier of codegened output (denoland/x is the default). This enables us to override to a local version or the NPM name.

Usage is slightly different.

```
deno run -A -r https://deno.land/x/capi/codegen.ts \
  --src=wss://rpc.polkadot.io \
  --out=polkadot \
  --import=capi
```

In the context of this repo, we could run the following:

```
deno task run codegen.ts \
  --src=wss://rpc.polkadot.io \
  --out=polkadot \
  --import=mod.ts
```

Given that we specify `mod.ts` as the Capi import specifier, the files generated into the `polkadot` dir will import capi via `../mod.ts`.