### PR TITLE
feat: add zsh to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Capi",
   "build": {
     "dockerfile": "../Dockerfile",
-    "target": "vscode"
+    "target": "dev"
   },
   "settings": {
     "files.watcherExclude": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
+FROM vscode as dev
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y zsh
 
 FROM vscode as gitpod
 


### PR DESCRIPTION
Resolves #463

## Description

Add dev as a new build stage in docker and install `zsh` in that stage; dev container file updated to point to `dev` stage. This ensures `zsh` is installed in dev builds and not production builds.


