### PR TITLE
chore: log util cleanup

### DIFF
--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -15,12 +15,15 @@ export class ExtrinsicStatusRune<out U1, out U2, out C extends Chain = Chain>
   }
 
   logStatus(...prefix: unknown[]): ExtrinsicStatusRune<U1, U2, C> {
-    return this.into(ValueRune).map((rune) =>
-      rune.into(ValueRune).map((value) => {
-        console.log(...prefix, value)
-        return value
-      })
-    ).into(ExtrinsicStatusRune, this.extrinsic)
+    return Rune
+      .tuple([this.into(ValueRune), ...prefix])
+      .map(([rune, ...prefix]) =>
+        rune.into(ValueRune).map((value) => {
+          console.log(...prefix, value)
+          return value
+        })
+      )
+      .into(ExtrinsicStatusRune, this.extrinsic)
   }
 
   terminalTransactionStatuses() {

--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -1,5 +1,5 @@
 import { known } from "../rpc/mod.ts"
-import { MetaRune, Rune, ValueRune } from "../rune/mod.ts"
+import { MetaRune, Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import { BlockRune } from "./BlockRune.ts"
 import { Chain } from "./ClientRune.ts"
 import { SignedExtrinsicRune } from "./SignedExtrinsicRune.ts"
@@ -14,10 +14,10 @@ export class ExtrinsicStatusRune<out U1, out U2, out C extends Chain = Chain>
     super(_prime)
   }
 
-  logStatus(...prefix: unknown[]): ExtrinsicStatusRune<U1, U2, C> {
+  logStatus<X>(...prefix: RunicArgs<X, unknown[]>): ExtrinsicStatusRune<U1, U2, C> {
     return Rune
-      .tuple([this.into(ValueRune), ...prefix])
-      .map(([rune, ...prefix]) =>
+      .tuple([this.into(ValueRune), Rune.tuple(prefix).lazy()])
+      .map(([rune, prefix]) =>
         rune.into(ValueRune).map((value) => {
           console.log(...prefix, value)
           return value

--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -15,14 +15,9 @@ export class ExtrinsicStatusRune<out U1, out U2, out C extends Chain = Chain>
   }
 
   logStatus<X>(...prefix: RunicArgs<X, unknown[]>): ExtrinsicStatusRune<U1, U2, C> {
-    return Rune
-      .tuple([this.into(ValueRune), Rune.tuple(prefix).lazy()])
-      .map(([rune, prefix]) =>
-        rune.into(ValueRune).map((value) => {
-          console.log(...prefix, value)
-          return value
-        })
-      )
+    return this
+      .into(ValueRune)
+      .map((rune) => rune.into(ValueRune).log(...prefix))
       .into(ExtrinsicStatusRune, this.extrinsic)
   }
 

--- a/rune/ValueRune.ts
+++ b/rune/ValueRune.ts
@@ -1,5 +1,5 @@
 import { PromiseOr } from "../util/types.ts"
-import { Batch, Run, Rune, Unhandled } from "./Rune.ts"
+import { Batch, Run, Rune, RunicArgs, Unhandled } from "./Rune.ts"
 import { Receipt } from "./Timeline.ts"
 
 type NonIndexSignatureKeys<T> = T extends T ? keyof {
@@ -115,8 +115,15 @@ export class ValueRune<out T, out U = never> extends Rune<T, U> {
     return ValueRune.new(RunSingular, this)
   }
 
-  dbg(...prefix: unknown[]) {
-    return this.map((value) => {
+  dbg<X>(...prefix: RunicArgs<X, unknown[]>) {
+    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
+      console.log(...prefix, value)
+      return value
+    })
+  }
+
+  log<X>(...prefix: RunicArgs<X, unknown[]>) {
+    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
       console.log(...prefix, value)
       return value
     })

--- a/rune/ValueRune.ts
+++ b/rune/ValueRune.ts
@@ -116,17 +116,21 @@ export class ValueRune<out T, out U = never> extends Rune<T, U> {
   }
 
   dbg<X>(...prefix: RunicArgs<X, unknown[]>) {
-    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
-      console.log(...prefix, value)
-      return value
-    })
+    return Rune
+      .tuple([this, Rune.tuple(prefix).lazy()])
+      .map(([value, prefix]) => {
+        console.log(...prefix, value)
+        return value
+      })
   }
 
   log<X>(...prefix: RunicArgs<X, unknown[]>) {
-    return Rune.tuple([this, ...prefix]).map(([value, ...prefix]) => {
-      console.log(...prefix, value)
-      return value
-    })
+    return Rune
+      .tuple([this, Rune.tuple(prefix).lazy()])
+      .map(([value, prefix]) => {
+        console.log(...prefix, value)
+        return value
+      })
   }
 
   chain<T2, U2>(fn: (result: ValueRune<T, never>) => Rune<T2, U2>): ValueRune<T2, U | U2> {


### PR DESCRIPTION
- make the `dbg` method on `ValueRune` accept Runes as prefixs
- make the `logStatus` of `extrinsicStatusRune` accept Runes as prefixes
- add a `log` method on `ValueRune` (currently does same thing as `dbg`, which will be reworked upon resolution of #517)