### PR TITLE
feat: `storageRune.size` method + `sizeTree` pattern

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -37,6 +37,9 @@ await Promise.all([
       name: "./patterns/identity",
       path: "./patterns/identity.ts",
     }, {
+      name: "./patterns/size_tree",
+      path: "./patterns/sizeTree.ts",
+    }, {
       name: "./server",
       path: "./server/mod.ts",
     }, {

--- a/examples/size_tree.ts
+++ b/examples/size_tree.ts
@@ -1,0 +1,6 @@
+import { sizeTree } from "capi/patterns/sizeTree.ts"
+import { chain } from "polkadot_dev/mod.ts"
+
+const result = await sizeTree(chain).run()
+
+console.log(result)

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -19,9 +19,13 @@ export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<
     this.$value = this.pallet.metadata.codec(this.into(ValueRune).access("value"))
   }
 
-  size<X>(...[blockHash]: RunicArgs<X, [HexHash?]>) {
+  size<X>(...[partialKey, blockHash]: RunicArgs<X, [partialKey?: unknown[], blockHash?: HexHash]>) {
     return this.pallet.metadata.chain.connection
-      .call("state_getStorageSize", this.$key.encoded([]).map(hex.encode), blockHash)
+      .call(
+        "state_getStorageSize",
+        this.$key.encoded(Rune.resolve(partialKey).map((x) => x ?? [])).map(hex.encode),
+        blockHash,
+      )
       .unhandle(null)
       .rehandle(null, () => Rune.constant(undefined))
   }

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -19,6 +19,13 @@ export class StorageRune<in out K extends unknown[], out V, out U> extends Rune<
     this.$value = this.pallet.metadata.codec(this.into(ValueRune).access("value"))
   }
 
+  size<X>(...[blockHash]: RunicArgs<X, [HexHash?]>) {
+    return this.pallet.metadata.chain.connection
+      .call("state_getStorageSize", this.$key.encoded([]).map(hex.encode), blockHash)
+      .unhandle(null)
+      .rehandle(null, () => Rune.constant(undefined))
+  }
+
   entryPageRaw<X>(
     ...[count, partialKey, start, blockHash]: RunicArgs<X, [
       count: number,

--- a/patterns/sizeTree.ts
+++ b/patterns/sizeTree.ts
@@ -2,7 +2,7 @@ import { Chain, ChainRune, HexHash, MetaRune, Rune, RunicArgs, ValueRune } from 
 
 export function sizeTree<U, C extends Chain, X>(
   chain: ChainRune<U, C>,
-  ...[blockHash]: RunicArgs<X, [HexHash?]>
+  ...[blockHash]: RunicArgs<X, [blockHash?: HexHash]>
 ) {
   const metadata = chain.metadata(blockHash)
   return metadata
@@ -13,7 +13,7 @@ export function sizeTree<U, C extends Chain, X>(
         Rune.rec(Object.fromEntries(
           pallet.storage?.entries.map((entry) => [
             entry.name,
-            metadata.pallet(pallet.name).storage(entry.name).size(blockHash),
+            metadata.pallet(pallet.name).storage(entry.name).size([], blockHash),
           ]) || [],
         )),
       ])))

--- a/patterns/sizeTree.ts
+++ b/patterns/sizeTree.ts
@@ -1,0 +1,23 @@
+import { Chain, ChainRune, HexHash, MetaRune, Rune, RunicArgs, ValueRune } from "../mod.ts"
+
+export function sizeTree<U, C extends Chain, X>(
+  chain: ChainRune<U, C>,
+  ...[blockHash]: RunicArgs<X, [HexHash?]>
+) {
+  const metadata = chain.metadata(blockHash)
+  return metadata
+    .into(ValueRune)
+    .map(({ pallets }) =>
+      Rune.rec(Object.fromEntries(pallets.map((pallet) => [
+        pallet.name,
+        Rune.rec(Object.fromEntries(
+          pallet.storage?.entries.map((entry) => [
+            entry.name,
+            metadata.pallet(pallet.name).storage(entry.name).size(blockHash),
+          ]) || [],
+        )),
+      ])))
+    )
+    .into(MetaRune)
+    .flat()
+}


### PR DESCRIPTION
A pattern for resolving a pallet-indexed lookup of storage-entry-size lookups.

```ts
import { sizeTree } from "capi/patterns/sizeTree.ts"
import { chain } from "polkadot_dev/mod.ts"

const result = await sizeTree(chain).run()
```

In this example `result` evaluates to something along the following lines:

```ts
{
  System: {
    Account: 1040,
    ExtrinsicCount: undefined,
    BlockWeight: 11,
    AllExtrinsicsLen: undefined,
    BlockHash: 32,
    ExtrinsicData: undefined,
    Number: undefined,
    ParentHash: 32,
    Digest: undefined,
    Events: undefined,
    EventCount: undefined,
    EventTopics: undefined,
    LastRuntimeUpgrade: 11,
    UpgradedToU32RefCount: 1,
    UpgradedToTripleRefCount: 1,
    ExecutionPhase: undefined
  },
  // other pallets...
}
```

Will hold off on merging until #655, so that we can ensure this pattern is accessible to NodeJS consumers.

@kianenigma, is this what you had in mind? As I understand it, we could take this a step further by iterating over the keys in storage maps... but that feels marginally wrong (in the same vein as [Shawn's comment here](https://github.com/polkadot-js/api/issues/4959#issuecomment-1159956421)).