### PR TITLE
fix: stop redirecting to `/@sha:abc123undefined`

### DIFF
--- a/codegen/server/server.ts
+++ b/codegen/server/server.ts
@@ -81,7 +81,7 @@ export abstract class CodegenServer {
     const [, version, path] = versionMatch
     const normalizedVersion = await this.normalizeVersion(version!)
     if (normalizedVersion !== version) {
-      return this.redirect(request, `/@${normalizedVersion}${path}`)
+      return this.redirect(request, `/@${normalizedVersion}${path ?? "/"}`)
     }
     if (!(await this.canHandleVersion(version!))) {
       return this.delegateRequest(request, version!, path!)


### PR DESCRIPTION
Fixes e.g. https://capi.dev/@ref:main