### PR TITLE
feat: virtual multisigs

### DIFF
--- a/deps/std/encoding/base64.ts
+++ b/deps/std/encoding/base64.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.177.0/encoding/base64.ts"

--- a/deps/std/encoding/base64.ts
+++ b/deps/std/encoding/base64.ts
@@ -1,1 +1,0 @@
-export * from "https://deno.land/std@0.177.0/encoding/base64.ts"

--- a/examples/multisig_transfer.ts
+++ b/examples/multisig_transfer.ts
@@ -1,8 +1,6 @@
 import { alice, bob, charlie, dave, Rune, ValueRune } from "capi"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { Balances, chain, System } from "polkadot_dev/mod.ts"
-// TODO: utilize type exposed from capi/patterns/MultisigRune.ts (when we enable client env specificity)
-import { MultiAddress } from "polkadot_dev/types/sp_runtime/multiaddress.ts"
 
 const multisig = Rune
   .constant({
@@ -18,7 +16,7 @@ console.log("Dave initial balance:", await System.Account.entry([dave.publicKey]
 await Balances
   .transfer({
     value: 2_000_000_000_000n,
-    dest: MultiAddress.Id(multisig.address),
+    dest: multisig.address,
   })
   .signed({ sender: alice })
   .sent()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,20 +1,23 @@
 import { alice, bob, charlie, dave, MultiAddress, Rune } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"
-import { Balances, chain, System } from "polkadot_dev/mod.ts"
+import { Balances, chain, System, Utility } from "polkadot_dev/mod.ts"
 import { parse } from "../deps/std/flags.ts"
 
 let { state } = parse(Deno.args, { string: ["state"] })
 if (!state) {
-  state = await VirtualMultisigRune.deployment(chain, {
-    founders: [alice.publicKey, bob.publicKey, charlie.publicKey],
-    threshold: 2,
-    deployer: alice,
-  }).hex.run()
+  state = await VirtualMultisigRune
+    .deployment(chain, {
+      founders: [alice.publicKey, bob.publicKey, charlie.publicKey],
+      threshold: 2,
+      deployer: alice,
+    })
+    .hex
+    .run()
 }
 
 console.log(`Virtual multisig state hex: ${state}`)
 
-const vMultisig = VirtualMultisigRune.fromHex(chain, state)
+const vMultisig = VirtualMultisigRune.hydrate(chain, state)
 
 const fundStash = Balances
   .transfer({
@@ -26,53 +29,42 @@ const fundStash = Balances
   .dbgStatus("Fund Stash:")
   .finalized()
 
-const fundBobProxy = vMultisig.fundSenderProxy(bob.publicKey, 20_000_000_000_000n)
-  .signed({ sender: bob })
-  .sent()
-  .dbgStatus("Fund Bob Proxy:")
-  .finalized()
-
-const fundCharlieProxy = vMultisig.fundSenderProxy(charlie.publicKey, 20_000_000_000_000n)
-  .signed({ sender: charlie })
-  .sent()
-  .dbgStatus("Fund Charlie Proxy:")
-  .finalized()
-
 const proposal = Balances.transfer({
   dest: dave.address,
   value: 1_234_000_000_000n,
 })
 
-const bobRatify = vMultisig
-  .ratify(bob.publicKey, proposal)
+const bobTx = Utility
+  .batchAll({
+    // @ts-ignore: fix upon #656
+    calls: Rune.array([
+      vMultisig.fundMemberProxy(bob.publicKey, 20_000_000_000_000n),
+      vMultisig.ratify(bob.publicKey, proposal),
+    ]),
+  })
   .signed({ sender: bob })
   .sent()
-  .dbgStatus("Bob ratify:")
+  .dbgStatus("Bob fund & ratify:")
   .finalized()
 
-const charlieRatify = vMultisig
-  .ratify(charlie.publicKey, proposal)
+const charlieTx = Utility
+  .batchAll({
+    // @ts-ignore: fix upon #656
+    calls: Rune.array([
+      vMultisig.fundMemberProxy(charlie.publicKey, 20_000_000_000_000n),
+      vMultisig.ratify(charlie.publicKey, proposal),
+    ]),
+  })
   .signed({ sender: charlie })
   .sent()
-  .dbgStatus("Charlie ratify:")
+  .dbgStatus("Charlie fund & ratify:")
   .finalized()
 
 await Rune
   .chain(() => vMultisig)
   .chain(() => fundStash)
-  .chain(() => fundBobProxy)
-  .chain(() => fundCharlieProxy)
-  .chain(() =>
-    Rune.tuple([
-      System.Account.entry(Rune.tuple([vMultisig.stash])).dbg("Stash Balance Before"),
-      System.Account.entry([dave.publicKey]).dbg("Dave Balance Before"),
-    ])
-  )
-  .chain(() => bobRatify)
-  .chain(() => charlieRatify)
-  .chain(() =>
-    Rune.tuple([
-      System.Account.entry(Rune.tuple([vMultisig.stash])).dbg("Stash Balance After"),
-      System.Account.entry([dave.publicKey]).dbg("Dave Balance After"),
-    ])
-  ).run()
+  .chain(() => System.Account.entry([dave.publicKey]).dbg("Dave Balance Before:"))
+  .chain(() => bobTx)
+  .chain(() => charlieTx)
+  .chain(() => System.Account.entry([dave.publicKey]).dbg("Dave Balance After:"))
+  .run()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,25 +1,43 @@
-import { alice, bob, charlie, Rune } from "capi"
+import { alice, bob, charlie, dave, Rune } from "capi"
 import { virtualMultisigDeployment } from "capi/patterns/multisig/mod.ts"
-import { chain } from "polkadot_dev/mod.ts"
+import { chain, System } from "polkadot_dev/mod.ts"
+import * as base64 from "../deps/std/encoding/base64.ts"
 
-// const virtualMultisig = Rune
-//   .constant({
-//     members: [alice, bob, charlie]
-//       .map(({ publicKey }) => ({ origin: publicKey })),
-//   })
-
-await virtualMultisigDeployment(chain, {
+const multisig = virtualMultisigDeployment(chain, {
   signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
-  threshold: 3,
-  configurator: alice,
-}).dbg().run()
+  threshold: 2,
+  deployer: alice,
+})
 
-// const newVirtualMultisig = VirtualMultisig.create({
-//   members: [alice, bob, charlie].map(({ publicKey }) => ({ origin: publicKey })),
-//   configurator: alice,
-// })
-// const existingVirtualMultisig = Rune
-//   .constant(new Uint8Array())
-//   .into(VirtualMultisig, chain)
+const multisigState = multisig.hex.map(base64.encode).dbg("Virtual multisig state:")
 
-// existingVirtualMultisig
+const proposal = chain.extrinsic(Rune.rec({
+  type: "Balances",
+  value: Rune.rec({
+    type: "transfer" as const,
+    dest: dave.address,
+    value: 1_234_567_890n,
+  }),
+}))
+
+const bobRatify = multisig
+  .ratify(1, proposal)
+  .signed({ sender: bob })
+  .sent()
+  .dbgStatus("Bob ratify:")
+  .finalized()
+
+const charlieRatify = multisig
+  .ratify(1, proposal)
+  .signed({ sender: charlie })
+  .sent()
+  .dbgStatus("Charlie ratify:")
+  .finalized()
+
+await Rune
+  .chain(() => multisig)
+  .chain(() => multisigState)
+  .chain(() => bobRatify)
+  .chain(() => charlieRatify)
+  .chain(() => System.Account.entry([dave.publicKey]).dbg())
+  .run()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,24 +1,27 @@
 import { alice, bob, charlie, dave, Rune } from "capi"
-import { virtualMultisigDeployment } from "capi/patterns/multisig/mod.ts"
-import { chain, System } from "polkadot_dev/mod.ts"
-import * as base64 from "../deps/std/encoding/base64.ts"
+import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"
+import { Balances, chain, System } from "polkadot_dev/mod.ts"
+import { parse } from "../deps/std/flags.ts"
 
-const vMultisig = virtualMultisigDeployment(chain, {
-  signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
-  threshold: 2,
-  deployer: alice,
+let { stateHex } = parse(Deno.args, { string: ["stateHex"] })
+if (!stateHex) {
+  stateHex = await VirtualMultisigRune
+    .deployment(chain, {
+      signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
+      threshold: 2,
+      deployer: alice,
+    })
+    .hex
+    .run()
+}
+console.log(`Virtual multisig state hex: ${stateHex}`)
+
+const vMultisig = VirtualMultisigRune.fromHex(chain, stateHex)
+
+const proposal = Balances.transfer({
+  dest: dave.address,
+  value: 1_234_567_890n,
 })
-
-const multisigState = vMultisig.hex.map(base64.encode).dbg("Virtual multisig state:")
-
-const proposal = chain.extrinsic(Rune.rec({
-  type: "Balances",
-  value: Rune.rec({
-    type: "transfer" as const,
-    dest: dave.address,
-    value: 1_234_567_890n,
-  }),
-}))
 
 const bobRatify = vMultisig
   .ratify(1, proposal)
@@ -36,7 +39,6 @@ const charlieRatify = vMultisig
 
 await Rune
   .chain(() => vMultisig)
-  .chain(() => multisigState)
   .chain(() => bobRatify)
   .chain(() => charlieRatify)
   .chain(() => System.Account.entry([dave.publicKey]).dbg())

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -29,13 +29,13 @@ const fundStash = Balances
   .dbgStatus("Fund Stash:")
   .finalized()
 
-const fundBobProxy = vMultisig.fundSenderProxy(1, 20_000_000_000_000n)
+const fundBobProxy = vMultisig.fundSenderProxy(bob.publicKey, 20_000_000_000_000n)
   .signed({ sender: bob })
   .sent()
   .dbgStatus("Fund Bob Proxy:")
   .finalized()
 
-const fundCharlieProxy = vMultisig.fundSenderProxy(2, 20_000_000_000_000n)
+const fundCharlieProxy = vMultisig.fundSenderProxy(charlie.publicKey, 20_000_000_000_000n)
   .signed({ sender: charlie })
   .sent()
   .dbgStatus("Fund Charlie Proxy:")
@@ -47,14 +47,14 @@ const proposal = Balances.transfer({
 })
 
 const bobRatify = vMultisig
-  .ratify(1, proposal)
+  .ratify(bob.publicKey, proposal)
   .signed({ sender: bob })
   .sent()
   .dbgStatus("Bob ratify:")
   .finalized()
 
 const charlieRatify = vMultisig
-  .ratify(2, proposal)
+  .ratify(charlie.publicKey, proposal)
   .signed({ sender: charlie })
   .sent()
   .dbgStatus("Charlie ratify:")

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,0 +1,9 @@
+import { alice, bob, charlie } from "capi"
+import { createVirtualMultisig } from "capi/patterns/multisig/mod.ts"
+import { chain } from "polkadot_dev/mod.ts"
+
+await createVirtualMultisig(chain, {
+  members: [alice, bob, charlie].map(({ publicKey }) => ({ origin: publicKey })),
+  threshold: 3,
+  configurator: alice,
+}).run()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -3,21 +3,18 @@ import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"
 import { Balances, chain, System } from "polkadot_dev/mod.ts"
 import { parse } from "../deps/std/flags.ts"
 
-let { stateHex } = parse(Deno.args, { string: ["stateHex"] })
-if (!stateHex) {
-  stateHex = await VirtualMultisigRune
-    .deployment(chain, {
-      signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
-      threshold: 2,
-      deployer: alice,
-    })
-    .hex
-    .run()
+let { state } = parse(Deno.args, { string: ["state"] })
+if (!state) {
+  state = await VirtualMultisigRune.deployment(chain, {
+    founders: [alice.publicKey, bob.publicKey, charlie.publicKey],
+    threshold: 2,
+    deployer: alice,
+  }).hex.run()
 }
 
-console.log(`Virtual multisig state hex: ${stateHex}`)
+console.log(`Virtual multisig state hex: ${state}`)
 
-const vMultisig = VirtualMultisigRune.fromHex(chain, stateHex)
+const vMultisig = VirtualMultisigRune.fromHex(chain, state)
 
 const fundStash = Balances
   .transfer({

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,9 +1,25 @@
-import { alice, bob, charlie } from "capi"
-import { createVirtualMultisig } from "capi/patterns/multisig/mod.ts"
+import { alice, bob, charlie, Rune } from "capi"
+import { virtualMultisigDeployment } from "capi/patterns/multisig/mod.ts"
 import { chain } from "polkadot_dev/mod.ts"
 
-await createVirtualMultisig(chain, {
-  members: [alice, bob, charlie].map(({ publicKey }) => ({ origin: publicKey })),
+// const virtualMultisig = Rune
+//   .constant({
+//     members: [alice, bob, charlie]
+//       .map(({ publicKey }) => ({ origin: publicKey })),
+//   })
+
+await virtualMultisigDeployment(chain, {
+  signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
   threshold: 3,
   configurator: alice,
-}).run()
+}).dbg().run()
+
+// const newVirtualMultisig = VirtualMultisig.create({
+//   members: [alice, bob, charlie].map(({ publicKey }) => ({ origin: publicKey })),
+//   configurator: alice,
+// })
+// const existingVirtualMultisig = Rune
+//   .constant(new Uint8Array())
+//   .into(VirtualMultisig, chain)
+
+// existingVirtualMultisig

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -19,10 +19,12 @@ console.log(`Virtual multisig state hex: ${stateHex}`)
 
 const vMultisig = VirtualMultisigRune.fromHex(chain, stateHex)
 
-const fundStash = Balances.transfer({
-  dest: vMultisig.stash.map(MultiAddress.Id),
-  value: 20_000_000_000_000n,
-}).signed({ sender: alice })
+const fundStash = Balances
+  .transfer({
+    dest: vMultisig.stash.map(MultiAddress.Id),
+    value: 20_000_000_000_000n,
+  })
+  .signed({ sender: alice })
   .sent()
   .dbgStatus("Fund Stash:")
   .finalized()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -4,11 +4,7 @@ import { chain, System } from "polkadot_dev/mod.ts"
 import * as base64 from "../deps/std/encoding/base64.ts"
 
 const vMultisig = virtualMultisigDeployment(chain, {
-  signatories: [
-    alice.publicKey,
-    bob.publicKey,
-    charlie.publicKey,
-  ],
+  signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
   threshold: 2,
   deployer: alice,
 })

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -63,11 +63,17 @@ await Rune
   .chain(() => fundStash)
   .chain(() => fundBobProxy)
   .chain(() => fundCharlieProxy)
+  .chain(() =>
+    Rune.tuple([
+      System.Account.entry(Rune.tuple([vMultisig.stash])).dbg("Stash Balance Before"),
+      System.Account.entry([dave.publicKey]).dbg("Dave Balance Before"),
+    ])
+  )
   .chain(() => bobRatify)
   .chain(() => charlieRatify)
   .chain(() =>
     Rune.tuple([
-      System.Account.entry(Rune.tuple([vMultisig.stash])).dbg("Stash Balance"),
-      System.Account.entry([dave.publicKey]).dbg("Dave Balance"),
+      System.Account.entry(Rune.tuple([vMultisig.stash])).dbg("Stash Balance After"),
+      System.Account.entry([dave.publicKey]).dbg("Dave Balance After"),
     ])
   ).run()

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -3,13 +3,17 @@ import { virtualMultisigDeployment } from "capi/patterns/multisig/mod.ts"
 import { chain, System } from "polkadot_dev/mod.ts"
 import * as base64 from "../deps/std/encoding/base64.ts"
 
-const multisig = virtualMultisigDeployment(chain, {
-  signatories: [alice.publicKey, bob.publicKey, charlie.publicKey],
+const vMultisig = virtualMultisigDeployment(chain, {
+  signatories: [
+    alice.publicKey,
+    bob.publicKey,
+    charlie.publicKey,
+  ],
   threshold: 2,
   deployer: alice,
 })
 
-const multisigState = multisig.hex.map(base64.encode).dbg("Virtual multisig state:")
+const multisigState = vMultisig.hex.map(base64.encode).dbg("Virtual multisig state:")
 
 const proposal = chain.extrinsic(Rune.rec({
   type: "Balances",
@@ -20,14 +24,14 @@ const proposal = chain.extrinsic(Rune.rec({
   }),
 }))
 
-const bobRatify = multisig
+const bobRatify = vMultisig
   .ratify(1, proposal)
   .signed({ sender: bob })
   .sent()
   .dbgStatus("Bob ratify:")
   .finalized()
 
-const charlieRatify = multisig
+const charlieRatify = vMultisig
   .ratify(1, proposal)
   .signed({ sender: charlie })
   .sent()
@@ -35,7 +39,7 @@ const charlieRatify = multisig
   .finalized()
 
 await Rune
-  .chain(() => multisig)
+  .chain(() => vMultisig)
   .chain(() => multisigState)
   .chain(() => bobRatify)
   .chain(() => charlieRatify)

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -27,18 +27,18 @@ export interface Multisig {
 
 // TODO: swap out `Chain` constraints upon subset gen issue resolution... same for other patterns
 export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multisig, U> {
-  threshold = this.into(ValueRune).access("threshold")
-  address = this.into(ValueRune).map(({ signatories, threshold }) =>
-    multisigAccountId(signatories, threshold)
-  )
-
-  private pallet
   private storage
+  threshold
+  accountId
 
   constructor(_prime: MultisigRune<U>["_prime"], readonly chain: ChainRune<U, C>) {
     super(_prime)
-    this.pallet = this.chain.metadata().pallet("Multisig")
-    this.storage = this.pallet.storage("Multisigs")
+    this.storage = this.chain.metadata().pallet("Multisig").storage("Multisigs")
+    const v = this.into(ValueRune)
+    this.threshold = v.access("threshold")
+    this.accountId = v.map(({ signatories, threshold }) =>
+      multisigAccountId(signatories, threshold)
+    )
   }
 
   otherSignatories<X>(...[sender]: RunicArgs<X, [sender: MultiAddress]>) {
@@ -122,15 +122,15 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
   }
 
   proposals<X>(...[count]: RunicArgs<X, [count: number]>) {
-    return this.storage.keyPage(count, Rune.tuple([this.address]))
+    return this.storage.keyPage(count, Rune.tuple([this.accountId]))
   }
 
   proposal<X>(...[callHash]: RunicArgs<X, [callHash: Uint8Array]>) {
-    return this.storage.entry(Rune.tuple([this.address, callHash]))
+    return this.storage.entry(Rune.tuple([this.accountId, callHash]))
   }
 
   isProposed<X>(...[callHash]: RunicArgs<X, [callHash: Uint8Array]>) {
-    return this.storage.entryRaw(Rune.tuple([this.address, callHash]))
+    return this.storage.entryRaw(Rune.tuple([this.accountId, callHash]))
       .map((entry) => entry !== null)
   }
 }

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -21,8 +21,8 @@ export interface MultisigVoteProps {
 }
 
 export interface Multisig {
-  signatories: Uint8Array[] // TODO: make this optional
-  threshold: number
+  signatories: Uint8Array[]
+  threshold?: number
 }
 
 // TODO: swap out `Chain` constraints upon subset gen issue resolution... same for other patterns
@@ -36,10 +36,10 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
     super(_prime)
     this.storage = this.chain.metadata().pallet("Multisig").storage("Multisigs")
     const v = this.into(ValueRune)
-    this.threshold = v.access("threshold")
-    this.accountId = v.map(({ signatories, threshold }) =>
-      multisigAccountId(signatories, threshold)
-    )
+    this.threshold = v.map(({ threshold, signatories }) => threshold ?? signatories.length)
+    this.accountId = Rune.tuple([v.access("signatories"), this.threshold]).map((
+      [signatories, threshold],
+    ) => multisigAccountId(signatories, threshold))
     this.address = this.accountId.map(MultiAddress.Id)
   }
 

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -21,7 +21,7 @@ export interface MultisigVoteProps {
 }
 
 export interface Multisig {
-  signatories: Uint8Array[]
+  signatories: Uint8Array[] // TODO: make this optional
   threshold: number
 }
 
@@ -30,6 +30,7 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
   private storage
   threshold
   accountId
+  address
 
   constructor(_prime: MultisigRune<U>["_prime"], readonly chain: ChainRune<U, C>) {
     super(_prime)
@@ -39,6 +40,7 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
     this.accountId = v.map(({ signatories, threshold }) =>
       multisigAccountId(signatories, threshold)
     )
+    this.address = this.accountId.map(MultiAddress.Id)
   }
 
   otherSignatories<X>(...[sender]: RunicArgs<X, [sender: MultiAddress]>) {

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -37,7 +37,7 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
     this.storage = this.chain.metadata().pallet("Multisig").storage("Multisigs")
     const v = this.into(ValueRune)
     this.threshold = v.map(({ threshold, signatories }) => threshold ?? signatories.length)
-    this.accountId = Rune.tuple([v.access("signatories"), this.threshold]).map((
+    this.accountId = Rune.fn(multisigAccountId).call(v.access("signatories"), this.threshold)
       [signatories, threshold],
     ) => multisigAccountId(signatories, threshold))
     this.address = this.accountId.map(MultiAddress.Id)

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -38,8 +38,6 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
     const v = this.into(ValueRune)
     this.threshold = v.map(({ threshold, signatories }) => threshold ?? signatories.length)
     this.accountId = Rune.fn(multisigAccountId).call(v.access("signatories"), this.threshold)
-      [signatories, threshold],
-    ) => multisigAccountId(signatories, threshold))
     this.address = this.accountId.map(MultiAddress.Id)
   }
 

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -36,7 +36,7 @@ export class MultisigRune<out U, out C extends Chain = Chain> extends Rune<Multi
     super(_prime)
     this.storage = this.chain.metadata().pallet("Multisig").storage("Multisigs")
     const v = this.into(ValueRune)
-    this.threshold = v.map(({ threshold, signatories }) => threshold ?? signatories.length)
+    this.threshold = v.map(({ threshold, signatories }) => threshold ?? signatories.length - 1)
     this.accountId = Rune.fn(multisigAccountId).call(v.access("signatories"), this.threshold)
     this.address = this.accountId.map(MultiAddress.Id)
   }

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -19,9 +19,9 @@ import { Multisig, MultisigRune } from "./MultisigRune.ts"
 export interface VirtualMultisig extends Multisig {
   stash: Uint8Array
 }
-export const $virtualMultisig = $.object(
+export const $virtualMultisig: $.Codec<VirtualMultisig> = $.object(
   $.field("signatories", $.array($.sizedUint8Array(32))),
-  $.field("threshold", $.option($.u8)),
+  $.optionalField("threshold", $.u8),
   $.field("stash", $.sizedUint8Array(32)),
 )
 

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -118,7 +118,7 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
       .signed({ sender: configurator })
       .sent()
       .dbgStatus("Proxy creation:")
-      .txEvents()
+      .finalizedEvents()
       .pipe(filterPureCreatedEvents)
       .map((events) =>
         events

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -21,7 +21,7 @@ export interface VirtualMultisig extends Multisig {
 }
 export const $virtualMultisig = $.object(
   $.field("signatories", $.array($.sizedUint8Array(32))),
-  $.field("threshold", $.u8),
+  $.field("threshold", $.option($.u8)),
   $.field("stash", $.sizedUint8Array(32)),
 )
 

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -1,0 +1,172 @@
+import { type Event as ProxyEvent } from "polkadot_dev/types/pallet_proxy/pallet.ts"
+import { type RuntimeEvent } from "polkadot_dev/types/polkadot_runtime.ts"
+import {
+  ChainRune,
+  Event,
+  ExtrinsicSender,
+  MetaRune,
+  MultiAddress,
+  Rune,
+  RunicArgs,
+  ValueRune,
+} from "../../mod.ts"
+import { replaceDelegateCalls } from "../proxy/mod.ts"
+import { MultisigRune } from "./MultisigRune.ts"
+
+export interface CreateVirtualMultisigProps {
+  members: {
+    origin: Uint8Array
+    deposit?: bigint
+  }[]
+  deposit?: bigint
+  threshold?: number
+  configurator: ExtrinsicSender // TODO: use DI
+}
+
+export function createVirtualMultisig<U, X>(
+  chain: ChainRune<U, any>,
+  props: RunicArgs<X, CreateVirtualMultisigProps>,
+) {
+  const defaultDeposit = chain.metadata().pallet("Balances").const("ExistentialDeposit").decoded
+    .unsafeAs<bigint>().into(ValueRune).map((e) => e + 1_000_000_000n)
+  const members = Rune.resolve(props.members)
+  const configurator = Rune.resolve(props.configurator)
+  const membersCount = members.map((members) => members.length)
+  const proxyCreationCalls = membersCount.map((n) =>
+    Rune.array(Array.from({ length: n + 1 }, (_, index) =>
+      chain.extrinsic({
+        type: "Proxy",
+        value: {
+          type: "createPure",
+          proxyType: "Any",
+          delay: 0,
+          index,
+        },
+      })))
+  ).into(MetaRune).flat()
+  const proxies = chain
+    .extrinsic(Rune.rec({
+      type: "Utility",
+      value: Rune.rec({
+        type: "batchAll",
+        calls: proxyCreationCalls,
+      }),
+    }))
+    .signed({ sender: configurator })
+    .sent()
+    .dbgStatus("Proxy creation:")
+    .txEvents()
+    .pipe(filterPureCreatedEvents)
+    .map((events) =>
+      events
+        .sort((a, b) => a.disambiguationIndex > b.disambiguationIndex ? 1 : -1)
+        .map(({ pure }) => pure)
+    )
+
+  const proxiesGrouped = Rune
+    .tuple([proxies, membersCount])
+    .map(([proxies, membersCount]) =>
+      [proxies.slice(0, membersCount), proxies[membersCount]] as [Uint8Array[], Uint8Array]
+    )
+  const memberProxies = proxiesGrouped.access(0)
+  const stashProxy = proxiesGrouped.access(1)
+  const memberProxyExistentialDepositCalls = Rune
+    .tuple([props.members, memberProxies, defaultDeposit])
+    .map(([members, memberProxies, defaultDeposit]) =>
+      Rune.array(memberProxies.map((memberProxy, i) =>
+        chain.extrinsic({
+          type: "Balances",
+          value: {
+            type: "transfer",
+            dest: MultiAddress.Id(memberProxy),
+            value: members[i]!.deposit ?? defaultDeposit,
+          },
+        })
+      ))
+    )
+    .into(MetaRune)
+    .flat()
+  const multisig = Rune
+    .rec({
+      signatories: memberProxies,
+      threshold: Rune
+        .resolve(props.threshold)
+        .unhandle(undefined)
+        .rehandle(undefined, () => membersCount),
+    })
+    .into(MultisigRune, chain)
+  const multisigExistentialDepositCall = chain.extrinsic(Rune.rec({
+    type: "Balances",
+    value: Rune.rec({
+      type: "transfer",
+      dest: multisig.accountId.map(MultiAddress.Id),
+      value: Rune
+        .tuple([props.deposit, defaultDeposit])
+        .map(([deposit, defaultDeposit]) => deposit ?? defaultDeposit),
+    }),
+  }))
+  const existentialDepositCalls = Rune
+    .tuple([memberProxyExistentialDepositCalls, multisigExistentialDepositCall])
+    .map(([m, s]) => [...m, s])
+  const existentialDeposits = chain
+    .extrinsic(Rune.rec({
+      type: "Utility",
+      value: Rune.rec({
+        type: "batchAll",
+        calls: existentialDepositCalls,
+      }),
+    }))
+    .signed({ sender: configurator })
+    .sent()
+    .dbgStatus("Existential deposits:")
+    .finalized()
+
+  const ownershipSwapCalls = Rune
+    .tuple([configurator, members, memberProxies, stashProxy, multisig.accountId])
+    .map(([configurator, members, memberProxies, stashProxy, multisigAccountId]) =>
+      Rune.array([
+        ...replaceDelegateCalls(
+          chain,
+          MultiAddress.Id(stashProxy),
+          configurator.address,
+          MultiAddress.Id(multisigAccountId),
+        ),
+        ...memberProxies.flatMap((proxy, i) =>
+          replaceDelegateCalls(
+            chain,
+            MultiAddress.Id(proxy),
+            configurator.address,
+            MultiAddress.Id(members[i]!.origin),
+          )
+        ),
+      ])
+    )
+    .into(MetaRune)
+    .flat()
+  const ownershipSwaps = chain
+    .extrinsic(Rune.rec({
+      type: "Utility",
+      value: Rune.rec({
+        type: "batchAll",
+        calls: ownershipSwapCalls,
+      }),
+    }))
+    .signed({ sender: configurator })
+    .sent()
+    .dbgStatus("Ownership swaps:")
+    .finalized()
+
+  return proxies
+    .chain(() => existentialDeposits)
+    .chain(() => ownershipSwaps)
+}
+
+export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [Event[]]>) {
+  return Rune.resolve(events).map((events) =>
+    events
+      .map((e) => e.event)
+      .filter((event): event is RuntimeEvent.Proxy => event.type === "Proxy")
+      .map((e) => e.value)
+      .filter((event): event is ProxyEvent.PureCreated => event.type === "PureCreated")
+  )
+}

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -44,15 +44,14 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
     this.proxies = v.access("signatoriesMap")
       .map((arr) => arr.map((a, i) => [hex.encode(a[0]), i] as const))
       .map((a) => Object.fromEntries(a))
+
+    this.inner = Rune.rec({
+      signatories: v.access("signatoriesMap").map((arr) => arr.map((a) => a[1])),
+      threshold: v.access("threshold"),
+    }).into(MultisigRune, chain)
+
     this.encoded = v.map((m) => $virtualMultisig.encode(m))
     this.hex = this.encoded.map(hex.encode)
-
-    const signatories = v.access("signatoriesMap").map((arr) => arr.map((a) => a[1]))
-    const threshold = v.access("threshold")
-    this.inner = Rune.rec({
-      signatories: signatories,
-      threshold: threshold,
-    }).into(MultisigRune, chain)
   }
 
   proxyBySenderAddr<X>(...[senderAddr]: RunicArgs<X, [Uint8Array]>) {

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -72,158 +72,165 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
       }),
     }) as Chain.Call<C>)
   }
-}
 
-export interface NewVirtualMultisigProps extends Multisig {
-  deployer: ExtrinsicSender
-  deposits?: bigint
-}
+  static fromHex<U, X>(chain: ChainRune<U, any>, ...[hexStr]: RunicArgs<X, [string]>) {
+    return Rune
+      .resolve(hexStr)
+      .map((s) => $virtualMultisig.decode(hex.decode(s)))
+      .into(VirtualMultisigRune, chain)
+  }
 
-export function virtualMultisigDeployment<U, X>(
-  chain: ChainRune<U, any>,
-  props: RunicArgs<X, NewVirtualMultisigProps>,
-) {
-  const { threshold } = props
-  const deposits = Rune
-    .resolve(props.deposits)
-    .unhandle(undefined)
-    .rehandle(
-      undefined,
-      () => chain.metadata().pallet("Balances").const("ExistentialDeposit").decoded,
-    )
-  const members = Rune.resolve(props.signatories)
-  const configurator = Rune.resolve(props.deployer)
-  const membersCount = members.map((members) => members.length)
-  const proxyCreationCalls = membersCount.map((n) =>
-    Rune.array(Array.from({ length: n + 1 }, (_, index) =>
-      chain.extrinsic({
-        type: "Proxy",
-        value: {
-          type: "createPure",
-          proxyType: "Any",
-          delay: 0,
-          index,
-        },
-      })))
-  ).into(MetaRune).flat()
-  const proxies = chain
-    .extrinsic(Rune.rec({
-      type: "Utility",
-      value: Rune.rec({
-        type: "batchAll",
-        calls: proxyCreationCalls,
-      }),
-    }))
-    .signed({ sender: configurator })
-    .sent()
-    .dbgStatus("Proxy creation:")
-    .txEvents()
-    .pipe(filterPureCreatedEvents)
-    .map((events) =>
-      events
-        .sort((a, b) => a.disambiguationIndex > b.disambiguationIndex ? 1 : -1)
-        .map(({ pure }) => pure)
-    )
-
-  const proxiesGrouped = Rune
-    .tuple([proxies, membersCount])
-    .map(([proxies, membersCount]) =>
-      [proxies.slice(0, membersCount), proxies[membersCount]] as [Uint8Array[], Uint8Array]
-    )
-  const memberProxies = proxiesGrouped.access(0)
-  const stashProxy = proxiesGrouped.access(1)
-  const memberProxyExistentialDepositCalls = Rune
-    .tuple([deposits, memberProxies])
-    .map(([value, memberProxies]) =>
-      Rune.array(memberProxies.map((memberProxy) =>
+  static deployment<U, X>(
+    chain: ChainRune<U, any>,
+    props: RunicArgs<X, VirtualMultisigDeploymentProps>,
+  ) {
+    const { threshold } = props
+    const deposits = Rune
+      .resolve(props.deposits)
+      .unhandle(undefined)
+      .rehandle(
+        undefined,
+        () => chain.metadata().pallet("Balances").const("ExistentialDeposit").decoded,
+      )
+    const members = Rune.resolve(props.signatories)
+    const configurator = Rune.resolve(props.deployer)
+    const membersCount = members.map((members) => members.length)
+    const proxyCreationCalls = membersCount.map((n) =>
+      Rune.array(Array.from({ length: n + 1 }, (_, index) =>
         chain.extrinsic({
-          type: "Balances",
+          type: "Proxy",
           value: {
-            type: "transfer",
-            dest: MultiAddress.Id(memberProxy),
-            value,
+            type: "createPure",
+            proxyType: "Any",
+            delay: 0,
+            index,
           },
-        })
-      ))
-    )
-    .into(MetaRune)
-    .flat()
-  const multisig = Rune
-    .rec({
-      signatories: memberProxies,
-      threshold,
-    })
-    .into(MultisigRune, chain)
-  const multisigExistentialDepositCall = chain.extrinsic(Rune.rec({
-    type: "Balances",
-    value: Rune.rec({
-      type: "transfer",
-      dest: multisig.accountId.map(MultiAddress.Id),
-      value: deposits,
-    }),
-  }))
-  const existentialDepositCalls = Rune
-    .tuple([memberProxyExistentialDepositCalls, multisigExistentialDepositCall])
-    .map(([m, s]) => [...m, s])
-  const existentialDeposits = chain
-    .extrinsic(Rune.rec({
-      type: "Utility",
-      value: Rune.rec({
-        type: "batchAll",
-        calls: existentialDepositCalls,
-      }),
-    }))
-    .signed({ sender: configurator })
-    .sent()
-    .dbgStatus("Existential deposits:")
-    .finalized()
+        })))
+    ).into(MetaRune).flat()
+    const proxies = chain
+      .extrinsic(Rune.rec({
+        type: "Utility",
+        value: Rune.rec({
+          type: "batchAll",
+          calls: proxyCreationCalls,
+        }),
+      }))
+      .signed({ sender: configurator })
+      .sent()
+      .dbgStatus("Proxy creation:")
+      .txEvents()
+      .pipe(filterPureCreatedEvents)
+      .map((events) =>
+        events
+          .sort((a, b) => a.disambiguationIndex > b.disambiguationIndex ? 1 : -1)
+          .map(({ pure }) => pure)
+      )
 
-  const ownershipSwapCalls = Rune
-    .tuple([configurator, members, memberProxies, stashProxy, multisig.address])
-    .map(([configurator, members, memberProxies, stashProxy, multisigAddress]) =>
-      Rune.array([
-        ...replaceDelegateCalls(
-          chain,
-          MultiAddress.Id(stashProxy),
-          configurator.address,
-          multisigAddress,
-        ),
-        ...memberProxies.flatMap((proxy, i) =>
-          replaceDelegateCalls(
-            chain,
-            MultiAddress.Id(proxy),
-            configurator.address,
-            MultiAddress.Id(members[i]!),
-          )
-        ),
-      ])
-    )
-    .into(MetaRune)
-    .flat()
-  const ownershipSwaps = chain
-    .extrinsic(Rune.rec({
-      type: "Utility",
-      value: Rune.rec({
-        type: "batchAll",
-        calls: ownershipSwapCalls,
-      }),
-    }))
-    .signed({ sender: configurator })
-    .sent()
-    .dbgStatus("Ownership swaps:")
-    .finalized()
-
-  return proxies
-    .chain(() => existentialDeposits)
-    .chain(() => ownershipSwaps)
-    .chain(() =>
-      Rune.rec({
+    const proxiesGrouped = Rune
+      .tuple([proxies, membersCount])
+      .map(([proxies, membersCount]) =>
+        [proxies.slice(0, membersCount), proxies[membersCount]] as [Uint8Array[], Uint8Array]
+      )
+    const memberProxies = proxiesGrouped.access(0)
+    const stashProxy = proxiesGrouped.access(1)
+    const memberProxyExistentialDepositCalls = Rune
+      .tuple([deposits, memberProxies])
+      .map(([value, memberProxies]) =>
+        Rune.array(memberProxies.map((memberProxy) =>
+          chain.extrinsic({
+            type: "Balances",
+            value: {
+              type: "transfer",
+              dest: MultiAddress.Id(memberProxy),
+              value,
+            },
+          })
+        ))
+      )
+      .into(MetaRune)
+      .flat()
+    const multisig = Rune
+      .rec({
         signatories: memberProxies,
         threshold,
-        stash: stashProxy,
       })
-    )
-    .into(VirtualMultisigRune, chain)
+      .into(MultisigRune, chain)
+    const multisigExistentialDepositCall = chain.extrinsic(Rune.rec({
+      type: "Balances",
+      value: Rune.rec({
+        type: "transfer",
+        dest: multisig.accountId.map(MultiAddress.Id),
+        value: deposits,
+      }),
+    }))
+    const existentialDepositCalls = Rune
+      .tuple([memberProxyExistentialDepositCalls, multisigExistentialDepositCall])
+      .map(([m, s]) => [...m, s])
+    const existentialDeposits = chain
+      .extrinsic(Rune.rec({
+        type: "Utility",
+        value: Rune.rec({
+          type: "batchAll",
+          calls: existentialDepositCalls,
+        }),
+      }))
+      .signed({ sender: configurator })
+      .sent()
+      .dbgStatus("Existential deposits:")
+      .finalized()
+
+    const ownershipSwapCalls = Rune
+      .tuple([configurator, members, memberProxies, stashProxy, multisig.address])
+      .map(([configurator, members, memberProxies, stashProxy, multisigAddress]) =>
+        Rune.array([
+          ...replaceDelegateCalls(
+            chain,
+            MultiAddress.Id(stashProxy),
+            configurator.address,
+            multisigAddress,
+          ),
+          ...memberProxies.flatMap((proxy, i) =>
+            replaceDelegateCalls(
+              chain,
+              MultiAddress.Id(proxy),
+              configurator.address,
+              MultiAddress.Id(members[i]!),
+            )
+          ),
+        ])
+      )
+      .into(MetaRune)
+      .flat()
+    const ownershipSwaps = chain
+      .extrinsic(Rune.rec({
+        type: "Utility",
+        value: Rune.rec({
+          type: "batchAll",
+          calls: ownershipSwapCalls,
+        }),
+      }))
+      .signed({ sender: configurator })
+      .sent()
+      .dbgStatus("Ownership swaps:")
+      .finalized()
+
+    return proxies
+      .chain(() => existentialDeposits)
+      .chain(() => ownershipSwaps)
+      .chain(() =>
+        Rune.rec({
+          signatories: memberProxies,
+          threshold,
+          stash: stashProxy,
+        })
+      )
+      .into(VirtualMultisigRune, chain)
+  }
+}
+
+export interface VirtualMultisigDeploymentProps extends Multisig {
+  deployer: ExtrinsicSender
+  deposits?: bigint
 }
 
 export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [Event[]]>) {

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -54,14 +54,16 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
   }
 
   fundSenderProxy<X>(...[senderIndex, amount]: RunicArgs<X, [number, bigint]>) {
-    return Rune.rec({
-      type: "Balances",
-      value: Rune.rec({
-        type: "transfer",
-        dest: this.proxyByIndex(senderIndex),
-        value: amount,
-      }),
-    }).unsafeAs<Chain.Call<C>>()
+    return Rune
+      .rec({
+        type: "Balances",
+        value: Rune.rec({
+          type: "transfer",
+          dest: this.proxyByIndex(senderIndex),
+          value: amount,
+        }),
+      })
+      .unsafeAs<Chain.Call<C>>()
       .into(ExtrinsicRune, this.chain)
   }
 

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -28,7 +28,6 @@ export function createVirtualMultisig<U, X>(
   props: RunicArgs<X, CreateVirtualMultisigProps>,
 ) {
   const defaultDeposit = chain.metadata().pallet("Balances").const("ExistentialDeposit").decoded
-    .unsafeAs<bigint>().into(ValueRune).map((e) => e + 1_000_000_000n)
   const members = Rune.resolve(props.members)
   const configurator = Rune.resolve(props.configurator)
   const membersCount = members.map((members) => members.length)

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -58,7 +58,7 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
       )
   }
 
-  fundSenderProxy<X>(...[senderAddr, amount]: RunicArgs<X, [Uint8Array, bigint]>) {
+  fundMemberProxy<X>(...[senderAddr, amount]: RunicArgs<X, [Uint8Array, bigint]>) {
     return Rune
       .rec({
         type: "Balances",
@@ -102,9 +102,9 @@ export class VirtualMultisigRune<out U, out C extends Chain = Chain>
       .into(ExtrinsicRune, this.chain)
   }
 
-  static fromHex<U, X>(chain: ChainRune<U, any>, ...[hexStr]: RunicArgs<X, [string]>) {
+  static hydrate<U, X>(chain: ChainRune<U, any>, ...[state]: RunicArgs<X, [state: string]>) {
     return Rune
-      .resolve(hexStr)
+      .resolve(state)
       .map((s) => $virtualMultisig.decode(hex.decode(s)))
       .into(VirtualMultisigRune, chain)
   }

--- a/patterns/multisig/mod.ts
+++ b/patterns/multisig/mod.ts
@@ -1,2 +1,3 @@
 export * from "./multisigAccountId.ts"
 export * from "./MultisigRune.ts"
+export * from "./VirtualMultisigRune.ts"

--- a/patterns/proxy/events.ts
+++ b/patterns/proxy/events.ts
@@ -1,0 +1,13 @@
+import { type Event as ProxyEvent } from "polkadot_dev/types/pallet_proxy/pallet.ts"
+import { type RuntimeEvent } from "polkadot_dev/types/polkadot_runtime.ts"
+import { Event, Rune, RunicArgs } from "../../mod.ts"
+
+export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [Event[]]>) {
+  return Rune.resolve(events).map((events) =>
+    events
+      .map((e) => e.event)
+      .filter((event): event is RuntimeEvent.Proxy => event.type === "Proxy")
+      .map((e) => e.value)
+      .filter((event): event is ProxyEvent.PureCreated => event.type === "PureCreated")
+  )
+}

--- a/patterns/proxy/mod.ts
+++ b/patterns/proxy/mod.ts
@@ -1,1 +1,2 @@
+export * from "./events.ts"
 export * from "./replaceDelegateCalls.ts"

--- a/patterns/proxy/mod.ts
+++ b/patterns/proxy/mod.ts
@@ -1,0 +1,1 @@
+export * from "./replaceDelegateCalls.ts"

--- a/patterns/proxy/replaceDelegateCalls.ts
+++ b/patterns/proxy/replaceDelegateCalls.ts
@@ -1,0 +1,43 @@
+import { ChainRune, MultiAddress, Rune, RunicArgs } from "../../mod.ts"
+
+export function replaceDelegateCalls<U, X>(
+  chain: ChainRune<U, any>,
+  ...[real, from, to]: RunicArgs<X, [real: MultiAddress, from: MultiAddress, to: MultiAddress]>
+) {
+  return [
+    chain.extrinsic(Rune.rec({
+      type: "Proxy",
+      value: Rune.rec({
+        type: "proxy",
+        real,
+        forceProxyType: "Any",
+        call: chain.extrinsic(Rune.rec({
+          type: "Proxy",
+          value: Rune.rec({
+            type: "addProxy",
+            proxyType: "Any",
+            delegate: to,
+            delay: 0,
+          }),
+        })),
+      }),
+    })),
+    chain.extrinsic(Rune.rec({
+      type: "Proxy",
+      value: Rune.rec({
+        type: "proxy",
+        real,
+        forceProxyType: "Any",
+        call: chain.extrinsic(Rune.rec({
+          type: "Proxy",
+          value: Rune.rec({
+            type: "removeProxy",
+            proxyType: "Any",
+            delegate: from,
+            delay: 0,
+          }),
+        })),
+      }),
+    })),
+  ]
+}

--- a/patterns/proxy/replaceDelegateCalls.ts
+++ b/patterns/proxy/replaceDelegateCalls.ts
@@ -10,7 +10,7 @@ export function replaceDelegateCalls<U, X>(
       value: Rune.rec({
         type: "proxy",
         real,
-        forceProxyType: "Any",
+        forceProxyType: undefined,
         call: chain.extrinsic(Rune.rec({
           type: "Proxy",
           value: Rune.rec({
@@ -27,7 +27,7 @@ export function replaceDelegateCalls<U, X>(
       value: Rune.rec({
         type: "proxy",
         real,
-        forceProxyType: "Any",
+        forceProxyType: undefined,
         call: chain.extrinsic(Rune.rec({
           type: "Proxy",
           value: Rune.rec({

--- a/words.txt
+++ b/words.txt
@@ -117,6 +117,7 @@ multiasset
 multichain
 multilocation
 multisigs
+multistash
 multistep
 neatcoin
 neer


### PR DESCRIPTION
Closes #658
Closes #555

This PR takes the learnings from #555 and integrates them into a `VirtualMultisigRune`. One can deploy a `VirtualMultisigRune` like so:

```ts
import { alice, bob, charlie, hex } from "capi"
import { VirtualMultisig } from "capi/patterns/multisig/mod.ts"
import { chain } from "polkadot_dev/mod.ts"

const state = await VirtualMultisigRune
  .deployment(chain, {
    founders: [alice.publicKey, bob.publicKey, charlie.publicKey],
    threshold: 2,
    deployer: alice,
  })
  .hex
  .run()

await Deno.writeTextFile("persist_this.txt", state)
```

To hydrate from the state hex, we do the following.

```ts
const vMultisig = VirtualMultisigRune.hydrate(chain, state)
```

To ratify a call from the stash account (signatory -> signatory proxy -> multisig -> stash), we can use virtual multisig's ratify method.

```ts
await vMultisig
  .ratify(bob.publicKey, proposal)
  .signed({ sender: bob })
  .sent()
  .dbgStatus("Bob ratify:")
  .finalized()
  .run()
```

> Note: ensure that you've funded the proxy (as it's initialized with no more than the existential deposit –– `fundMemberProxy`)

Open questions:

- Should `VirtualMultisig` depend on mappings from the member accounts to the proxy accounts? This would allow us to avoid the DX of passing signatory index into the `ratify` method.
- Voting signatories in and out (how might we elegantly persist this data?)
- Validation such as threshold and existing member of vmultisig