### PR TITLE
fix: smoldot connection race condition

### DIFF
--- a/rpc/Connection.ts
+++ b/rpc/Connection.ts
@@ -99,9 +99,8 @@ export abstract class Connection {
     if (typeof message.id === "number") {
       this.callResultPendings[message.id]?.resolve(message)
       delete this.callResultPendings[message.id]
-      if (!message.error && this.subscriptionPendingInits[message.id]) {
-        this.subscriptionPendingInits[message.id]!(message.result as string)
-      }
+      const init = this.subscriptionPendingInits[message.id]
+      if (!message.error && init) init(message.result as string)
     } else if (message.params) {
       this.subscriptionHandlers[message.params.subscription]?.(message)
     } else {

--- a/rpc/Connection.ts
+++ b/rpc/Connection.ts
@@ -51,10 +51,14 @@ export abstract class Connection {
 
   protected abstract close(): void
 
-  callResultPendings: Record<number, Deferred<RpcCallMessage>> = {}
   async call(method: string, params: unknown[]) {
-    await this.ready()
     const id = this.nextId++
+    return this.#call(id, method, params)
+  }
+
+  callResultPendings: Record<number, Deferred<RpcCallMessage>> = {}
+  async #call(id: number, method: string, params: unknown[]) {
+    await this.ready()
     const pending = deferred<RpcCallMessage>()
     this.callResultPendings[id] = pending
     this.send(id, method, params)
@@ -62,6 +66,7 @@ export abstract class Connection {
   }
 
   subscriptionHandlers: Record<string, RpcSubscriptionHandler> = {}
+  subscriptionPendingInits: Record<number, (subscriptionId: string) => void> = {}
   async subscription(
     subscribe: string,
     unsubscribe: string,
@@ -69,22 +74,34 @@ export abstract class Connection {
     handler: RpcSubscriptionHandler,
     signal: AbortSignal,
   ) {
-    const message = await this.call(subscribe, params)
-    if (signal.aborted) return
-    if (message.error) return handler(message)
-    const subscriptionId = message.result as string
-    this.subscriptionHandlers[subscriptionId] = handler
-    signal.addEventListener("abort", () => {
-      delete this.subscriptionHandlers[subscriptionId]
-      this.send(this.nextId++, unsubscribe, [subscriptionId])
-    })
+    const id = this.nextId++
+    this.subscriptionPendingInits[id] = (subscriptionId) => {
+      delete this.subscriptionPendingInits[id]
+      if (signal.aborted) return
+      signal.addEventListener("abort", () => {
+        delete this.subscriptionHandlers[subscriptionId]
+        this.send(this.nextId++, unsubscribe, [subscriptionId])
+      })
+      this.subscriptionHandlers[subscriptionId] = handler
+    }
+    const message = await this.#call(id, subscribe, params)
+    if (signal.aborted) {
+      delete this.subscriptionPendingInits[id]
+      return
+    }
+    if (message.error) {
+      delete this.subscriptionPendingInits[id]
+      return handler(message)
+    }
   }
 
   handle(message: RpcIngressMessage) {
-    console.log("handle", { message })
     if (typeof message.id === "number") {
       this.callResultPendings[message.id]?.resolve(message)
       delete this.callResultPendings[message.id]
+      if (!message.error && this.subscriptionPendingInits[message.id]) {
+        this.subscriptionPendingInits[message.id]!(message.result as string)
+      }
     } else if (message.params) {
       this.subscriptionHandlers[message.params.subscription]?.(message)
     } else {

--- a/rpc/Connection.ts
+++ b/rpc/Connection.ts
@@ -81,6 +81,7 @@ export abstract class Connection {
   }
 
   handle(message: RpcIngressMessage) {
+    console.log("handle", { message })
     if (typeof message.id === "number") {
       this.callResultPendings[message.id]?.resolve(message)
       delete this.callResultPendings[message.id]

--- a/rpc/smoldot.test.ts
+++ b/rpc/smoldot.test.ts
@@ -9,75 +9,58 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
   async fn(t) {
-    await t.step({
-      name: "relay chain connection",
-      async fn() {
-        const relayChainSpec = await fetchText(
-          "https://raw.githubusercontent.com/paritytech/substrate-connect/main/packages/connect/src/connector/specs/polkadot.json",
-        )
-        const connection = new SmoldotConnection({
-          relayChainSpec,
-        })
-        await connection.ready()
-        const controller = new AbortController()
-        const pendingMessage = deferred<RpcSubscriptionMessage>()
-        connection.subscription(
-          "chainHead_unstable_follow",
-          "chainHead_unstable_unfollow",
-          [false],
-          (message) => {
-            controller.abort()
-            pendingMessage.resolve(message)
-          },
-          controller.signal,
-        )
-        const message = await pendingMessage
-        assertEquals((await message.params?.result as any).event, "initialized")
-      },
+    await t.step("relay chain connection", async () => {
+      const relayChainSpec = await fetchText(
+        "https://raw.githubusercontent.com/paritytech/substrate-connect/main/packages/connect/src/connector/specs/polkadot.json",
+      )
+      const connection = new SmoldotConnection({ relayChainSpec })
+      await connection.ready()
+      const controller = new AbortController()
+      const pendingMessage = deferred<RpcSubscriptionMessage>()
+      connection.subscription(
+        "chainHead_unstable_follow",
+        "chainHead_unstable_unfollow",
+        [false],
+        (message) => {
+          controller.abort()
+          pendingMessage.resolve(message)
+        },
+        controller.signal,
+      )
+      const message = await pendingMessage
+      assertEquals((await message.params?.result as any).event, "initialized")
     })
 
-    await t.step({
-      name: "parachain connection",
-      async fn() {
-        const relayChainSpec = await fetchText(
-          "https://raw.githubusercontent.com/paritytech/substrate-connect/main/packages/connect/src/connector/specs/westend2.json",
-        )
-        const parachainSpec = await fetchText(
-          "https://raw.githubusercontent.com/paritytech/substrate-connect/main/projects/demo/src/assets/westend-westmint.json",
-        )
-        const connection = new SmoldotConnection({
-          relayChainSpec,
-          parachainSpec,
-        })
-        await connection.ready()
-        const controller = new AbortController()
-        const pendingMessage = deferred<RpcSubscriptionMessage>()
-        connection.subscription(
-          "chainHead_unstable_follow",
-          "chainHead_unstable_unfollow",
-          [false],
-          (message) => {
-            controller.abort()
-            pendingMessage.resolve(message)
-          },
-          controller.signal,
-        )
-        const message = await pendingMessage
-        assertEquals((await message.params?.result as any).event, "initialized")
-      },
+    await t.step("parachain connection", async () => {
+      const relayChainSpec = await fetchText(
+        "https://raw.githubusercontent.com/paritytech/substrate-connect/main/packages/connect/src/connector/specs/westend2.json",
+      )
+      const parachainSpec = await fetchText(
+        "https://raw.githubusercontent.com/paritytech/substrate-connect/main/projects/demo/src/assets/westend-westmint.json",
+      )
+      const connection = new SmoldotConnection({
+        relayChainSpec,
+        parachainSpec,
+      })
+      await connection.ready()
+      const controller = new AbortController()
+      const pendingMessage = deferred<RpcSubscriptionMessage>()
+      connection.subscription(
+        "chainHead_unstable_follow",
+        "chainHead_unstable_unfollow",
+        [false],
+        (message) => {
+          controller.abort()
+          pendingMessage.resolve(message)
+        },
+        controller.signal,
+      )
+      const message = await pendingMessage
+      assertEquals((await message.params?.result as any).event, "initialized")
     })
 
-    await t.step({
-      name: "invalid chain spec",
-      fn() {
-        assertRejects(
-          async () =>
-            new SmoldotConnection({
-              relayChainSpec: "",
-            }),
-          AddChainError,
-        )
-      },
+    await t.step("invalid chain spec", async () => {
+      await assertRejects(async () => new SmoldotConnection({ relayChainSpec: "" }), AddChainError)
     })
   },
 })

--- a/rpc/smoldot.test.ts
+++ b/rpc/smoldot.test.ts
@@ -1,0 +1,43 @@
+import { deferred } from "../deps/std/async.ts"
+import { SmoldotConnection } from "./smoldot.ts"
+
+Deno.test({
+  name: "Smoldot",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const relayChainSpec = await fetchText(
+      "https://raw.githubusercontent.com/paritytech/substrate-connect/main/packages/connect/src/connector/specs/polkadot.json",
+    )
+
+    const connection = new SmoldotConnection({
+      relayChainSpec,
+    })
+
+    await connection.ready()
+
+    const controller = new AbortController()
+
+    const pending = deferred()
+
+    connection.subscription(
+      "chainHead_unstable_follow",
+      "chainHead_unstable_unfollow",
+      [false],
+      (message) => {
+        console.log({ message })
+        pending.resolve()
+      },
+      controller.signal,
+    )
+
+    await pending
+    controller.abort()
+
+    // await delay(60 * 1000)
+  },
+})
+
+async function fetchText(url: string) {
+  return (await fetch(url)).text()
+}

--- a/rpc/smoldot.test.ts
+++ b/rpc/smoldot.test.ts
@@ -59,9 +59,18 @@ Deno.test({
       assertEquals((await message.params?.result as any).event, "initialized")
     })
 
-    await t.step("invalid chain spec", async () => {
-      await assertRejects(async () => new SmoldotConnection({ relayChainSpec: "" }), AddChainError)
-    })
+    await t.step(
+      "invalid chain spec",
+      async () => {
+        await assertRejects(
+          async () => {
+            const connection = new SmoldotConnection({ relayChainSpec: "" })
+            return connection.smoldotChainPending
+          },
+          AddChainError,
+        )
+      },
+    )
   },
 })
 


### PR DESCRIPTION
- Fixes subscription handler setup (`Connection.handle` was invoked before the subscription handler was set)
- Add unit test for Smoldot
