### PR TITLE
chore: rename `rune.watch` to `rune.iter`

### DIFF
--- a/examples/watch.ts
+++ b/examples/watch.ts
@@ -15,7 +15,7 @@ const root = Rune.rec({
 })
 
 let i = 0
-for await (const values of root.watch()) {
+for await (const values of root.iter()) {
   console.log(values)
   if (++i === 3) break
 }

--- a/rune/Rune.test.ts
+++ b/rune/Rune.test.ts
@@ -38,7 +38,7 @@ const count = Rune.asyncIter(() => iter([1, 2, 3]))
 
 Deno.test("stream", async () => {
   assertEquals(await count.run(), 1)
-  assertEquals(await _collect(count.watch()), [1, 2, 3])
+  assertEquals(await _collect(count.iter()), [1, 2, 3])
   assertEquals(await count.collect().run(), [1, 2, 3])
   assertEquals(await count.map((x) => x + "").collect().run(), ["1", "2", "3"])
 

--- a/rune/Rune.ts
+++ b/rune/Rune.ts
@@ -63,13 +63,13 @@ export class Rune<out T, out U = never> {
   }
 
   async run(batch = new Batch()): Promise<T> {
-    for await (const value of this.watch(batch)) {
+    for await (const value of this.iter(batch)) {
       return value
     }
     throw new Error("Rune did not yield any values")
   }
 
-  async *watch(batch = new Batch()) {
+  async *iter(batch = new Batch()) {
     const abortController = new AbortController()
     const primed = batch.prime(this, abortController.signal)
     let time = 0

--- a/rune/rune.md
+++ b/rune/rune.md
@@ -85,7 +85,7 @@ const ay = a.map((value) => delay(500).then(() => `${value}.y`)) // a0.y, a1.y, 
 const az = Rune.tuple([ax, ay])
 
 const start = Date.now()
-for await (const value of az.watch()) {
+for await (const value of az.iter()) {
   console.log(Date.now() - start, value)
 }
 
@@ -311,7 +311,7 @@ const bc = Rune.tuple([b, c])
 const allTogetherNow = Rune.tuple([ab, bc])
 
 const start = Date.now()
-for await (const value of allTogetherNow.watch()) {
+for await (const value of allTogetherNow.iter()) {
   console.log(Date.now() - start, value)
 }
 


### PR DESCRIPTION
Resolves #579

The name `iter` is more fitting than `watch` bc this method will also be used for getting iterators from non-subscription meta runes (for instance, key page iteration (#567)).