### PR TITLE
chore: misc ss58 cleanup

### DIFF
--- a/effects/extrinsic.ts
+++ b/effects/extrinsic.ts
@@ -99,7 +99,7 @@ export class SignedExtrinsic<
     const senderSs58 = Z.ls(addrPrefix, this.props.sender).next(([addrPrefix, sender]) => {
       switch (sender.type) {
         case "Id": {
-          return U.ss58.encode(addrPrefix, sender.value)
+          return U.returnThrows<U.ss58.EncodeError>()(() => U.ss58.encode(addrPrefix, sender.value))
         }
         default: {
           unimplemented()
@@ -155,6 +155,7 @@ export function extrinsicsDecoded<Client extends Z.$<rpc.Client>>(client: Client
     )
 }
 
+// TODO: ensure that ss58 encoding failure is represented in `U` of to-be `ExtrinsicRune`
 function $extrinsic<
   Client extends Z.$<rpc.Client> = Z.$<rpc.Client>,
   Rest extends [sign?: Z.$<Signer>] = [sign?: Z.$<Signer>],

--- a/util/error.ts
+++ b/util/error.ts
@@ -6,5 +6,11 @@ export function throwIfError<T>(value: T): Exclude<T, Error> {
 }
 
 export function returnThrows<Throw>() {
-  return <R>(run: () => R) => run() as R | Throw
+  return <R>(run: () => R): R | Throw => {
+    try {
+      return run()
+    } catch (e) {
+      return e as Throw
+    }
+  }
 }

--- a/util/error.ts
+++ b/util/error.ts
@@ -4,3 +4,7 @@ export function throwIfError<T>(value: T): Exclude<T, Error> {
   }
   return value as Exclude<T, Error>
 }
+
+export function returnThrows<Throw>() {
+  return <R>(run: () => R) => run() as R | Throw
+}

--- a/util/ss58.test.ts
+++ b/util/ss58.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertInstanceOf } from "../deps/std/testing/asserts.ts"
+import { returnThrows } from "./error.ts"
 import * as ss58 from "./ss58.ts"
 import { alice } from "./test_pairs.ts"
 
@@ -33,26 +34,37 @@ for (
 
 Deno.test("ss58.encode invalid public key length", () => {
   assertInstanceOf(
-    ss58.encode(0, alice.publicKey.slice(0, 30)),
+    returnThrows<ss58.EncodeError>()(() => ss58.encode(0, alice.publicKey.slice(0, 30))),
     ss58.InvalidPublicKeyLengthError,
   )
 })
 
 Deno.test("ss58.encode invalid network prefix", () => {
-  assertInstanceOf(ss58.encode(46, alice.publicKey, [0]), ss58.InvalidNetworkPrefixError)
+  assertInstanceOf(
+    returnThrows<ss58.EncodeError>()(() => ss58.encode(46, alice.publicKey, [0])),
+    ss58.InvalidNetworkPrefixError,
+  )
 })
 
 Deno.test("ss58.decodeRaw long address", () => {
-  assertInstanceOf(ss58.decodeRaw(new Uint8Array(40)), ss58.InvalidAddressLengthError)
+  assertInstanceOf(
+    returnThrows<ss58.DecodeError>()(() => ss58.decodeRaw(new Uint8Array(40))),
+    ss58.InvalidAddressLengthError,
+  )
 })
 
 Deno.test("ss58.decodeRaw short address", () => {
-  assertInstanceOf(ss58.decodeRaw(new Uint8Array(30)), ss58.InvalidAddressLengthError)
+  assertInstanceOf(
+    returnThrows<ss58.DecodeError>()(() => ss58.decodeRaw(new Uint8Array(30))),
+    ss58.InvalidAddressLengthError,
+  )
 })
 
 Deno.test("ss58.decodeRaw invalid checksum", () => {
   assertInstanceOf(
-    ss58.decodeRaw(Uint8Array.of(0, ...alice.publicKey, 255, 255)),
+    returnThrows<ss58.DecodeError>()(() =>
+      ss58.decodeRaw(Uint8Array.of(0, ...alice.publicKey, 255, 255))
+    ),
     ss58.InvalidAddressChecksumError,
   )
 })

--- a/util/ss58.test.ts
+++ b/util/ss58.test.ts
@@ -1,5 +1,4 @@
-import { assertEquals, assertInstanceOf } from "../deps/std/testing/asserts.ts"
-import { returnThrows } from "./error.ts"
+import { assertEquals, assertThrows } from "../deps/std/testing/asserts.ts"
 import * as ss58 from "./ss58.ts"
 import { alice } from "./test_pairs.ts"
 
@@ -33,38 +32,36 @@ for (
 }
 
 Deno.test("ss58.encode invalid public key length", () => {
-  assertInstanceOf(
-    returnThrows<ss58.EncodeError>()(() => ss58.encode(0, alice.publicKey.slice(0, 30))),
-    ss58.InvalidPublicKeyLengthError,
+  assertThrows(
+    () => ss58.encode(0, alice.publicKey.slice(0, 30)),
+    ss58.InvalidPublicKeyLengthError.prototype.message,
   )
 })
 
 Deno.test("ss58.encode invalid network prefix", () => {
-  assertInstanceOf(
-    returnThrows<ss58.EncodeError>()(() => ss58.encode(46, alice.publicKey, [0])),
-    ss58.InvalidNetworkPrefixError,
+  assertThrows(
+    () => ss58.encode(46, alice.publicKey, [0]),
+    ss58.InvalidNetworkPrefixError.prototype.message,
   )
 })
 
 Deno.test("ss58.decodeRaw long address", () => {
-  assertInstanceOf(
-    returnThrows<ss58.DecodeError>()(() => ss58.decodeRaw(new Uint8Array(40))),
-    ss58.InvalidAddressLengthError,
+  assertThrows(
+    () => ss58.decodeRaw(new Uint8Array(40)),
+    ss58.InvalidAddressLengthError.prototype.message,
   )
 })
 
 Deno.test("ss58.decodeRaw short address", () => {
-  assertInstanceOf(
-    returnThrows<ss58.DecodeError>()(() => ss58.decodeRaw(new Uint8Array(30))),
-    ss58.InvalidAddressLengthError,
+  assertThrows(
+    () => ss58.decodeRaw(new Uint8Array(30)),
+    ss58.InvalidAddressLengthError.prototype.message,
   )
 })
 
 Deno.test("ss58.decodeRaw invalid checksum", () => {
-  assertInstanceOf(
-    returnThrows<ss58.DecodeError>()(() =>
-      ss58.decodeRaw(Uint8Array.of(0, ...alice.publicKey, 255, 255))
-    ),
-    ss58.InvalidAddressChecksumError,
+  assertThrows(
+    () => ss58.decodeRaw(Uint8Array.of(0, ...alice.publicKey, 255, 255)),
+    ss58.InvalidAddressChecksumError.prototype.message,
   )
 })

--- a/util/ss58.test.ts
+++ b/util/ss58.test.ts
@@ -32,36 +32,24 @@ for (
 }
 
 Deno.test("ss58.encode invalid public key length", () => {
-  assertThrows(
-    () => ss58.encode(0, alice.publicKey.slice(0, 30)),
-    ss58.InvalidPublicKeyLengthError.prototype.message,
-  )
+  assertThrows(() => ss58.encode(0, alice.publicKey.slice(0, 30)), ss58.InvalidPublicKeyLengthError)
 })
 
 Deno.test("ss58.encode invalid network prefix", () => {
-  assertThrows(
-    () => ss58.encode(46, alice.publicKey, [0]),
-    ss58.InvalidNetworkPrefixError.prototype.message,
-  )
+  assertThrows(() => ss58.encode(46, alice.publicKey, [0]), ss58.InvalidNetworkPrefixError)
 })
 
 Deno.test("ss58.decodeRaw long address", () => {
-  assertThrows(
-    () => ss58.decodeRaw(new Uint8Array(40)),
-    ss58.InvalidAddressLengthError.prototype.message,
-  )
+  assertThrows(() => ss58.decodeRaw(new Uint8Array(40)), ss58.InvalidAddressLengthError)
 })
 
 Deno.test("ss58.decodeRaw short address", () => {
-  assertThrows(
-    () => ss58.decodeRaw(new Uint8Array(30)),
-    ss58.InvalidAddressLengthError.prototype.message,
-  )
+  assertThrows(() => ss58.decodeRaw(new Uint8Array(30)), ss58.InvalidAddressLengthError)
 })
 
 Deno.test("ss58.decodeRaw invalid checksum", () => {
   assertThrows(
     () => ss58.decodeRaw(Uint8Array.of(0, ...alice.publicKey, 255, 255)),
-    ss58.InvalidAddressChecksumError.prototype.message,
+    ss58.InvalidAddressChecksumError,
   )
 })

--- a/util/ss58.ts
+++ b/util/ss58.ts
@@ -9,11 +9,11 @@ export function encode(
   return base58.encode(encodeRaw(prefix, pubKey, validNetworkPrefixes))
 }
 
-export const encodeRaw = (
+export function encodeRaw(
   prefix: number,
   pubKey: Uint8Array,
   validNetworkPrefixes?: readonly number[],
-): Uint8Array => {
+): Uint8Array {
   const isValidPublicKeyLength = !!VALID_PUBLIC_KEY_LENGTHS[pubKey.length]
 
   if (!isValidPublicKeyLength) {


### PR DESCRIPTION
Previously, errors were returned from this utility. This is not a common pattern (even though we do so in Zones/soon Rune). Figured it should be split out of the raw ss58 utils.