### PR TITLE
chore: lint examples ignore file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno lint
+      - run: deno run -A _tasks/validate_ignore.ts --dir examples

--- a/examples/.ignore
+++ b/examples/.ignore
@@ -1,4 +1,3 @@
-mod.ts
 multisig_transfer.ts
 ink_e2e/main.ts
 xcm_asset_teleportation.ts


### PR DESCRIPTION
Check the `.ignore` file in the `examples` directory to make sure that it doesn't specify any files that don't exist. 