### PR TITLE
fix: new version of deno throws error relating to import map

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -20,10 +20,6 @@
       "capi": "http://localhost:4646/mod.ts",
       "capi/patterns/": "http://localhost:4646/patterns/",
       "zombienet/": "http://localhost:4646/frame/zombienet/zombienets/"
-    },
-    "http://localhost:4646/": {
-      "http://localhost:4646/": "./",
-      "http://localhost:4646/frame/": "http://localhost:4646/frame/"
     }
   }
 }

--- a/patterns/identity.ts
+++ b/patterns/identity.ts
@@ -40,7 +40,7 @@ export class IdentityInfoTranscoders<A extends Record<string, any>> {
           .resolve(props[key])
           .unhandle(undefined)
           .map(encodeStr)
-          .rehandle(undefined, () => Data.None()),
+          .rehandle(undefined, () => Rune.resolve(Data.None())),
       ])))
       .unsafeAs<Record<typeof REST_KEYS[number], Data>>()
     return Rune


### PR DESCRIPTION
Deno version 1.31.0 was just released. Running examples now results in an error (says that mapping from `http://localhost:4646/` to `./` is illegal). For now, we'll do away with the mapping.