### PR TITLE
feat: `Rune.str`, dbg/log cleanup, transaction sequence example

### DIFF
--- a/examples/transfer_sequence.ts
+++ b/examples/transfer_sequence.ts
@@ -1,0 +1,36 @@
+import { alice, bob, charlie, dave, Rune, RunicArgs, Sr25519, ValueRune } from "capi"
+import { Balances, System } from "westend_dev/mod.ts"
+
+await aliceFree()
+  .log("Alice balance after transfers")
+  .chain(() =>
+    Object
+      .entries({ bob, charlie, dave })
+      .reduce<ValueRune<any, any>>((acc, args) =>
+        acc
+          .chain(() => beforeThenTxThenAfter(...args))
+          .into(ValueRune), Rune.constant(undefined))
+  )
+  .chain(() => aliceFree().log("Alice balance after transfers"))
+  .run()
+
+function aliceFree() {
+  return System.Account.entry([alice.publicKey]).access("data", "free")
+}
+
+function beforeThenTxThenAfter<X>(...args: RunicArgs<X, [name: string, pair: Sr25519]>) {
+  const [name, pair] = RunicArgs.resolve(args)
+  const dest = pair.access("address")
+  const accountKey = Rune.tuple([pair.access("publicKey")])
+  const tx = Balances
+    .transfer({ dest, value: 1000123n })
+    .signed({ sender: alice })
+    .sent()
+    .logStatus(Rune.str`transfer to ${name}:`)
+    .finalized()
+  const free = () => System.Account.entry(accountKey).access("data", "free")
+  return free()
+    .log(Rune.str`${name} balance before transfer:`)
+    .chain(() => tx)
+    .chain(() => free().log(Rune.str`${name} balance after transfer:`))
+}

--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -1,5 +1,5 @@
 import { known } from "../rpc/mod.ts"
-import { MetaRune, Rune, ValueRune } from "../rune/mod.ts"
+import { MetaRune, Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import { BlockRune } from "./BlockRune.ts"
 import { Chain } from "./ClientRune.ts"
 import { SignedExtrinsicRune } from "./SignedExtrinsicRune.ts"
@@ -14,13 +14,16 @@ export class ExtrinsicStatusRune<out U1, out U2, out C extends Chain = Chain>
     super(_prime)
   }
 
-  logStatus(...prefix: unknown[]): ExtrinsicStatusRune<U1, U2, C> {
-    return this.into(ValueRune).map((rune) =>
-      rune.into(ValueRune).map((value) => {
-        console.log(...prefix, value)
-        return value
-      })
-    ).into(ExtrinsicStatusRune, this.extrinsic)
+  logStatus<X>(...prefix: RunicArgs<X, unknown[]>): ExtrinsicStatusRune<U1, U2, C> {
+    return Rune
+      .tuple([this.into(ValueRune), ...prefix])
+      .map(([rune, ...prefix]) =>
+        rune.into(ValueRune).map((value) => {
+          console.log(...prefix, value)
+          return value
+        })
+      )
+      .into(ExtrinsicStatusRune, this.extrinsic)
   }
 
   terminalTransactionStatuses() {

--- a/rune/Rune.ts
+++ b/rune/Rune.ts
@@ -123,6 +123,21 @@ export class Rune<out T, out U = never> {
     })
   }
 
+  static str<X, T extends TemplateStringsArray, R extends unknown[]>(
+    ...args: RunicArgs<X, [T, ...R]>
+  ) {
+    return Rune
+      .tuple(args)
+      .map(([strings, ...values]) =>
+        strings
+          .map((templateString, i) => {
+            const value = values[i]
+            return value !== undefined ? `${templateString}${value}` : templateString
+          })
+          .join("")
+      )
+  }
+
   static captureUnhandled<R extends unknown[], T2, U2>(
     sources: [...R],
     fn: (

--- a/rune/ValueRune.ts
+++ b/rune/ValueRune.ts
@@ -1,5 +1,5 @@
 import { PromiseOr } from "../util/types.ts"
-import { Batch, Run, Rune, Unhandled } from "./Rune.ts"
+import { Batch, Run, Rune, RunicArgs, Unhandled } from "./Rune.ts"
 import { Receipt } from "./Timeline.ts"
 
 type NonIndexSignatureKeys<T> = T extends T ? keyof {
@@ -115,8 +115,15 @@ export class ValueRune<out T, out U = never> extends Rune<T, U> {
     return ValueRune.new(RunSingular, this)
   }
 
-  dbg(...prefix: unknown[]) {
-    return this.map((value) => {
+  dbg<X>(...prefix: RunicArgs<X, unknown[]>) {
+    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
+      console.log(...prefix, value)
+      return value
+    })
+  }
+
+  log<X>(...prefix: RunicArgs<X, unknown[]>) {
+    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
       console.log(...prefix, value)
       return value
     })


### PR DESCRIPTION
**1) `Rune.str`, a tagged template fn for interpolating Runes in a string**

```ts
const name = Rune.constant("Capi")
const message = Rune.str`Hello ${name}!`
```

**2) runified `valueRune.dbg` and `extrinsicStatusRune.logStatus`**

One can now specify a Rune as a prefix

**3) `rune.log`**

A duplicate of `dbg` (for now) –– I suppose we'll change this behavior upon resolution of #517

**4) transaction sequence example**

- log initial Alice balance
- sequentially do the following for Bob, Charlie and Dave
  - log initial balance
  - send funds from Alice to current address
  - log final balance
- log final Alice balance