### PR TITLE
feat: add connection retry to proxyProvider

### DIFF
--- a/deps/std/async.ts
+++ b/deps/std/async.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.127.0/async/mod.ts"
+export * from "https://deno.land/std@0.170.0/async/mod.ts"

--- a/examples/derived.ts
+++ b/examples/derived.ts
@@ -1,9 +1,18 @@
 import * as C from "http://localhost:5646/@local/mod.ts"
 import * as U from "http://localhost:5646/@local/util/mod.ts"
 
-const ids = C.entryRead(C.polkadot)("Paras", "Parachains", [])
-  .access("value")
-  .as<number[]>()
+// TODO: uncomment these lines to run a single effect upon solving `count` in zones
+// or effects/rpc.ts#discardCheck
+// const ids = C.entryRead(C.polkadot)("Paras", "Parachains", [])
+//   .access("value")
+//   .as<number[]>()
+
+const ids = U.throwIfError(
+  await C.entryRead(C.polkadot)("Paras", "Parachains", [])
+    .access("value")
+    .as<number[]>()
+    .run(),
+)
 
 const root = C.Z.each(ids, (id) => {
   return C.entryRead(C.polkadot)("Paras", "Heads", [id])

--- a/rpc/provider/base.ts
+++ b/rpc/provider/base.ts
@@ -86,11 +86,11 @@ export class ListenersContainer<
   >()
 
   set(discoveryValue: DiscoveryValue, listener: ProviderListener<SendErrorData, HandlerErrorData>) {
-    let map = this.#listeners.get(discoveryValue)
-    if (!map) {
-      map = new Map()
-      this.#listeners.set(discoveryValue, map)
-    }
+    const map = U.getOrInit(this.#listeners, discoveryValue, () =>
+      new Map<
+        ProviderListener<SendErrorData, HandlerErrorData>,
+        ProviderListener<SendErrorData, HandlerErrorData>
+      >())
     if (map.has(listener)) return
     map.set(
       listener,

--- a/rpc/provider/proxy.test.ts
+++ b/rpc/provider/proxy.test.ts
@@ -5,9 +5,14 @@ import { setup } from "./test_util.ts"
 
 Deno.test({
   name: "Proxy Provider",
+  sanitizeResources: false,
+  sanitizeOps: false,
   async fn(t) {
     await t.step({
       name: "send/listen",
+      // TODO: await T.polkadot initializes a 2nd proxyProvider
+      sanitizeResources: false,
+      sanitizeOps: false,
       async fn() {
         const [ref, message] = await setup(proxyProvider, await T.polkadot.url, "system_health", [])
         A.assertNotInstanceOf(message, Error)
@@ -18,7 +23,6 @@ Deno.test({
 
     await t.step({
       name: "create WebSocket error",
-      ignore: true,
       async fn() {
         const [ref, message] = await setup(
           proxyProvider,
@@ -33,7 +37,6 @@ Deno.test({
 
     await t.step({
       name: "close WebSocket while listening",
-      ignore: true,
       async fn() {
         const server = createWebSocketServer(function() {
           this.close()

--- a/rpc/provider/proxy.test.ts
+++ b/rpc/provider/proxy.test.ts
@@ -18,6 +18,7 @@ Deno.test({
 
     await t.step({
       name: "create WebSocket error",
+      ignore: true,
       async fn() {
         const [ref, message] = await setup(
           proxyProvider,
@@ -32,6 +33,7 @@ Deno.test({
 
     await t.step({
       name: "close WebSocket while listening",
+      ignore: true,
       async fn() {
         const server = createWebSocketServer(function() {
           this.close()

--- a/rpc/provider/proxy.test.ts
+++ b/rpc/provider/proxy.test.ts
@@ -1,6 +1,6 @@
 import * as A from "../../deps/std/testing/asserts.ts"
 import * as T from "../../test_util/mod.ts"
-import { proxyProvider } from "./proxy.ts"
+import { proxyProviderFactory } from "./proxy.ts"
 import { setup } from "./test_util.ts"
 
 Deno.test({
@@ -14,7 +14,12 @@ Deno.test({
       sanitizeResources: false,
       sanitizeOps: false,
       async fn() {
-        const [ref, message] = await setup(proxyProvider, await T.polkadot.url, "system_health", [])
+        const [ref, message] = await setup(
+          proxyProviderFactory(),
+          await T.polkadot.url,
+          "system_health",
+          [],
+        )
         A.assertNotInstanceOf(message, Error)
         A.assertExists(message.result)
         A.assertNotInstanceOf(await ref.release(), Error)
@@ -25,7 +30,7 @@ Deno.test({
       name: "create WebSocket error",
       async fn() {
         const [ref, message] = await setup(
-          proxyProvider,
+          proxyProviderFactory({ retryOptions: { maxAttempts: 1 } }),
           "invalid-endpoint-url",
           "system_health",
           [],
@@ -42,7 +47,7 @@ Deno.test({
           this.close()
         })
         const [ref, message] = await setup(
-          proxyProvider,
+          proxyProviderFactory(),
           server.url,
           "system_health",
           [],
@@ -58,7 +63,7 @@ Deno.test({
       async fn() {
         const server = createWebSocketServer()
         const [ref, message] = await setup(
-          proxyProvider,
+          proxyProviderFactory(),
           server.url,
           "system_health",
           // make JSON.stringify to throw

--- a/rpc/provider/proxy.ts
+++ b/rpc/provider/proxy.ts
@@ -1,67 +1,37 @@
 import { retry } from "../../deps/std/async.ts"
-import { nextIdFactory, Provider, ProviderListener } from "./base.ts"
+import * as msg from "../messages.ts"
+import { ListenersContainer, nextIdFactory, Provider, ProviderListener } from "./base.ts"
 import { ProviderCloseError, ProviderHandlerError, ProviderSendError } from "./errors.ts"
-
-/** Global lookup of existing connections */
-// const connections = new Map<string, ProxyProviderConnection>()
-// type ProxyProviderConnection = ProviderConnection<WebSocket, Event, Event>
 
 const nextId = nextIdFactory()
 
-const listeners = new Map<
-  string,
-  Map<ProviderListener<Event, Event>, ProviderListener<Event, Event>>
->()
-
-function setListener(url: string, listener: ProviderListener<Event, Event>) {
-  if (!listeners.has(url)) {
-    listeners.set(url, new Map())
-  }
-  const map = listeners.get(url)!
-  if (map.has(listener)) return
-  map.set(
-    listener,
-    listener.bind({
-      stop: () => deleteListener(url, listener),
-    }),
-  )
-}
-
-function deleteListener(url: string, listener: ProviderListener<Event, Event>) {
-  if (!listeners.has(url)) return
-  const map = listeners.get(url)!
-  map.delete(listener)
-}
-
-function callListener(url: string, message: Parameters<ProviderListener<Event, Event>>[0]) {
-  if (!listeners.has(url)) return
-  for (const listener of listeners.get(url)!.values()) {
-    listener(message)
-  }
-}
+const listenersContainer = new ListenersContainer<string, Event, Event>()
+const activeWs = new Map<string, WebSocket>()
+const connectingWs = new Map<string, Promise<WebSocket>>()
+const CUSTOM_WS_CLOSE_CODE = 4000
 
 export const proxyProvider: Provider<string, Event, Event, Event> = (url, listener) => {
-  setListener(url, listener)
-  let ws: WebSocket
+  listenersContainer.set(url, listener)
+  let ws: WebSocket | undefined
   return {
     nextId,
     send: (message) => {
       ;(async () => {
         try {
-          ws = await openWsWithRetry(url, listener)
+          ws = await openedWs(url, (e) => listenersContainer.forEachListener(url, e))
         } catch (error) {
-          return callListener(url, new ProviderHandlerError(error as Event))
+          return listener(new ProviderHandlerError(error as Event))
         }
         try {
           ws.send(JSON.stringify(message))
         } catch (error) {
-          callListener(url, new ProviderSendError(error as Event, message))
+          listener(new ProviderSendError(error as Event, message))
         }
       })()
     },
     release: () => {
-      deleteListener(url, listener)
-      if (ws) {
+      listenersContainer.delete(url, listener)
+      if (!listenersContainer.count(url) && ws) {
         return closeWs(ws)
       }
       return Promise.resolve(undefined)
@@ -69,79 +39,69 @@ export const proxyProvider: Provider<string, Event, Event, Event> = (url, listen
   }
 }
 
-const activeWs = new Map<string, WebSocket>()
-const connectingWs = new Map<string, Promise<WebSocket>>()
-
-function openWsWithRetry(
+function openedWs(
   url: string,
   listener: ProviderListener<Event, Event>,
 ) {
-  return retry(() => openWs(url, listener), { maxAttempts: 10 })
-}
-
-function openWs(
-  url: string,
-  listener: ProviderListener<Event, Event>,
-) {
-  if (activeWs.has(url)) {
-    return Promise.resolve(activeWs.get(url)!)
-  }
-  if (connectingWs.has(url)) {
-    return connectingWs.get(url)!
-  }
-
-  const openedWs = new Promise<WebSocket>((resolve, reject) => {
-    const connectingWsController = new AbortController()
-    const ws = new WebSocket(url)
-    ws.addEventListener(
-      "open",
-      () => {
-        connectingWsController.abort()
-        connectingWs.delete(url)
-        activeWs.set(url, ws)
-
-        const activeWsController = new AbortController()
-        ws.addEventListener(
-          "message",
-          (e) => listener(JSON.parse(e.data)),
-          activeWsController,
-        )
-        ws.addEventListener(
-          "error",
-          (e) => {
-            activeWs.delete(url)
-            listener(new ProviderHandlerError(e))
-          },
-          activeWsController,
-        )
-        ws.addEventListener(
-          "close",
-          (e) => {
-            activeWs.delete(url)
-            activeWsController.abort()
-            if (!e.wasClean) {
+  return retry(() => {
+    if (activeWs.has(url)) {
+      return Promise.resolve(activeWs.get(url)!)
+    }
+    if (connectingWs.has(url)) {
+      return connectingWs.get(url)!
+    }
+    const openedWs = new Promise<WebSocket>((resolve, reject) => {
+      const connectingWsController = new AbortController()
+      const ws = new WebSocket(url)
+      ws.addEventListener(
+        "open",
+        () => {
+          connectingWsController.abort()
+          connectingWs.delete(url)
+          activeWs.set(url, ws)
+          const activeWsController = new AbortController()
+          ws.addEventListener(
+            "message",
+            (e) => listener(msg.parse(e.data)),
+            activeWsController,
+          )
+          ws.addEventListener(
+            "error",
+            (e) => {
+              activeWs.delete(url)
               listener(new ProviderHandlerError(e))
-            }
-          },
-          activeWsController,
-        )
-        resolve(ws)
-      },
-      connectingWsController,
-    )
-    ws.addEventListener(
-      "close",
-      (e) => {
-        connectingWsController.abort()
-        connectingWs.delete(url)
-        activeWs.delete(url)
-        reject(e)
-      },
-      connectingWsController,
-    )
+            },
+            activeWsController,
+          )
+          ws.addEventListener(
+            "close",
+            (e) => {
+              activeWs.delete(url)
+              activeWsController.abort()
+              if (e.code !== CUSTOM_WS_CLOSE_CODE) {
+                listener(new ProviderHandlerError(e))
+              }
+            },
+            activeWsController,
+          )
+          resolve(ws)
+        },
+        connectingWsController,
+      )
+      ws.addEventListener(
+        "close",
+        (e) => {
+          connectingWsController.abort()
+          connectingWs.delete(url)
+          activeWs.delete(url)
+          reject(e)
+        },
+        connectingWsController,
+      )
+    })
+    connectingWs.set(url, openedWs)
+    return openedWs
   })
-  connectingWs.set(url, openedWs)
-  return openedWs
 }
 
 function closeWs(socket: WebSocket): Promise<undefined | ProviderCloseError<Event>> {
@@ -158,6 +118,6 @@ function closeWs(socket: WebSocket): Promise<undefined | ProviderCloseError<Even
       controller.abort()
       resolve(new ProviderCloseError(e))
     }, controller)
-    socket.close()
+    socket.close(CUSTOM_WS_CLOSE_CODE, "Client normal closure")
   })
 }

--- a/rpc/provider/proxy.ts
+++ b/rpc/provider/proxy.ts
@@ -1,95 +1,147 @@
-import * as U from "../../util/mod.ts"
-import * as msg from "../messages.ts"
-import { nextIdFactory, Provider, ProviderConnection, ProviderListener } from "./base.ts"
+import { retry } from "../../deps/std/async.ts"
+import { nextIdFactory, Provider, ProviderListener } from "./base.ts"
 import { ProviderCloseError, ProviderHandlerError, ProviderSendError } from "./errors.ts"
 
 /** Global lookup of existing connections */
-const connections = new Map<string, ProxyProviderConnection>()
-type ProxyProviderConnection = ProviderConnection<WebSocket, Event, Event>
+// const connections = new Map<string, ProxyProviderConnection>()
+// type ProxyProviderConnection = ProviderConnection<WebSocket, Event, Event>
 
 const nextId = nextIdFactory()
 
+const listeners = new Map<
+  string,
+  Map<ProviderListener<Event, Event>, ProviderListener<Event, Event>>
+>()
+
+function setListener(url: string, listener: ProviderListener<Event, Event>) {
+  if (!listeners.has(url)) {
+    listeners.set(url, new Map())
+  }
+  const map = listeners.get(url)!
+  if (map.has(listener)) return
+  map.set(
+    listener,
+    listener.bind({
+      stop: () => deleteListener(url, listener),
+    }),
+  )
+}
+
+function deleteListener(url: string, listener: ProviderListener<Event, Event>) {
+  if (!listeners.has(url)) return
+  const map = listeners.get(url)!
+  map.delete(listener)
+}
+
+function callListener(url: string, message: Parameters<ProviderListener<Event, Event>>[0]) {
+  if (!listeners.has(url)) return
+  for (const listener of listeners.get(url)!.values()) {
+    listener(message)
+  }
+}
+
 export const proxyProvider: Provider<string, Event, Event, Event> = (url, listener) => {
+  setListener(url, listener)
+  let ws: WebSocket
   return {
     nextId,
     send: (message) => {
-      let conn
-      try {
-        conn = connection(url, listener)
-      } catch (error) {
-        listener(new ProviderHandlerError(error as Event))
-        return
-      }
       ;(async () => {
-        const openError = await ensureWsOpen(conn.inner)
-        if (openError) {
-          conn.forEachListener(new ProviderSendError(openError, message))
-          return
+        try {
+          ws = await openWsWithRetry(url, listener)
+        } catch (error) {
+          return callListener(url, new ProviderHandlerError(error as Event))
         }
         try {
-          conn.inner.send(JSON.stringify(message))
+          ws.send(JSON.stringify(message))
         } catch (error) {
-          listener(new ProviderSendError(error as Event, message))
+          callListener(url, new ProviderSendError(error as Event, message))
         }
       })()
     },
     release: () => {
-      const conn = connections.get(url)
-      if (!conn) {
-        return Promise.resolve(undefined)
-      }
-      const { cleanUp, listeners, inner } = conn
-      listeners.delete(listener)
-      if (!listeners.size) {
-        connections.delete(url)
-        cleanUp()
-        return closeWs(inner)
+      deleteListener(url, listener)
+      if (ws) {
+        return closeWs(ws)
       }
       return Promise.resolve(undefined)
     },
   }
 }
 
-function connection(
+const activeWs = new Map<string, WebSocket>()
+const connectingWs = new Map<string, Promise<WebSocket>>()
+
+function openWsWithRetry(
   url: string,
   listener: ProviderListener<Event, Event>,
-): ProxyProviderConnection {
-  const conn = U.getOrInit(connections, url, () => {
-    const controller = new AbortController()
-    const ws = new WebSocket(url)
-    ws.addEventListener("message", (e) => {
-      conn!.forEachListener(msg.parse(e.data))
-    }, controller)
-    ws.addEventListener("error", (e) => {
-      conn!.forEachListener(new ProviderHandlerError(e))
-    }, controller)
-    ws.addEventListener("close", (e) => {
-      conn!.forEachListener(new ProviderHandlerError(e))
-    }, controller)
-    return new ProviderConnection(ws, () => controller.abort())
-  })
-  conn.addListener(listener)
-  return conn
+) {
+  return retry(() => openWs(url, listener), { maxAttempts: 10 })
 }
 
-function ensureWsOpen(ws: WebSocket): Promise<undefined | Event> {
-  if (ws.readyState === WebSocket.OPEN) {
-    return Promise.resolve(undefined)
-  } else if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
-    return Promise.resolve(new Event("error"))
-  } else {
-    return new Promise<undefined | Event>((resolve) => {
-      const controller = new AbortController()
-      ws.addEventListener("open", () => {
-        controller.abort()
-        resolve(undefined)
-      }, controller)
-      ws.addEventListener("error", (e) => {
-        controller.abort()
-        resolve(e)
-      }, controller)
-    })
+function openWs(
+  url: string,
+  listener: ProviderListener<Event, Event>,
+) {
+  if (activeWs.has(url)) {
+    return Promise.resolve(activeWs.get(url)!)
   }
+  if (connectingWs.has(url)) {
+    return connectingWs.get(url)!
+  }
+
+  const openedWs = new Promise<WebSocket>((resolve, reject) => {
+    const connectingWsController = new AbortController()
+    const ws = new WebSocket(url)
+    ws.addEventListener(
+      "open",
+      () => {
+        connectingWsController.abort()
+        connectingWs.delete(url)
+        activeWs.set(url, ws)
+
+        const activeWsController = new AbortController()
+        ws.addEventListener(
+          "message",
+          (e) => listener(JSON.parse(e.data)),
+          activeWsController,
+        )
+        ws.addEventListener(
+          "error",
+          (e) => {
+            activeWs.delete(url)
+            listener(new ProviderHandlerError(e))
+          },
+          activeWsController,
+        )
+        ws.addEventListener(
+          "close",
+          (e) => {
+            activeWs.delete(url)
+            activeWsController.abort()
+            if (!e.wasClean) {
+              listener(new ProviderHandlerError(e))
+            }
+          },
+          activeWsController,
+        )
+        resolve(ws)
+      },
+      connectingWsController,
+    )
+    ws.addEventListener(
+      "close",
+      (e) => {
+        connectingWsController.abort()
+        connectingWs.delete(url)
+        activeWs.delete(url)
+        reject(e)
+      },
+      connectingWsController,
+    )
+  })
+  connectingWs.set(url, openedWs)
+  return openedWs
 }
 
 function closeWs(socket: WebSocket): Promise<undefined | ProviderCloseError<Event>> {


### PR DESCRIPTION
Add proxy connection retry.
The retry logic uses https://deno.land/std@0.170.0/async/mod.ts?s=retry

How it works?
- apply the retry logic to create an opened `WebSocket`
- if the `WebSocket` gets closed, attached listeners will be sent an error
- the next attempt to get an opened `WebSocket` will apply the retry logic again

There are 2 topics about retries
- connection retries
- call/subscription retry

This PR attempts to solve the 1st bullet by improving the provider.
To solve the call/subscription retry, some knowledge about the inflight message intents (and ids) is needed.
That means that call/subscription retry need to be solved at the client level or above.

Next step
- implement connection retry for `smoldot`