### PR TITLE
fix: codegen rpc.Client setup

### DIFF
--- a/codegen/server/server.ts
+++ b/codegen/server/server.ts
@@ -152,7 +152,7 @@ export const client = new LocalClientEffect(${JSON.stringify(chainUrl.slice(4))}
           `
           : `
 import * as C from ${JSON.stringify(`/@${version}/mod.ts`)}
-export const client = C.rpc.rpcClient(C.rpc.proxyProvider, ${JSON.stringify(chainUrl)})
+export const client = new C.rpc.Client(C.rpc.proxyProvider, ${JSON.stringify(chainUrl)})
           `,
         importSpecifier: `/@${version}/mod.ts`,
       })

--- a/codegen/server/server.ts
+++ b/codegen/server/server.ts
@@ -152,7 +152,7 @@ export const client = new LocalClientEffect(${JSON.stringify(chainUrl.slice(4))}
           `
           : `
 import * as C from ${JSON.stringify(`/@${version}/mod.ts`)}
-export const client = new C.rpc.Client(C.rpc.proxyProvider, ${JSON.stringify(chainUrl)})
+export const client = C.rpcClient(C.rpc.proxyProvider, ${JSON.stringify(chainUrl)})
           `,
         importSpecifier: `/@${version}/mod.ts`,
       })


### PR DESCRIPTION
Fixes the `C.rpc.Client` setup

