### PR TITLE
fix: update `capi_crypto_wrappers` for browser support

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -27,6 +27,8 @@ await Promise.all([
         name: "@substrate/smoldot-light",
         version: "0.6.20",
       },
+      "https://raw.githubusercontent.com/paritytech/capi-crypto-wrappers/14289c5/lib.ts":
+        "https://raw.githubusercontent.com/paritytech/capi-crypto-wrappers/14289c5/lib.node.ts",
     },
     package: {
       name: "capi",

--- a/deps/capi_crypto_wrappers.ts
+++ b/deps/capi_crypto_wrappers.ts
@@ -1,1 +1,1 @@
-export * from "https://raw.githubusercontent.com/paritytech/capi-crypto-wrappers/e15ce9d65afeb479ef095d4ae8b387c4adce3d3f/mod.ts"
+export * from "https://raw.githubusercontent.com/paritytech/capi-crypto-wrappers/14289c5/mod.ts"


### PR DESCRIPTION
Resolves #434 

- For deno & fresh, it inlines the wasm blob in the JS (url fetch wasn't working with fresh) but loads it asynchronously to support browsers' limit on synchronous wasm instantiation
- For node, it inlines the wasm blob in the JS and loads it synchronously as node doesn't support TLA