### PR TITLE
chore: error cleanup

### DIFF
--- a/effects/common.ts
+++ b/effects/common.ts
@@ -2,7 +2,7 @@ import * as rpc from "../rpc/mod.ts";
 
 // TODO: handle this elsewhere
 export class RpcError extends Error {
-  override readonly name = "RpcCall";
+  override readonly name = "RpcError";
   code;
   attempt;
 

--- a/effects/common.ts
+++ b/effects/common.ts
@@ -1,8 +1,8 @@
 import * as rpc from "../rpc/mod.ts";
-import * as U from "../util/mod.ts";
 
 // TODO: handle this elsewhere
-export class RpcError extends U.ErrorCtor("RpcCall") {
+export class RpcError extends Error {
+  override readonly name = "RpcCall";
   code;
   attempt;
 

--- a/effects/extrinsic.ts
+++ b/effects/extrinsic.ts
@@ -58,7 +58,7 @@ export class SignedExtrinsic<
     const senderSs58 = Z.call(
       Z.ls(addrPrefix, props.sender),
       function senderSs58([addrPrefix, sender]) {
-        return ((): string => {
+        return (() => {
           switch (sender.type) {
             case "Id": {
               return ss58.encode(addrPrefix, sender.value);

--- a/effects/extrinsic.ts
+++ b/effects/extrinsic.ts
@@ -58,17 +58,15 @@ export class SignedExtrinsic<
     const senderSs58 = Z.call(
       Z.ls(addrPrefix, props.sender),
       function senderSs58([addrPrefix, sender]) {
-        return (() => {
-          switch (sender.type) {
-            case "Id": {
-              return ss58.encode(addrPrefix, sender.value);
-            }
-            // TODO: other types
-            default: {
-              unimplemented();
-            }
+        switch (sender.type) {
+          case "Id": {
+            return ss58.encode(addrPrefix, sender.value);
           }
-        })();
+          // TODO: other types
+          default: {
+            unimplemented();
+          }
+        }
       },
     );
     const accountNextIndex = rpcCall(config, "system_accountNextIndex", [senderSs58]);

--- a/effects/metadata.ts
+++ b/effects/metadata.ts
@@ -78,5 +78,5 @@ export function mapMetadata<PalletMetadata extends Z.$<M.Pallet>, EntryName exte
 }
 
 export class ExpectedMapError extends Error {
-  override readonly name = "ExpectedMap";
+  override readonly name = "ExpectedMapError";
 }

--- a/effects/metadata.ts
+++ b/effects/metadata.ts
@@ -77,4 +77,6 @@ export function mapMetadata<PalletMetadata extends Z.$<M.Pallet>, EntryName exte
   );
 }
 
-export class ExpectedMapError extends U.ErrorCtor("ExpectedMap") {}
+export class ExpectedMapError extends Error {
+  override readonly name = "ExpectedMap";
+}

--- a/effects/rpcSubscription.ts
+++ b/effects/rpcSubscription.ts
@@ -49,7 +49,8 @@ export function rpcSubscription<
 }
 
 // TODO: handle elsewhere
-export class RpcSubscriptionError extends U.ErrorCtor("RpcSubscription") {
+export class RpcSubscriptionError extends Error {
+  override readonly name = "RpcSubscription";
   constructor(readonly error: rpc.ErrMessage["error"]) {
     super();
   }

--- a/effects/rpcSubscription.ts
+++ b/effects/rpcSubscription.ts
@@ -50,7 +50,8 @@ export function rpcSubscription<
 
 // TODO: handle elsewhere
 export class RpcSubscriptionError extends Error {
-  override readonly name = "RpcSubscription";
+  override readonly name = "RpcSubscriptionError";
+
   constructor(readonly error: rpc.ErrMessage["error"]) {
     super();
   }

--- a/frame_metadata/Codec.ts
+++ b/frame_metadata/Codec.ts
@@ -112,6 +112,8 @@ export function DeriveCodec(tys: M.Ty[]): DeriveCodec {
 }
 
 export class ChainError<T> extends Error {
+  override readonly name = "ChainError";
+
   constructor(readonly value: T) {
     super();
   }

--- a/frame_metadata/Key.ts
+++ b/frame_metadata/Key.ts
@@ -56,7 +56,3 @@ export function $storageKey(props: StorageKeyProps): $.Codec<unknown[]> {
     },
   });
 }
-
-export class StorageEntryMissingHasher extends Error {}
-export class InvalidArgErr extends Error {}
-export class DecodeNonTransparentKeyError extends Error {}

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -152,17 +152,23 @@ export function fromPrefixedHex(scaleEncoded: string): Metadata {
 export function getPallet(metadata: Metadata, name: string): Pallet | PalletNotFoundError {
   return metadata.pallets.find((pallet) => pallet.name === name) || new PalletNotFoundError();
 }
-export class PalletNotFoundError extends U.ErrorCtor("PalletNotFound") {}
+export class PalletNotFoundError extends Error {
+  override readonly name = "PalletNotFoundError";
+}
 
 export function getEntry(pallet: Pallet, name: string): StorageEntry | EntryNotFoundError {
   return pallet.storage?.entries.find((entry) => entry.name === name) || new EntryNotFoundError();
 }
-export class EntryNotFoundError extends U.ErrorCtor("EntryNotFound") {}
+export class EntryNotFoundError extends Error {
+  override readonly name = "EntryNotFoundError";
+}
 
 export function getConst(pallet: Pallet, name: string): Constant | ConstNotFoundError {
   return pallet.constants?.find((constant) => constant.name === name) || new ConstNotFoundError();
 }
-export class ConstNotFoundError extends U.ErrorCtor("ConstNotFound") {}
+export class ConstNotFoundError extends Error {
+  override readonly name = "ConstNotFoundError";
+}
 
 export function getPalletAndEntry(
   metadata: Metadata,

--- a/hashers/mod.ts
+++ b/hashers/mod.ts
@@ -1,7 +1,6 @@
 import { blake2b } from "../deps/blake2b.ts";
 import * as $ from "../deps/scale.ts";
 import { EncodeBuffer } from "../deps/scale.ts";
-import { DecodeNonTransparentKeyError } from "../frame_metadata/Key.ts";
 import { Xxhash } from "./xxhash.ts";
 
 export abstract class Hasher {
@@ -122,4 +121,8 @@ function updateHashing(hashing: Hashing, data: EncodeBuffer) {
       hashing.update(array);
     }
   }
+}
+
+export class DecodeNonTransparentKeyError extends Error {
+  override readonly name = "DecodeNonTransparentKeyError";
 }

--- a/rpc/common.ts
+++ b/rpc/common.ts
@@ -1,4 +1,3 @@
-import { ErrorCtor } from "../util/mod.ts";
 import * as msg from "./messages.ts";
 
 export type ProviderMethods = Record<string, (...args: any[]) => any>;
@@ -39,4 +38,6 @@ export interface ClientHooks<InternalError> {
   close?: () => void;
 }
 
-export class ParseRawIngressMessageError extends ErrorCtor("ParseRawIngressMessage") {}
+export class ParseRawIngressMessageError extends Error {
+  override readonly name = "ParseRawIngressMessage";
+}

--- a/rpc/providers/proxy.ts
+++ b/rpc/providers/proxy.ts
@@ -1,6 +1,5 @@
 import { Config } from "../../config/mod.ts";
 import { deadline, deferred } from "../../deps/std/async.ts";
-import { ErrorCtor } from "../../util/mod.ts";
 import * as B from "../Base.ts";
 import { ClientHooks, ParseRawIngressMessageError } from "../common.ts";
 
@@ -78,5 +77,9 @@ export class ProxyClient extends B.Client<MessageEvent, Event, FailedToDisconnec
   }
 }
 
-export class FailedToOpenConnectionError extends ErrorCtor("FailedToOpenConnection") {}
-export class FailedToDisconnectError extends ErrorCtor("FailedToDisconnect") {}
+export class FailedToOpenConnectionError extends Error {
+  override readonly name = "FailedToOpenConnection";
+}
+export class FailedToDisconnectError extends Error {
+  override readonly name = "FailedToDisconnect";
+}

--- a/rpc/providers/smoldot.ts
+++ b/rpc/providers/smoldot.ts
@@ -1,6 +1,5 @@
 import { Config } from "../../config/mod.ts";
 import type * as smoldot from "../../deps/smoldot.ts";
-import { ErrorCtor } from "../../util/mod.ts";
 import { Client, OnMessage } from "../Base.ts";
 import { ClientHooks, ParseRawIngressMessageError } from "../common.ts";
 
@@ -80,15 +79,21 @@ async function ensureInstance(): Promise<smoldot.Client | FailedToStartSmoldotEr
   return _state.smoldotInstance;
 }
 
-export class FailedToStartSmoldotError extends ErrorCtor("FailedToStartSmoldot") {}
-export class FailedToAddChainError extends ErrorCtor("FailedToAddChain") {
+export class FailedToStartSmoldotError extends Error {
+  override readonly name = "FailedToStartSmoldot";
+}
+export class FailedToAddChainError extends Error {
+  override readonly name = "FailedToAddChain";
   constructor(readonly inner: unknown) {
     super();
   }
 }
-export class SmoldotInternalError extends ErrorCtor("SmoldotInternal") {}
+export class SmoldotInternalError extends Error {
+  override readonly name = "SmoldotInternal";
+}
 // TODO: specify narrow `AlreadyDestroyedError` & `CrashError` from Smoldot
-export class FailedToRemoveChainError extends ErrorCtor("FailedToRemoveChain") {
+export class FailedToRemoveChainError extends Error {
+  override readonly name = "FailedToRemoveChain";
   constructor(readonly inner: unknown) {
     super();
   }

--- a/ss58/mod.test.ts
+++ b/ss58/mod.test.ts
@@ -1,15 +1,6 @@
-import { assertEquals, assertThrows } from "../deps/std/testing/asserts.ts";
+import { assertEquals, assertInstanceOf } from "../deps/std/testing/asserts.ts";
 import * as T from "../test_util/mod.ts";
-
-import {
-  decode,
-  decodeRaw,
-  encode,
-  InvalidAddressChecksumError,
-  InvalidAddressLengthError,
-  InvalidNetworkPrefixError,
-  InvalidPublicKeyLengthError,
-} from "./mod.ts";
+import * as ss58 from "./mod.ts";
 
 for (
   const [networkName, address, [prefix, publicKey]] of [
@@ -31,34 +22,37 @@ for (
   ] as const
 ) {
   Deno.test(`ss58.encode ${networkName}`, () => {
-    const actual = encode(prefix, publicKey);
+    const actual = ss58.encode(prefix, publicKey);
     assertEquals(actual, address);
   });
   Deno.test(`ss58.decode ${networkName}`, () => {
-    const actual = decode(address);
+    const actual = ss58.decode(address);
     assertEquals(actual, [prefix, publicKey]);
   });
 }
 
 Deno.test("ss58.encode invalid public key length", () => {
-  assertThrows(() => encode(0, T.alice.publicKey.slice(0, 30)), InvalidPublicKeyLengthError);
+  assertInstanceOf(
+    ss58.encode(0, T.alice.publicKey.slice(0, 30)),
+    ss58.InvalidPublicKeyLengthError,
+  );
 });
 
 Deno.test("ss58.encode invalid network prefix", () => {
-  assertThrows(() => encode(46, T.alice.publicKey, [0]), InvalidNetworkPrefixError);
+  assertInstanceOf(ss58.encode(46, T.alice.publicKey, [0]), ss58.InvalidNetworkPrefixError);
 });
 
 Deno.test("ss58.decodeRaw long address", () => {
-  assertThrows(() => decodeRaw(new Uint8Array(40)), InvalidAddressLengthError);
+  assertInstanceOf(ss58.decodeRaw(new Uint8Array(40)), ss58.InvalidAddressLengthError);
 });
 
 Deno.test("ss58.decodeRaw short address", () => {
-  assertThrows(() => decodeRaw(new Uint8Array(30)), InvalidAddressLengthError);
+  assertInstanceOf(ss58.decodeRaw(new Uint8Array(30)), ss58.InvalidAddressLengthError);
 });
 
 Deno.test("ss58.decodeRaw invalid checksum", () => {
-  assertThrows(
-    () => decodeRaw(Uint8Array.of(0, ...T.alice.publicKey, 255, 255)),
-    InvalidAddressChecksumError,
+  assertInstanceOf(
+    ss58.decodeRaw(Uint8Array.of(0, ...T.alice.publicKey, 255, 255)),
+    ss58.InvalidAddressChecksumError,
   );
 });

--- a/util/error.ts
+++ b/util/error.ts
@@ -1,10 +1,3 @@
-/** Produces an error whose name is represented within the type system */
-export function ErrorCtor<Name extends string>(name: Name) {
-  return class extends Error {
-    override readonly name = name;
-  };
-}
-
 export function throwIfError<T>(value: T): Exclude<T, Error> {
   if (value instanceof Error) {
     throw value;


### PR DESCRIPTION
- Return instead of throw from Ss58 transcoders
- Create new error ctors without a bespoke util