### PR TITLE
fix: process resource cleanup in start task

### DIFF
--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -26,13 +26,13 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot
-          binary-version: v0.9.36
+          binary-version: v0.9.37
           binary-github: https://github.com/paritytech/polkadot
       - name: Setup Cumulus
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot-parachain
-          binary-version: v0.9.360
+          binary-version: v0.9.370
           binary-github: https://github.com/paritytech/cumulus
       - name: Setup Zombienet
         uses: ./.github/actions/setup-binary

--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot
-          binary-version: v0.9.36
+          binary-version: v0.9.37
           binary-github: https://github.com/paritytech/polkadot
       - name: Setup Cumulus
         uses: ./.github/actions/setup-binary
@@ -38,6 +38,6 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: zombienet-linux-x64
-          binary-version: v1.3.30
+          binary-version: v1.3.34
           binary-github: https://github.com/paritytech/zombienet
       - run: deno task star

--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Zombienet
         uses: ./.github/actions/setup-binary
         with:
-          binary-name: zombienet-linux
+          binary-name: zombienet-linux-x64
           binary-version: v1.3.30
           binary-github: https://github.com/paritytech/zombienet
       - run: deno task star

--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -38,6 +38,6 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: zombienet-linux
-          binary-version: v1.3.18
+          binary-version: v1.3.30
           binary-github: https://github.com/paritytech/zombienet
       - run: deno task star

--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -26,13 +26,13 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot
-          binary-version: v0.9.37
+          binary-version: v0.9.36
           binary-github: https://github.com/paritytech/polkadot
       - name: Setup Cumulus
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot-parachain
-          binary-version: v0.9.370
+          binary-version: v0.9.360
           binary-github: https://github.com/paritytech/cumulus
       - name: Setup Zombienet
         uses: ./.github/actions/setup-binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-binary
         with:
           binary-name: polkadot
-          binary-version: v0.9.36
+          binary-version: v0.9.37
           binary-github: https://github.com/paritytech/polkadot
       - name: Setup Cumulus
         uses: ./.github/actions/setup-binary

--- a/_tasks/star.ts
+++ b/_tasks/star.ts
@@ -87,4 +87,14 @@ for (const [file, deps] of entries.slice(1)) {
 
 console.log("Checked successfully")
 
-setTimeout(() => console.log(Deno.resources()), 100)
+setTimeout(async () => {
+  console.log(Deno.resources())
+
+  let p = Deno.run({ cmd: ["ps", "-aux"] })
+  await p.status()
+  p.close()
+
+  p = Deno.run({ cmd: ["ps", "-He"] })
+  await p.status()
+  p.close()
+}, 100)

--- a/_tasks/star.ts
+++ b/_tasks/star.ts
@@ -86,15 +86,3 @@ for (const [file, deps] of entries.slice(1)) {
 }
 
 console.log("Checked successfully")
-
-setTimeout(async () => {
-  console.log(Deno.resources())
-
-  let p = Deno.run({ cmd: ["ps", "-aux"] })
-  await p.status()
-  p.close()
-
-  p = Deno.run({ cmd: ["ps", "-He"] })
-  await p.status()
-  p.close()
-}, 100)

--- a/main.ts
+++ b/main.ts
@@ -79,4 +79,10 @@ async function after() {
     self.addEventListener("unload", () => Deno.exit(status.code))
     controller.abort()
   }
+  if (Deno.env.has("CI")) {
+    console.log(Deno.resources())
+    const p = Deno.run({ cmd: ["ps", "-He"] })
+    await p.status()
+    p.close()
+  }
 }

--- a/main.ts
+++ b/main.ts
@@ -75,10 +75,8 @@ async function after() {
   if (cmd.length) {
     const process = Deno.run({ cmd })
     const status = await process.status()
+    self.addEventListener("unload", () => Deno.exit(status.code))
     process.close()
-    self.addEventListener("unload", () => {
-      Deno.exit(status.code)
-    })
     controller.abort()
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -75,6 +75,7 @@ async function after() {
   if (cmd.length) {
     const process = Deno.run({ cmd })
     const status = await process.status()
+    process.close()
     self.addEventListener("unload", () => Deno.exit(status.code))
     controller.abort()
   }

--- a/main.ts
+++ b/main.ts
@@ -77,16 +77,8 @@ async function after() {
     const status = await process.status()
     process.close()
     self.addEventListener("unload", () => {
-      console.log("unloading....")
-      console.log(Deno.resources())
       Deno.exit(status.code)
     })
     controller.abort()
-  }
-  if (Deno.env.has("CI")) {
-    console.log(Deno.resources())
-    const p = Deno.run({ cmd: ["ps", "-He"] })
-    await p.status()
-    p.close()
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -76,7 +76,11 @@ async function after() {
     const process = Deno.run({ cmd })
     const status = await process.status()
     process.close()
-    self.addEventListener("unload", () => Deno.exit(status.code))
+    self.addEventListener("unload", () => {
+      console.log("unloading....")
+      console.log(Deno.resources())
+      Deno.exit(status.code)
+    })
     controller.abort()
   }
   if (Deno.env.has("CI")) {

--- a/providers/frame/dev.ts
+++ b/providers/frame/dev.ts
@@ -38,7 +38,7 @@ export class PolkadotDevProvider extends FrameProxyProvider {
         stderr: "null",
       })
       this.env.signal.addEventListener("abort", () => {
-        process.kill()
+        process.kill("SIGKILL")
         process.close()
       })
     } catch (_e) {

--- a/providers/frame/dev.ts
+++ b/providers/frame/dev.ts
@@ -34,8 +34,8 @@ export class PolkadotDevProvider extends FrameProxyProvider {
     try {
       const process = Deno.run({
         cmd,
-        stdout: "piped",
-        stderr: "piped",
+        stdout: "null",
+        stderr: "null",
       })
       this.env.signal.addEventListener("abort", () => {
         process.kill()

--- a/providers/frame/dev.ts
+++ b/providers/frame/dev.ts
@@ -38,7 +38,7 @@ export class PolkadotDevProvider extends FrameProxyProvider {
         stderr: "null",
       })
       this.env.signal.addEventListener("abort", () => {
-        process.kill("SIGKILL")
+        process.kill()
         process.close()
       })
     } catch (_e) {

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -98,6 +98,8 @@ export class ZombienetProvider extends FrameProxyProvider {
         closeProcess = () => {}
         process.kill()
         process.close()
+        process.stdout.close()
+        process.stderr.close()
       }
       this.env.signal.addEventListener("abort", async () => {
         closeWatcher()

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -97,7 +97,7 @@ export class ZombienetProvider extends FrameProxyProvider {
       let closeProcess = () => {
         closeProcess = () => {}
         console.log("closing zombienet rid:", process.rid)
-        process.kill("SIGKILL")
+        process.kill("SIGINT")
         process.stdout.close()
         process.stderr.close()
         process.close()

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -97,7 +97,7 @@ export class ZombienetProvider extends FrameProxyProvider {
       let closeProcess = () => {
         closeProcess = () => {}
         console.log("closing zombienet rid:", process.rid)
-        process.kill()
+        process.kill("SIGKILL")
         process.stdout.close()
         process.stderr.close()
         process.close()

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -14,7 +14,7 @@ export interface ZombienetProviderProps {
 
 const defaultZombienetPaths: Record<string, string | undefined> = {
   darwin: "zombienet-macos",
-  linux: "zombienet-linux",
+  linux: "zombienet-linux-x64",
 }
 
 export class ZombienetProvider extends FrameProxyProvider {

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -96,7 +96,6 @@ export class ZombienetProvider extends FrameProxyProvider {
       })
       let closeProcess = () => {
         closeProcess = () => {}
-        console.log("closing zombienet rid:", process.rid)
         process.kill("SIGINT")
         process.stdout.close()
         process.stderr.close()

--- a/providers/frame/zombienet.ts
+++ b/providers/frame/zombienet.ts
@@ -96,10 +96,11 @@ export class ZombienetProvider extends FrameProxyProvider {
       })
       let closeProcess = () => {
         closeProcess = () => {}
+        console.log("closing zombienet rid:", process.rid)
         process.kill()
-        process.close()
         process.stdout.close()
         process.stderr.close()
+        process.close()
       }
       this.env.signal.addEventListener("abort", async () => {
         closeWatcher()


### PR DESCRIPTION
Based on trial and error, it seems that sometimes `zombienet` Deno resources are not properly released.
I haven't been able to identify the root cause.
The `unload` event is not fired in these cases.
```
self.addEventListener("unload", () => Deno.exit(status.code))
```

This PR 
- closes child processes started with `Deno.run`
- closes child processes `piped` file descriptors
- upgrades polkadot, polkadot-parachain and zombienet versions

Note: I've observed that the `star` task sometimes keeps running even after closing fd and processes 

Another theory to explore is that this could be correlated to a recent Deno version upgrade.

This is related to https://github.com/paritytech/capi/pull/625