### PR TITLE
chore: update to scale v0.8.2

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -23,9 +23,9 @@ await Promise.all([
     }],
     outDir,
     mappings: {
-      "https://deno.land/x/scale@v0.7.0/mod.ts": {
-        name: "parity-scale-codec",
-        version: "^0.7.0",
+      "https://deno.land/x/scale@v0.8.2/mod.ts": {
+        name: "scale-codec",
+        version: "^0.8.2",
       },
       "https://deno.land/x/zones@v0.1.0-beta.6/mod.ts": {
         name: "zones",

--- a/deps/scale.ts
+++ b/deps/scale.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/scale@v0.7.0/mod.ts";
+export * from "https://deno.land/x/scale@v0.8.2/mod.ts";


### PR DESCRIPTION
The NPM package name also changed to `scale-codec`