### PR TITLE
fix: usage of new `scale-ts` version

### DIFF
--- a/codegen/frame/codecs.ts
+++ b/codegen/frame/codecs.ts
@@ -53,7 +53,7 @@ export function codecs(ctx: FrameCodegen) {
     stringUnion(ty) {
       return addCodecDecl(
         ty,
-        `$.stringUnion(${
+        `$.literalUnion(${
           S.object(
             ...ty.members.map((
               x,

--- a/frame_metadata/Metadata.ts
+++ b/frame_metadata/Metadata.ts
@@ -3,7 +3,7 @@ import { $tyId, $tys, Ty } from "../scale_info/Ty.ts"
 import * as U from "../util/mod.ts"
 
 export type HasherKind = $.Native<typeof $hasherKind>
-const $hasherKind = $.stringUnion([
+const $hasherKind = $.literalUnion([
   "Blake2_128",
   "Blake2_256",
   "Blake2_128Concat",
@@ -14,7 +14,7 @@ const $hasherKind = $.stringUnion([
 ])
 
 export type StorageEntryModifier = $.Native<typeof $storageEntryModifier>
-export const $storageEntryModifier = $.stringUnion([
+export const $storageEntryModifier = $.literalUnion([
   "Optional",
   "Default",
 ])

--- a/providers/frame/dev.ts
+++ b/providers/frame/dev.ts
@@ -53,7 +53,7 @@ export class PolkadotDevProvider extends FrameProxyProvider {
 }
 
 type DevRuntimeName = $.Native<typeof $devRuntimeName>
-const $devRuntimeName = $.stringUnion([
+const $devRuntimeName = $.literalUnion([
   "polkadot",
   "kusama",
   "westend",

--- a/scale_info/Codec.ts
+++ b/scale_info/Codec.ts
@@ -46,7 +46,7 @@ export function DeriveCodec(tys: Ty[]): DeriveCodec {
       for (const { index, name } of ty.members) {
         members[index] = normalizeIdent(name)
       }
-      return $.stringUnion(members)
+      return $.literalUnion(members)
     },
     taggedUnion(ty) {
       const members: Record<number, $.Variant<any, any>> = {}

--- a/scale_info/Ty.ts
+++ b/scale_info/Ty.ts
@@ -55,7 +55,7 @@ export const $field: $.Codec<Field> = $.object(
 )
 
 export type PrimitiveKind = $.Native<typeof $primitiveKind>
-const $primitiveKind = $.stringUnion([
+const $primitiveKind = $.literalUnion([
   "bool",
   "char",
   "str",


### PR DESCRIPTION
Replaces no-longer-valid usage of `scale-ts` `stringUnion` with `literalUnion`.