### PR TITLE
feat: add zombienet and polkadot-parachain to devcontainer

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 image:
   file: Dockerfile
 tasks:
-  - init: deno task star
+  - init: deno task codegen && deno task star
 vscode:
   extensions:
     - EditorConfig.EditorConfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,18 @@ ARG DENO_VERSION=1.29.1
 FROM denoland/deno:${DENO_VERSION} as vscode
 
 ARG POLKADOT_VERSION=v0.9.36
+ARG POLKADOT_PARACHAIN_VERSION=v0.9.320
+ARG ZOMBIENET_VERSION=v1.3.18
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y unzip curl git \
+  && apt-get install -y unzip curl git procps \
   && curl -L -o /usr/local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/${POLKADOT_VERSION}/polkadot \
   && chmod +x /usr/local/bin/polkadot \
+  && curl -L -o /usr/local/bin/polkadot-parachain https://github.com/paritytech/cumulus/releases/download/${POLKADOT_PARACHAIN_VERSION}/polkadot-parachain \
+  && chmod +x /usr/local/bin/polkadot-parachain \
+  && curl -L -o /usr/local/bin/zombienet-linux https://github.com/paritytech/zombienet/releases/download/${ZOMBIENET_VERSION}/zombienet-linux \
+  && chmod +x /usr/local/bin/zombienet-linux \
   && curl -fsSL https://dprint.dev/install.sh | DPRINT_INSTALL=/usr/local sh \
   && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get install -y nodejs \
@@ -20,7 +26,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 FROM vscode as dev
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y zsh
+  && apt-get install -y zsh \
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 FROM vscode as gitpod
 

--- a/words.txt
+++ b/words.txt
@@ -209,3 +209,4 @@ paritypr
 lparachain
 unioned
 rustc
+procps


### PR DESCRIPTION
Add `zombienet-linux` and `polkadot-parachain` binaries to the docker image

**How to test?**

- https://gitpod.io/#https://github.com/paritytech/capi/tree/feat/zombienet-devcontainer
- open the terminal and run `deno task run examples/smart_contract.ts`

Note: using docker in M1 Macs it doesn't work and it seems to be related to `qemu-x86_64` CPU emulation.