### PR TITLE
fix: ci & issue re deno upgrade

### DIFF
--- a/.github/workflows/check_secrets.yml
+++ b/.github/workflows/check_secrets.yml
@@ -2,7 +2,7 @@ name: Check Secrets
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/deno_deploy.yml
+++ b/.github/workflows/deno_deploy.yml
@@ -1,4 +1,6 @@
 name: Deno Deploy
+# Omitting pull requests here is intentional because it could be used as an
+# attack vector from an outside source
 on: push
 jobs:
   deploy:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,5 +1,7 @@
 name: Check Formatting
-on: push
+on:
+  - pull_request
+  - push
 jobs:
   check:
     name: Check Formatting

--- a/.github/workflows/spawn_examples.yml
+++ b/.github/workflows/spawn_examples.yml
@@ -1,7 +1,8 @@
 name: Spawn Examples
 on:
-  workflow_dispatch:
-  push:
+  - workflow_dispatch
+  - push
+  - pull_request
 jobs:
   generate_example_paths:
     name: Generate example paths

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,7 @@
 name: Spellcheck
-on: push
+on:
+  - pull_request
+  - push
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test
-on: push
+on:
+  - pull_request
+  - push
 jobs:
   test:
     name: Run Tests

--- a/rpc/client.ts
+++ b/rpc/client.ts
@@ -52,7 +52,7 @@ export class Client<
         this.activeSubscriptions[id]!(e)
         delete this.activeSubscriptions[id]
       }
-    } else if (typeof e.id === "number") {
+    } else if (e.id !== undefined) {
       const pendingCall = this.pendingCalls[e.id]
       pendingCall?.resolve(e)
       delete this.pendingCalls[e.id]


### PR DESCRIPTION
Resolves #469

## Description

- Fixes the compiler error and updates the `id` check of `IngressMessage` to just check if the `id` is undefined or not. It can never be a number base on the type definition: https://github.com/paritytech/capi/blob/fix/test-suite/rpc/messages.ts#L9. 
- Adds CI to PR builds -- i.e. in the case of a forked repo submitting a PR.
- Fixes one of the workflows pointing from `master` to `main`.