### PR TITLE
chore: cleanup using metadata in runes

### DIFF
--- a/fluent/BlockRune.ts
+++ b/fluent/BlockRune.ts
@@ -1,4 +1,4 @@
-import * as M from "../frame_metadata/mod.ts"
+import { $extrinsic } from "../frame_metadata/mod.ts"
 import { known } from "../rpc/mod.ts"
 import { ArrayRune, Rune } from "../rune/mod.ts"
 import { ValueRune } from "../rune/ValueRune.ts"
@@ -26,19 +26,19 @@ export class BlockRune<out U, out C extends Chain = Chain> extends Rune<known.Si
 
   extrinsics() {
     const metadata = this.client.metadata()
-    const $extrinsic = Rune
+    const $extrinsic_ = Rune
       .rec({
         metadata,
         deriveCodec: metadata.deriveCodec,
         sign: null!,
         prefix: null!,
       })
-      .map(M.$extrinsic)
+      .map($extrinsic)
       .into(CodecRune)
     return this
       .extrinsicsRaw()
       .into(ArrayRune)
-      .mapArray((h) => $extrinsic.decoded(h.map(hex.decode)))
+      .mapArray((h) => $extrinsic_.decoded(h.map(hex.decode)))
   }
 
   events() {

--- a/fluent/ClientRune.ts
+++ b/fluent/ClientRune.ts
@@ -1,5 +1,5 @@
 import * as $ from "../deps/scale.ts"
-import * as M from "../frame_metadata/mod.ts"
+import { fromPrefixedHex } from "../frame_metadata/mod.ts"
 import { Event } from "../primitives/mod.ts"
 import * as rpc from "../rpc/mod.ts"
 import { MetaRune, Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
@@ -35,7 +35,7 @@ export class ClientRune<out U, out C extends Chain = Chain> extends Rune<rpc.Cli
   metadata<X>(...[blockHash]: RunicArgs<X, [blockHash?: HexHash]>) {
     return state
       .getMetadata(this.as(Rune), blockHash)
-      .map(M.fromPrefixedHex)
+      .map(fromPrefixedHex)
       .throws($.ScaleError)
       .into(MetadataRune, this)
   }
@@ -54,7 +54,7 @@ export class ClientRune<out U, out C extends Chain = Chain> extends Rune<rpc.Cli
       .unsafeAs<number>()
   }
 
-  chainVersion = rpcCall<[], string>("system_version")(this.as(Rune))
+  chainVersion = rpcCall<[], string>("system_version")(this.as(ClientRune))
 
   private _asCodegen<C extends Chain>() {
     return this as any as ClientRune<U, C>

--- a/fluent/ConstRune.ts
+++ b/fluent/ConstRune.ts
@@ -1,8 +1,8 @@
-import * as M from "../frame_metadata/mod.ts"
+import { Constant } from "../frame_metadata/mod.ts"
 import { Rune, ValueRune } from "../rune/mod.ts"
 import { PalletRune } from "./PalletRune.ts"
 
-export class ConstRune<out U> extends Rune<M.Constant, U> {
+export class ConstRune<out U> extends Rune<Constant, U> {
   $value
   decoded
 

--- a/fluent/ExtrinsicRune.ts
+++ b/fluent/ExtrinsicRune.ts
@@ -1,4 +1,4 @@
-import * as M from "../frame_metadata/mod.ts"
+import { $call, $extrinsic } from "../frame_metadata/mod.ts"
 import { MultiAddress, Signer } from "../primitives/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import { Era, era } from "../scale_info/mod.ts"
@@ -29,7 +29,7 @@ export class ExtrinsicRune<out U, out C extends Chain = Chain> extends Rune<C["c
     super(_prime)
     const metadata = this.client.metadata()
     this.hash = Rune.rec({ metadata, deriveCodec: metadata.deriveCodec })
-      .map((x) => Blake2_256.$hash(M.$call(x)))
+      .map((x) => Blake2_256.$hash($call(x)))
       .into(CodecRune)
       .encoded(this)
   }
@@ -39,12 +39,12 @@ export class ExtrinsicRune<out U, out C extends Chain = Chain> extends Rune<C["c
     const metadata = this.client.metadata()
     const System = metadata.pallet("System")
     const addrPrefix = System.const("SS58Prefix").decoded.unsafeAs<number>()
-    const $extrinsic = Rune.rec({
+    const $extrinsic_ = Rune.rec({
       metadata,
       deriveCodec: metadata.deriveCodec,
       sign: props.sender.access("sign"),
       prefix: addrPrefix,
-    }).map(M.$extrinsic).into(CodecRune)
+    }).map($extrinsic).into(CodecRune)
     const versions = System.const("Version").decoded.unsafeAs<
       { specVersion: number; transactionVersion: number }
     >().into(ValueRune)
@@ -82,23 +82,23 @@ export class ExtrinsicRune<out U, out C extends Chain = Chain> extends Rune<C["c
       call: this,
       signature,
     })
-    const extrinsic = $extrinsic.encoded(extrinsicProps)
+    const extrinsic = $extrinsic_.encoded(extrinsicProps)
     return extrinsic.into(SignedExtrinsicRune, this.client)
   }
 
   encoded() {
     const metadata = this.client.metadata()
-    const $extrinsic = Rune.rec({
+    const $extrinsic_ = Rune.rec({
       metadata,
       deriveCodec: metadata.deriveCodec,
       sign: null!,
       prefix: null!,
-    }).map(M.$extrinsic).into(CodecRune)
+    }).map($extrinsic).into(CodecRune)
     const $extrinsicProps = Rune.rec({
       protocolVersion: 4,
       call: this,
     })
-    return $extrinsic.encoded($extrinsicProps)
+    return $extrinsic_.encoded($extrinsicProps)
   }
 
   feeEstimate() {

--- a/fluent/MetadataRune.ts
+++ b/fluent/MetadataRune.ts
@@ -1,11 +1,11 @@
-import * as M from "../frame_metadata/mod.ts"
+import { getPallet, Metadata } from "../frame_metadata/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import { DeriveCodec, Ty } from "../scale_info/mod.ts"
 import { Chain, ClientRune } from "./ClientRune.ts"
 import { CodecRune } from "./CodecRune.ts"
 import { PalletRune } from "./PalletRune.ts"
 
-export class MetadataRune<out U, out C extends Chain = Chain> extends Rune<M.Metadata, U> {
+export class MetadataRune<out U, out C extends Chain = Chain> extends Rune<Metadata, U> {
   constructor(_prime: MetadataRune<U>["_prime"], readonly client: ClientRune<U, C>) {
     super(_prime)
   }
@@ -13,9 +13,11 @@ export class MetadataRune<out U, out C extends Chain = Chain> extends Rune<M.Met
   pallet<X>(...[palletName]: RunicArgs<X, [palletName: string]>) {
     return Rune
       .tuple([this.as(Rune), palletName])
-      .map(([metadata, palletName]) => M.getPallet(metadata, palletName))
-      .unhandle(M.PalletNotFoundError)
-      .into(PalletRune, this)
+      .map(([metadata, palletName]) => getPallet(metadata, palletName))
+      .unhandle(undefined)
+      .rehandle(undefined, () => Rune.constant(new PalletNotFoundError()))
+      .unhandle(PalletNotFoundError)
+      .into(PalletRune, this.as(MetadataRune))
   }
 
   deriveCodec = this.into(ValueRune).map((x) => DeriveCodec(x.tys))
@@ -24,3 +26,11 @@ export class MetadataRune<out U, out C extends Chain = Chain> extends Rune<M.Met
     return Rune.tuple([this.deriveCodec, ty]).map(([derive, ty]) => derive(ty)).into(CodecRune)
   }
 }
+
+export class PalletNotFoundError extends Error {
+  override readonly name = "PalletNotFoundError"
+}
+
+// export class TypeNotFoundError extends Error {
+//   override readonly name = "TypeNotFoundError"
+// }

--- a/fluent/PalletRune.ts
+++ b/fluent/PalletRune.ts
@@ -11,8 +11,8 @@ export class PalletRune<out U> extends Rune<Pallet, U> {
 
   storage<X>(...[storageName]: RunicArgs<X, [storageName: string]>) {
     return Rune
-      .tuple([this.as(Rune), storageName])
-      .map(([metadata, palletName]) => getStorage(metadata, palletName))
+      .fn(getStorage)
+      .call(this.as(PalletRune), storageName)
       .unhandle(undefined)
       .rehandle(undefined, () => Rune.constant(new StorageNotFoundError()))
       .unhandle(StorageNotFoundError)
@@ -21,8 +21,8 @@ export class PalletRune<out U> extends Rune<Pallet, U> {
 
   const<X>(...[constName]: RunicArgs<X, [constantName: string]>) {
     return Rune
-      .tuple([this.as(Rune), constName])
-      .map(([metadata, constName]) => getConst(metadata, constName))
+      .fn(getConst)
+      .call(this.as(PalletRune), constName)
       .unhandle(undefined)
       .rehandle(undefined, () => Rune.constant(new ConstNotFoundError()))
       .unhandle(ConstNotFoundError)

--- a/fluent/PalletRune.ts
+++ b/fluent/PalletRune.ts
@@ -1,10 +1,10 @@
-import * as M from "../frame_metadata/mod.ts"
+import { getConst, getStorage, Pallet } from "../frame_metadata/mod.ts"
 import { Rune, RunicArgs } from "../rune/mod.ts"
 import { ConstRune } from "./ConstRune.ts"
 import { MetadataRune } from "./MetadataRune.ts"
 import { StorageRune } from "./StorageRune.ts"
 
-export class PalletRune<out U> extends Rune<M.Pallet, U> {
+export class PalletRune<out U> extends Rune<Pallet, U> {
   constructor(_prime: PalletRune<U>["_prime"], readonly metadata: MetadataRune<U>) {
     super(_prime)
   }
@@ -12,16 +12,28 @@ export class PalletRune<out U> extends Rune<M.Pallet, U> {
   storage<X>(...[storageName]: RunicArgs<X, [storageName: string]>) {
     return Rune
       .tuple([this.as(Rune), storageName])
-      .map(([metadata, palletName]) => M.getStorage(metadata, palletName))
-      .unhandle(M.StorageNotFoundError)
-      .into(StorageRune, this)
+      .map(([metadata, palletName]) => getStorage(metadata, palletName))
+      .unhandle(undefined)
+      .rehandle(undefined, () => Rune.constant(new StorageNotFoundError()))
+      .unhandle(StorageNotFoundError)
+      .into(StorageRune, this.as(PalletRune))
   }
 
   const<X>(...[constName]: RunicArgs<X, [constantName: string]>) {
     return Rune
       .tuple([this.as(Rune), constName])
-      .map(([metadata, constName]) => M.getConst(metadata, constName))
-      .unhandle(M.ConstNotFoundError)
-      .into(ConstRune, this)
+      .map(([metadata, constName]) => getConst(metadata, constName))
+      .unhandle(undefined)
+      .rehandle(undefined, () => Rune.constant(new ConstNotFoundError()))
+      .unhandle(ConstNotFoundError)
+      .into(ConstRune, this.as(PalletRune))
   }
+}
+
+export class StorageNotFoundError extends Error {
+  override readonly name = "StorageNotFoundError"
+}
+
+export class ConstNotFoundError extends Error {
+  override readonly name = "ConstNotFoundError"
 }

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -1,24 +1,27 @@
 import * as $ from "../deps/scale.ts"
-import * as M from "../frame_metadata/mod.ts"
+import { $storageKey, StorageEntry } from "../frame_metadata/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import * as U from "../util/mod.ts"
 import { CodecRune } from "./CodecRune.ts"
 import { PalletRune } from "./PalletRune.ts"
 import { state } from "./rpc_method_runes.ts"
 
-export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<M.StorageEntry, U> {
-  constructor(_prime: StorageRune<K, V, U>["_prime"], readonly pallet: PalletRune<U>) {
-    super(_prime)
-    this.$key = Rune.rec({
-      deriveCodec: this.pallet.metadata.deriveCodec,
-      pallet: this.pallet,
-      storageEntry: this.as(Rune),
-    }).map(M.$storageKey).into(CodecRune)
-    this.$value = this.pallet.metadata.codec(this.into(ValueRune).access("value"))
-  }
-
+export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<StorageEntry, U> {
   $key
   $value
+
+  constructor(_prime: StorageRune<K, V, U>["_prime"], readonly pallet: PalletRune<U>) {
+    super(_prime)
+    this.$key = Rune
+      .rec({
+        deriveCodec: this.pallet.metadata.deriveCodec,
+        pallet: this.pallet,
+        storageEntry: this.as(Rune),
+      })
+      .map($storageKey)
+      .into(CodecRune)
+    this.$value = this.pallet.metadata.codec(this.into(ValueRune).access("value"))
+  }
 
   entryRaw<X>(...[key, blockHash]: RunicArgs<X, [key: K, blockHash?: U.HexHash]>) {
     const storageKey = this.$key.encoded(key).map(U.hex.encode)

--- a/frame_metadata/Key.test.ts
+++ b/frame_metadata/Key.test.ts
@@ -1,27 +1,22 @@
+import * as $ from "../deps/scale.ts"
 import { assertEquals } from "../deps/std/testing/asserts.ts"
 import { DeriveCodec } from "../scale_info/Codec.ts"
-import * as U from "../util/mod.ts"
+import { alice, hex, throwIfUndefined } from "../util/mod.ts"
 import * as downloaded from "./_downloaded/mod.ts"
 import { $storageKey } from "./Key.ts"
-import { getPalletAndEntry } from "./Metadata.ts"
-
-const metadata = downloaded.polkadot
-const deriveCodec = DeriveCodec(metadata.tys)
+import { getPallet, getStorage } from "./Metadata.ts"
 
 Deno.test("System Accounts Key", () => {
-  const systemAccountPalletAndEntry = getPalletAndEntry(metadata, "System", "Account")
-  if (systemAccountPalletAndEntry instanceof Error) throw systemAccountPalletAndEntry
-  const [pallet, storageEntry] = systemAccountPalletAndEntry
-  const $key = $storageKey({ deriveCodec, pallet, storageEntry })
+  const $key = setup("System", "Account")
   const partialKey: unknown[] = []
   assertEquals(
-    U.hex.encode($key.encode(partialKey)),
+    hex.encode($key.encode(partialKey)),
     "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9",
   )
-  const key = [U.alice.publicKey]
+  const key = [alice.publicKey]
   const encoded = $key.encode(key)
   assertEquals(
-    U.hex.encode(encoded),
+    hex.encode(encoded),
     "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
   )
   const decoded = $key.decode(encoded)
@@ -29,12 +24,11 @@ Deno.test("System Accounts Key", () => {
 })
 
 Deno.test("Auction Winning Key", () => {
-  const [pallet, storageEntry] = U.throwIfError(getPalletAndEntry(metadata, "Auctions", "Winning"))
-  const $key = $storageKey({ deriveCodec, pallet, storageEntry })
+  const $key = setup("Auctions", "Winning")
   const key = [5]
   const encoded = $key.encode(key)
   assertEquals(
-    U.hex.encode(encoded),
+    hex.encode(encoded),
     "ca32a41f4b3ed515863dc0a38697f84e4a20667fb1dc58cb22bcadfd9ab7f67c39b9d2792f8bd4c305000000",
   )
   const decoded = $key.decode(encoded)
@@ -42,14 +36,20 @@ Deno.test("Auction Winning Key", () => {
 })
 
 Deno.test("Multisig Multisigs partial storage Key", () => {
-  const [pallet, storageEntry] = U.throwIfError(
-    getPalletAndEntry(metadata, "Multisig", "Multisigs"),
-  )
-  const $key = $storageKey({ deriveCodec, pallet, storageEntry })
-  const key = [U.alice.publicKey]
+  const $key = setup("Multisig", "Multisigs")
+  const key = [alice.publicKey]
   const encoded = $key.encode(key)
   assertEquals(
-    U.hex.encode(encoded),
+    hex.encode(encoded),
     "7474449cca95dc5d0c00e71735a6d17d3cd15a3fd6e04e47bee3922dbfa92c8d518366b5b1bc7c99d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
   )
 })
+
+const metadata = downloaded.polkadot
+const deriveCodec = DeriveCodec(metadata.tys)
+
+function setup(palletName: string, storageName: string): $.Codec<unknown[]> {
+  const pallet = throwIfUndefined(getPallet(metadata, palletName))
+  const storageEntry = throwIfUndefined(getStorage(pallet, storageName))
+  return $storageKey({ deriveCodec, pallet, storageEntry })
+}

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -149,41 +149,31 @@ export function fromPrefixedHex(scaleEncoded: string): Metadata {
   return $metadata.decode(U.hex.decode(scaleEncoded as U.Hex))
 }
 
-export function getPallet(metadata: Metadata, name: string): Pallet | PalletNotFoundError {
-  return metadata.pallets.find((pallet) => pallet.name === name) || new PalletNotFoundError(name)
-}
-export class PalletNotFoundError extends Error {
-  override readonly name = "PalletNotFoundError"
+export function getPallet(metadata: Metadata, name: string): Pallet | undefined {
+  return metadata.pallets.find((pallet) => pallet.name === name)
 }
 
-export function getStorage(pallet: Pallet, name: string): StorageEntry | StorageNotFoundError {
+export function getStorage(pallet: Pallet, name: string): StorageEntry | undefined {
   return pallet.storage?.entries.find((entry) => entry.name === name)
-    || new StorageNotFoundError(name)
-}
-export class StorageNotFoundError extends Error {
-  override readonly name = "StorageNotFoundError"
 }
 
-export function getConst(pallet: Pallet, name: string): Constant | ConstNotFoundError {
+export function getConst(pallet: Pallet, name: string): Constant | undefined {
   return pallet.constants?.find((constant) => constant.name === name)
-    || new ConstNotFoundError(name)
-}
-export class ConstNotFoundError extends Error {
-  override readonly name = "ConstNotFoundError"
 }
 
-export function getPalletAndEntry(
+export function getType(metadata: Metadata, path: string[]): Ty | undefined {
+  return metadata.tys.find((ty) =>
+    ty.path.length === path.length && ty.path.every((val, index) => val === path[index])
+  )
+}
+
+export function getPalletConstruct<M>(
+  getConstruct: (pallet: Pallet, constructName: string) => M,
   metadata: Metadata,
   palletName: string,
-  entryName: string,
-): [Pallet, StorageEntry] | PalletNotFoundError | StorageNotFoundError {
+  constructName: string,
+): M | undefined {
   const pallet = getPallet(metadata, palletName)
-  if (pallet instanceof Error) {
-    return pallet
-  }
-  const entry = getStorage(pallet, entryName)
-  if (entry instanceof Error) {
-    return entry
-  }
-  return [pallet, entry]
+  if (pallet) return getConstruct(pallet, constructName)
+  return
 }

--- a/util/error.ts
+++ b/util/error.ts
@@ -5,6 +5,13 @@ export function throwIfError<T>(value: T): Exclude<T, Error> {
   return value as Exclude<T, Error>
 }
 
+export function throwIfUndefined<T>(value: T): Exclude<T, undefined> {
+  if (value === undefined) {
+    throw new Error()
+  }
+  return value as Exclude<T, undefined>
+}
+
 export function returnThrows<Throw>() {
   return <R>(run: () => R): R | Throw => {
     try {


### PR DESCRIPTION
- We no longer return errors from the metadata-searching utils. Instead, we return `undefined`s and then unhandle/rehandle them into errors within corresponding Runes.
- Remove all `* as M` imports. Instead, we import specifically what is needed.