### PR TITLE
chore: update scale dependency to 0.10.0

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -15,9 +15,9 @@ await Promise.all([
         name: "wat-the-crypto",
         version: "^0.0.1",
       },
-      "https://deno.land/x/scale@v0.9.1/mod.ts": {
+      "https://deno.land/x/scale@v0.10.0/mod.ts": {
         name: "scale-codec",
-        version: "^0.9.1",
+        version: "^0.10.0",
       },
       "https://deno.land/x/zones@v0.1.0-beta.13/mod.ts": {
         name: "zones",

--- a/codegen/genCodecs.ts
+++ b/codegen/genCodecs.ts
@@ -27,24 +27,25 @@ import type * as types from "./types/mod.ts"
       return addCodecDecl(
         ty,
         `$.object(${
-          ty.fields.map((x) =>
-            S.array([
-              S.string(normalizeCase(x.name!)),
-              this.visit(x.ty),
-            ])
-          ).join(", ")
+          ty.fields.map((x) => `$.field(${S.string(normalizeCase(x.name!))}, ${this.visit(x.ty)})`)
+            .join(", ")
         })`,
       )
     },
     option(ty, some) {
       return addCodecDecl(ty, `$.option(${this.visit(some)})`)
     },
+
+    //  $.instance(ChainError, $.tuple(this.visit(err)), (x) => x.value),
+
     result(ty, ok, err) {
       return addCodecDecl(
         ty,
         `$.result(${
           this.visit(ok)
-        }, $.instance(C.ChainError<$.Native<typeof $${err.id}>>, ["value", ${this.visit(err)}]))`,
+        }, $.instance(C.ChainError<$.Native<typeof $${err.id}>>, $.tuple(${
+          this.visit(err)
+        }), (x) => x.value))`,
       )
     },
     never(ty) {

--- a/codegen/genCodecs.ts
+++ b/codegen/genCodecs.ts
@@ -37,8 +37,6 @@ import type * as types from "./types/mod.ts"
       return addCodecDecl(ty, `$.option(${this.visit(some)})`)
     },
 
-    //  $.instance(ChainError, $.tuple(this.visit(err)), (x) => x.value),
-
     result(ty, ok, err) {
       return addCodecDecl(
         ty,

--- a/codegen/genCodecs.ts
+++ b/codegen/genCodecs.ts
@@ -35,7 +35,6 @@ import type * as types from "./types/mod.ts"
     option(ty, some) {
       return addCodecDecl(ty, `$.option(${this.visit(some)})`)
     },
-
     result(ty, ok, err) {
       return addCodecDecl(
         ty,
@@ -43,7 +42,7 @@ import type * as types from "./types/mod.ts"
           this.visit(ok)
         }, $.instance(C.ChainError<$.Native<typeof $${err.id}>>, $.tuple(${
           this.visit(err)
-        }), (x) => x.value))`,
+        }), (x) => [x.value]))`,
       )
     },
     never(ty) {

--- a/codegen/genCodecs.ts
+++ b/codegen/genCodecs.ts
@@ -1,4 +1,3 @@
-import { $ } from "../mod.ts"
 import { Ty, TyVisitor } from "../scale_info/mod.ts"
 import { normalizeCase } from "../util/case.ts"
 import { CodegenProps } from "./mod.ts"

--- a/codegen/genCodecs.ts
+++ b/codegen/genCodecs.ts
@@ -1,3 +1,4 @@
+import { $ } from "../mod.ts"
 import { Ty, TyVisitor } from "../scale_info/mod.ts"
 import { normalizeCase } from "../util/case.ts"
 import { CodegenProps } from "./mod.ts"
@@ -78,17 +79,14 @@ import type * as types from "./types/mod.ts"
                 const value = fields.length === 1
                   ? this.visit(fields[0]!.ty)
                   : `$.tuple(${fields.map((f) => this.visit(f.ty)).join(", ")})`
-                props = [S.array([S.string("value"), value])]
+                props = [`$.field(${S.string("value")}, ${value})`]
               } else {
                 // Object variant
-                props = fields.map((field) =>
-                  S.array([
-                    S.string(normalizeCase(field.name!)),
-                    this.visit(field.ty),
-                  ])
-                )
+                props = fields.map((
+                  field,
+                ) => `$.field(${S.string(normalizeCase(field.name!))}, ${this.visit(field.ty)})`)
               }
-              return [`${index}`, S.array([S.string(type), ...props])]
+              return [`${index}`, `$.variant(${S.string(type)}, ${props.join(",")})`]
             }),
           )
         })`,

--- a/deps/scale.ts
+++ b/deps/scale.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/scale@v0.9.1/mod.ts"
+export * from "https://deno.land/x/scale@v0.10.0/mod.ts"

--- a/effects/contracts/events.ts
+++ b/effects/contracts/events.ts
@@ -11,13 +11,15 @@ export function events(inkMetadata: Z.$<InkMetadata>, events: Z.$<ExtrinsicEvent
       $.taggedUnion(
         "type",
         inkMetadata.V3.spec.events
-          .map((e) => [
-            e.label,
-            [
-              "value",
-              $.tuple(...e.args.map((a) => DeriveCodec(inkMetadata.V3.types)(a.type.type))),
-            ],
-          ]),
+          .map((e) =>
+            $.variant(
+              e.label,
+              $.field(
+                "value",
+                $.tuple(...e.args.map((a) => DeriveCodec(inkMetadata.V3.types)(a.type.type))),
+              ),
+            )
+          ),
       )
     )
   return Z.ls(events, $events).next(([events, $events]) =>

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -34,13 +34,13 @@ export interface MapStorageEntryType {
 export type StorageEntryType = PlainStorageEntryType | MapStorageEntryType
 
 export const $storageEntryType: $.Codec<StorageEntryType> = $.taggedUnion("type", [
-  ["Plain", ["value", $tyId]],
-  [
+  $.variant("Plain", $.field("value", $tyId)),
+  $.variant(
     "Map",
-    ["hashers", $.array($hasherKind)],
-    ["key", $tyId],
-    ["value", $tyId],
-  ],
+    $.field("hashers", $.array($hasherKind)),
+    $.field("key", $tyId),
+    $.field("value", $tyId),
+  ),
 ])
 
 export type StorageEntry = {
@@ -50,17 +50,17 @@ export type StorageEntry = {
   docs: string[]
 } & StorageEntryType
 
-export const $storageEntry: $.Codec<StorageEntry> = $.spread(
-  $.spread(
+export const $storageEntry: $.Codec<StorageEntry> = $.object(
+  $.object(
     $.object(
-      ["name", $.str],
-      ["modifier", $storageEntryModifier],
+      $.field("name", $.str),
+      $.field("modifier", $storageEntryModifier),
     ),
     $storageEntryType,
   ),
   $.object(
-    ["default", $.uint8Array],
-    ["docs", $.array($.str)],
+    $.field("default", $.uint8Array),
+    $.field("docs", $.array($.str)),
   ),
 )
 
@@ -69,8 +69,8 @@ export interface Storage {
   entries: StorageEntry[]
 }
 export const $storage: $.Codec<Storage> = $.object(
-  ["prefix", $.str],
-  ["entries", $.array($storageEntry)],
+  $.field("prefix", $.str),
+  $.field("entries", $.array($storageEntry)),
 )
 
 export interface Constant {
@@ -80,29 +80,29 @@ export interface Constant {
   docs: string[]
 }
 export const $constant: $.Codec<Constant> = $.object(
-  ["name", $.str],
-  ["ty", $tyId],
-  ["value", $.uint8Array],
-  ["docs", $.array($.str)],
+  $.field("name", $.str),
+  $.field("ty", $tyId),
+  $.field("value", $.uint8Array),
+  $.field("docs", $.array($.str)),
 )
 
 export interface Pallet {
   name: string
-  storage: Storage | undefined
-  calls: Ty | undefined
-  event: Ty | undefined
+  storage?: Storage
+  calls?: Ty
+  event?: Ty
   constants: Constant[]
-  error: Ty | undefined
+  error?: Ty
   i: number
 }
 export const $pallet: $.Codec<Pallet> = $.object(
-  ["name", $.str],
-  ["storage", $.option($storage)],
-  ["calls", $.option($tyId)],
-  ["event", $.option($tyId)],
-  ["constants", $.array($constant)],
-  ["error", $.option($tyId)],
-  ["i", $.u8],
+  $.field("name", $.str),
+  $.optionalField("storage", $storage),
+  $.optionalField("calls", $tyId),
+  $.optionalField("event", $tyId),
+  $.field("constants", $.array($constant)),
+  $.optionalField("error", $tyId),
+  $.field("i", $.u8),
 )
 
 export interface SignedExtensionMetadata {
@@ -111,9 +111,9 @@ export interface SignedExtensionMetadata {
   additionalSigned: Ty
 }
 export const $signedExtensionMetadata: $.Codec<SignedExtensionMetadata> = $.object(
-  ["ident", $.str],
-  ["ty", $tyId],
-  ["additionalSigned", $tyId],
+  $.field("ident", $.str),
+  $.field("ty", $tyId),
+  $.field("additionalSigned", $tyId),
 )
 
 export interface ExtrinsicDef {
@@ -122,9 +122,9 @@ export interface ExtrinsicDef {
   signedExtensions: SignedExtensionMetadata[]
 }
 export const $extrinsicDef: $.Codec<ExtrinsicDef> = $.object(
-  ["ty", $tyId],
-  ["version", $.u8],
-  ["signedExtensions", $.array($signedExtensionMetadata)],
+  $.field("ty", $tyId),
+  $.field("version", $.u8),
+  $.field("signedExtensions", $.array($signedExtensionMetadata)),
 )
 
 // https://docs.substrate.io/build/application-development/#metadata-system
@@ -138,11 +138,11 @@ export interface Metadata {
   extrinsic: ExtrinsicDef
 }
 export const $metadata: $.Codec<Metadata> = $.object(
-  ["magicNumber", $.constant<typeof magicNumber>(magicNumber, $.u32)],
-  ["version", $.constant<14>(14, $.u8)],
-  ["tys", $tys],
-  ["pallets", $.array($pallet)],
-  ["extrinsic", $extrinsicDef],
+  $.field("magicNumber", $.constant<typeof magicNumber>(magicNumber, $.u32)),
+  $.field("version", $.constant<14>(14, $.u8)),
+  $.field("tys", $tys),
+  $.field("pallets", $.array($pallet)),
+  $.field("extrinsic", $extrinsicDef),
 )
 
 export function fromPrefixedHex(scaleEncoded: string): Metadata {

--- a/ink_metadata/known.ts
+++ b/ink_metadata/known.ts
@@ -7,8 +7,8 @@ export interface Weight {
   proofSize: bigint
 }
 const $weightCodec: $.Codec<Weight> = $.object(
-  ["refTime", $.compact($.u64)],
-  ["proofSize", $.compact($.u64)],
+  $.field("refTime", $.compact($.u64)),
+  $.field("proofSize", $.compact($.u64)),
 )
 
 export type ContractsApiCallArgs = [
@@ -51,29 +51,24 @@ export interface ContractsApiCallResult {
   }
 }
 export const $contractsApiCallResult: $.Codec<ContractsApiCallResult> = $.object(
-  // gas_consumed
-  ["gasConsumed", $weightCodec],
-  // gas_required
-  ["gasRequired", $weightCodec],
-  // storage_deposit
-  [
+  $.field("gasConsumed", $weightCodec),
+  $.field("gasRequired", $weightCodec),
+  $.field(
     "storageDeposit",
     $.taggedUnion("type", [
-      ["Refund", ["value", $balanceCodec]],
-      ["Charge", ["value", $balanceCodec]],
+      $.variant("Refund", $.field("value", $balanceCodec)),
+      $.variant("Charge", $.field("value", $balanceCodec)),
     ]),
-  ],
-  // debug_message
-  ["debugMessage", $.str],
-  // result
-  [
+  ),
+  $.field("debugMessage", $.str),
+  $.field(
     "result",
     $.object(
-      ["flags", $.u32],
+      $.field("flags", $.u32),
       // TODO: improve result error coded
-      ["data", $.result($.uint8Array, $.never)],
+      $.field("data", $.result($.uint8Array, $.never)),
     ),
-  ],
+  ),
 )
 
 export type ContractsApiInstantiateArgs = [
@@ -89,24 +84,17 @@ export type ContractsApiInstantiateArgs = [
   salt: Uint8Array,
 ]
 export const $contractsApiInstantiateArgs: $.Codec<ContractsApiInstantiateArgs> = $.tuple(
-  // origin
   $.sizedUint8Array(32),
-  // balance
   $balanceCodec,
-  // gasLimit
   $.option($weightCodec),
-  // storageDepositLimit
   $.option($balanceCodec),
-  // codeOrHash
   $.taggedUnion("type", [
     // code
-    ["Upload", ["value", $.uint8Array]],
+    $.variant("Upload", $.field("value", $.uint8Array)),
     // hash
-    ["Existing", ["value", $.sizedUint8Array(32)]],
+    $.variant("Existing", $.field("value", $.sizedUint8Array(32))),
   ]),
-  // data
   $.uint8Array,
-  // salt
   $.uint8Array,
 )
 
@@ -130,33 +118,28 @@ export interface ContractsApiInstantiateResult {
   }
 }
 export const $contractsApiInstantiateResult: $.Codec<ContractsApiInstantiateResult> = $.object(
-  // gas_consumed
-  ["gasConsumed", $weightCodec],
-  // gas_required
-  ["gasRequired", $weightCodec],
-  // storage_deposit
-  [
+  $.field("gasConsumed", $weightCodec),
+  $.field("gasRequired", $weightCodec),
+  $.field(
     "storageDeposit",
     $.taggedUnion("type", [
-      ["Refund", ["value", $balanceCodec]],
-      ["Charge", ["value", $balanceCodec]],
+      $.variant("Refund", $.field("value", $balanceCodec)),
+      $.variant("Charge", $.field("value", $balanceCodec)),
     ]),
-  ],
-  // debug_message
-  ["debugMessage", $.str],
-  // result
-  [
+  ),
+  $.field("debugMessage", $.str),
+  $.field(
     "result",
     $.object(
-      [
+      $.field(
         "result",
         $.object(
-          ["flags", $.u32],
+          $.field("flags", $.u32),
           // TODO: improve result error coded
-          ["data", $.result($.uint8Array, $.never)],
+          $.field("data", $.result($.uint8Array, $.never)),
         ),
-      ],
-      ["accountId", $.sizedUint8Array(32)],
+      ),
+      $.field("accountId", $.sizedUint8Array(32)),
     ),
-  ],
+  ),
 )

--- a/primitives/MultiAddress.ts
+++ b/primitives/MultiAddress.ts
@@ -2,11 +2,11 @@ import * as $ from "../deps/scale.ts"
 import { $null } from "../scale_info/Codec.ts"
 
 export const $multiAddress: $.Codec<MultiAddress> = $.taggedUnion("type", {
-  0: ["Id", ["value", $.sizedUint8Array(32)]],
-  1: ["Index", ["value", $null]],
-  2: ["Raw", ["value", $.uint8Array]],
-  3: ["Address32", ["value", $.sizedUint8Array(32)]],
-  4: ["Address20", ["value", $.sizedUint8Array(20)]],
+  0: $.variant("Id", $.field("value", $.sizedUint8Array(32))),
+  1: $.variant("Index", $.field("value", $null)),
+  2: $.variant("Raw", $.field("value", $.uint8Array)),
+  3: $.variant("Address32", $.field("value", $.sizedUint8Array(32))),
+  4: $.variant("Address20", $.field("value", $.sizedUint8Array(20))),
 })
 
 export type MultiAddress =

--- a/primitives/MultiSignature.ts
+++ b/primitives/MultiSignature.ts
@@ -35,7 +35,7 @@ export namespace MultiSignature {
 }
 
 export const $multiSignature: $.Codec<MultiSignature> = $.taggedUnion("type", {
-  0: ["Ed25519", ["value", $.sizedUint8Array(64)]],
-  1: ["Sr25519", ["value", $.sizedUint8Array(64)]],
-  2: ["Ecdsa", ["value", $.sizedUint8Array(65)]],
+  0: $.variant("Ed25519", $.field("value", $.sizedUint8Array(64))),
+  1: $.variant("Sr25519", $.field("value", $.sizedUint8Array(64))),
+  2: $.variant("Ecdsa", $.field("value", $.sizedUint8Array(65))),
 })

--- a/scale_info/Codec.ts
+++ b/scale_info/Codec.ts
@@ -35,7 +35,7 @@ export function DeriveCodec(tys: Ty[]): DeriveCodec {
     result(_ty, ok, err) {
       return $.result(
         this.visit(ok),
-        $.instance(ChainError, $.tuple(this.visit(err)), (x) => x.value),
+        $.instance(ChainError, $.tuple(this.visit(err)), (x) => [x.value]),
       )
     },
     never() {

--- a/scale_info/Codec.ts
+++ b/scale_info/Codec.ts
@@ -26,14 +26,17 @@ export function DeriveCodec(tys: Ty[]): DeriveCodec {
     },
     objectStruct(ty) {
       return $.object(
-        ...ty.fields.map((x): $.AnyField => [normalizeCase(x.name!), this.visit(x.ty)]),
+        ...ty.fields.map((x) => $.field(normalizeCase(x.name!), this.visit(x.ty))),
       )
     },
     option(_ty, some) {
       return $.option(this.visit(some))
     },
     result(_ty, ok, err) {
-      return $.result(this.visit(ok), $.instance(ChainError, ["value", this.visit(err)]))
+      return $.result(
+        this.visit(ok),
+        $.instance(ChainError, $.tuple(this.visit(err)), (x) => x.value),
+      )
     },
     never() {
       return $.never as any
@@ -46,27 +49,24 @@ export function DeriveCodec(tys: Ty[]): DeriveCodec {
       return $.stringUnion(members)
     },
     taggedUnion(ty) {
-      const members: Record<number, $.AnyTaggedUnionMember> = {}
+      const members: Record<number, $.Variant<any, any>> = {}
       for (const { fields, name, index } of ty.members) {
-        let member: $.AnyTaggedUnionMember
+        let member: $.Variant<any, any>
         const type = normalizeCase(name)
         if (fields.length === 0) {
-          member = [type]
+          member = $.variant(type)
         } else if (fields[0]!.name === undefined) {
           // Tuple variant
           const $value = fields.length === 1
             ? this.visit(fields[0]!.ty)
             : $.tuple(...fields.map((f) => this.visit(f.ty)))
-          member = [type, ["value", $value]]
+          member = $.variant(type, $.field("value", $value))
         } else {
           // Object variant
           const memberFields = fields.map((field) => {
-            return [
-              normalizeCase(field.name!),
-              this.visit(field.ty),
-            ] as [string, $.Codec<unknown>]
+            return $.field(normalizeCase(field.name!), this.visit(field.ty))
           })
-          member = [type, ...memberFields]
+          member = $.variant(type, ...memberFields)
         }
         members[index] = member
       }

--- a/scale_info/Ty.ts
+++ b/scale_info/Ty.ts
@@ -42,16 +42,16 @@ export const $tyId: $.Codec<Ty> = $.createCodec({
 })
 
 export interface Field {
-  name: string | undefined
+  name?: string
   ty: Ty
-  typeName: string | undefined
+  typeName?: string
   docs: string[]
 }
 export const $field: $.Codec<Field> = $.object(
-  ["name", $.option($.str)],
-  ["ty", $tyId],
-  ["typeName", $.option($.str)],
-  ["docs", $.array($.str)],
+  $.optionalField("name", $.str),
+  $.field("ty", $tyId),
+  $.optionalField("typeName", $.str),
+  $.field("docs", $.array($.str)),
 )
 
 export type PrimitiveKind = $.Native<typeof $primitiveKind>
@@ -124,57 +124,34 @@ export type TyDef =
   | CompactTyDef
   | BitSequenceTyDef
 export const $tyDef: $.Codec<TyDef> = $.taggedUnion("type", [
-  [
-    "Struct",
-    ["fields", $.array($field)],
-  ],
-  [
+  $.variant("Struct", $.field("fields", $.array($field))),
+  $.variant(
     "Union",
-    [
+    $.field(
       "members",
       $.array($.object(
-        ["name", $.str],
-        ["fields", $.array($field)],
-        ["index", $.u8],
-        ["docs", $.array($.str)],
+        $.field("name", $.str),
+        $.field("fields", $.array($field)),
+        $.field("index", $.u8),
+        $.field("docs", $.array($.str)),
       )),
-    ],
-  ],
-  [
-    "Sequence",
-    ["typeParam", $tyId],
-  ],
-  [
-    "SizedArray",
-    ["len", $.u32],
-    ["typeParam", $tyId],
-  ],
-  [
-    "Tuple",
-    ["fields", $.array($tyId)],
-  ],
-  [
-    "Primitive",
-    ["kind", $primitiveKind],
-  ],
-  [
-    "Compact",
-    ["typeParam", $tyId],
-  ],
-  [
-    "BitSequence",
-    ["bitOrderType", $tyId],
-    ["bitStoreType", $tyId],
-  ],
+    ),
+  ),
+  $.variant("Sequence", $.field("typeParam", $tyId)),
+  $.variant("SizedArray", $.field("len", $.u32), $.field("typeParam", $tyId)),
+  $.variant("Tuple", $.field("fields", $.array($tyId))),
+  $.variant("Primitive", $.field("kind", $primitiveKind)),
+  $.variant("Compact", $.field("typeParam", $tyId)),
+  $.variant("BitSequence", $.field("bitOrderType", $tyId), $.field("bitStoreType", $tyId)),
 ])
 
 export interface Param {
   name: string
-  ty: Ty | undefined
+  ty?: Ty
 }
 export const $param: $.Codec<Param> = $.object(
-  ["name", $.str],
-  ["ty", $.option($tyId)],
+  $.field("name", $.str),
+  $.optionalField("ty", $tyId),
 )
 
 export type Ty = {
@@ -183,16 +160,16 @@ export type Ty = {
   params: Param[]
   docs: string[]
 } & TyDef
-export const $ty: $.Codec<Ty> = $.spread(
-  $.spread(
+export const $ty: $.Codec<Ty> = $.object(
+  $.object(
     $.object(
-      ["id", $.compact($.u32)],
-      ["path", $.array($.str)],
-      ["params", $.array($param)],
+      $.field("id", $.compact($.u32)),
+      $.field("path", $.array($.str)),
+      $.field("params", $.array($param)),
     ),
     $tyDef,
   ),
   $.object(
-    ["docs", $.array($.str)],
+    $.field("docs", $.array($.str)),
   ),
 )

--- a/scale_info/overrides/Era.ts
+++ b/scale_info/overrides/Era.ts
@@ -50,8 +50,8 @@ export const $era: $.Codec<Era> = $.createCodec({
   },
   _assert: $
     .taggedUnion("type", [
-      ["Immortal"],
-      ["Mortal", ["period", $.u64], ["phase", $.u64]],
+      $.variant("Immortal"),
+      $.variant("Mortal", $.field("period", $.u64), $.field("phase", $.u64)),
     ])
     ._assert,
 })

--- a/util/hashers.test.ts
+++ b/util/hashers.test.ts
@@ -27,7 +27,6 @@ const foo: Foo = {
     a: new TextEncoder().encode("hello world"),
     b: [],
     c: Promise.resolve("abc"),
-    d: undefined,
   },
 }
 

--- a/util/hashers.test.ts
+++ b/util/hashers.test.ts
@@ -7,14 +7,14 @@ interface Foo {
   a: Uint8Array
   b: boolean[]
   c: Promise<string>
-  d: Foo | undefined
+  d?: Foo
 }
 
 const $foo: $.Codec<Foo> = $.object(
-  ["a", $.uint8Array],
-  ["b", $.array($.bool)],
-  ["c", $.promise($.str)],
-  ["d", $.option($.deferred(() => $foo))],
+  $.field("a", $.uint8Array),
+  $.field("b", $.array($.bool)),
+  $.field("c", $.promise($.str)),
+  $.optionalField("d", $.deferred(() => $foo)),
 )
 
 const foo: Foo = {


### PR DESCRIPTION
Resolves #497.

One minor downside to this change is that the types can no longer "catch" the optional fields. i.e. if the field is optional and we don't put it in the codec then it wont be caught by the compiler.


