### PR TITLE
docs: remove PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Resolves #
-
-- [ ] There is an associated issue (**required**)
-- [ ] The change is described in detail
-- [ ] There are new or updated tests validating the change (if applicable)
-
-## Description


### PR DESCRIPTION
As pointed out by @tjjfvi,––at this point in development––we likely don't need an issue for every PR (especially when they're simple one-off tasks). this can create a fair amount of noise. Most contributors will know that it's good educate to discuss large code changes before making them.