### PR TITLE
feat: entry page retrieval

### DIFF
--- a/examples/entry_page.ts
+++ b/examples/entry_page.ts
@@ -1,6 +1,6 @@
 import { Uniques } from "statemint/mod.ts"
 
-const collections = Uniques.Class.entryPage(100)
+const collections = Uniques.Class.entryPage(10)
 
 const result = await collections.run()
 

--- a/examples/entry_page.ts
+++ b/examples/entry_page.ts
@@ -1,0 +1,7 @@
+import { Uniques } from "statemint/mod.ts"
+
+const collections = Uniques.Class.entryPage(100)
+
+const result = await collections.run()
+
+console.log(result)

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -52,6 +52,7 @@ export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<
           })
         )
       })
+      .unsafeAs<[[K, V][]]>()
   }
 
   entryRaw<X>(...[key, blockHash]: RunicArgs<X, [key: K, blockHash?: HexHash]>) {

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -44,16 +44,18 @@ export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<
     ]>
   ) {
     return Rune
-      .tuple([this.entryPageRaw(count, partialKey, start, blockHash), this.$key, this.$value])
-      .map(([changeset, $key, $value]) => {
-        return changeset.map(({ changes }) =>
-          changes.map(([k, v]) => {
-            return [$key.decode(hex.decode(k)), v ? $value.decode(hex.decode(v)) : undefined]
-          })
-        )
-      })
-      // TODO: why wrapped within the array? Is this consistently a 1-element tuple?
-      .unsafeAs<[K, V][][]>()
+      .tuple([
+        this.entryPageRaw(count, partialKey, start, blockHash).access(0),
+        this.$key,
+        this.$value,
+      ])
+      .map(([changeset, $key, $value]) =>
+        changeset!.changes.map(([k, v]) => [
+          $key.decode(hex.decode(k)),
+          v ? $value.decode(hex.decode(v)) : undefined,
+        ])
+      )
+      .unsafeAs<[K, V][]>()
   }
 
   entryRaw<X>(...[key, blockHash]: RunicArgs<X, [key: K, blockHash?: HexHash]>) {

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -52,7 +52,8 @@ export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<
           })
         )
       })
-      .unsafeAs<[[K, V][]]>()
+      // TODO: why wrapped within the array? Is this consistently a 1-element tuple?
+      .unsafeAs<[K, V][][]>()
   }
 
   entryRaw<X>(...[key, blockHash]: RunicArgs<X, [key: K, blockHash?: HexHash]>) {


### PR DESCRIPTION
Resolves #643

Allows one to retrieve a list of entries as they do a list of keys.

```ts
import { Uniques } from "statemint/mod.ts"

const collections = Uniques.Class.entryPage(100)

const result = await collections.run()

console.log(result)
```

Will soon be complemented by #567.

> Note: was confused by the name of the result, storage changeset. Doesn't represent a diff after all.