### PR TITLE
chore: update scale; exclude scale from udd

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -52,9 +52,9 @@ await Promise.all([
         name: "wat-the-crypto",
         version: "0.0.1",
       },
-      "https://deno.land/x/scale@v0.11.0-beta.0/mod.ts": {
+      "https://deno.land/x/scale@v0.11.0/mod.ts#=": {
         name: "scale-codec",
-        version: "0.11.0-beta.0",
+        version: "0.11.0",
       },
       "https://deno.land/x/smoldot@light-js-deno-v0.7.6/index-deno.js": {
         name: "@substrate/smoldot-light",

--- a/deps/scale.ts
+++ b/deps/scale.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/scale@v0.11.0-beta.1/mod.ts"
+export * from "https://deno.land/x/scale@v0.11.0/mod.ts#="


### PR DESCRIPTION
Updating scale usually needs more than just bumping the version, and we're typically on top of scale updates anyway.