### PR TITLE
feat: improve ss58 encoding/decoding

### DIFF
--- a/crypto/ss58.test.ts
+++ b/crypto/ss58.test.ts
@@ -31,6 +31,7 @@ for (
     ],
     [
       "substrate 2 byte payload + 2 byte checksum",
+      // cspell:disable-next-line
       "5jrpfEX",
       [42, Uint8Array.from([1, 2]), 2],
     ],
@@ -51,6 +52,7 @@ for (
     ],
     [
       "substrate 4 byte payload + 4 byte checksum",
+      // cspell:disable-next-line
       "Y1aeU7vNADWR",
       [42, Uint8Array.from([1, 2, 3, 4]), 4],
     ],
@@ -66,6 +68,7 @@ for (
     ],
     [
       "substrate 8 byte payload + 3 byte checksum",
+      // cspell:disable-next-line
       "nyUcq3hBw8bqwazt",
       [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 3],
     ],
@@ -86,11 +89,13 @@ for (
     ],
     [
       "substrate 8 byte payload + 7 byte checksum",
+      // cspell:disable-next-line
       "6BqUqhpVKyG11bpoR1cb8R",
       [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 7],
     ],
     [
       "substrate 8 byte payload + 8 byte checksum",
+      // cspell:disable-next-line
       "PtpysyAc2jKD3ehyryi5dkj",
       [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 8],
     ],

--- a/crypto/ss58.test.ts
+++ b/crypto/ss58.test.ts
@@ -107,7 +107,7 @@ for (
   ] as const
 ) {
   Deno.test(`ss58.encode ${networkName}`, () => {
-    const actual = ss58.encode(prefix, payload, { checksumLength })
+    const actual = ss58.encode(prefix, payload, checksumLength)
     assertEquals(actual, address)
   })
   Deno.test(`ss58.decode ${networkName}`, () => {
@@ -118,13 +118,6 @@ for (
 
 Deno.test("ss58.encode invalid payload length", () => {
   assertThrows(() => ss58.encode(0, alice.publicKey.slice(0, 30)), ss58.InvalidPayloadLengthError)
-})
-
-Deno.test("ss58.encode invalid network prefix", () => {
-  assertThrows(
-    () => ss58.encode(46, alice.publicKey, { validNetworkPrefixes: [0] }),
-    ss58.InvalidNetworkPrefixError,
-  )
 })
 
 Deno.test("ss58.decodeRaw long address", () => {

--- a/crypto/ss58.test.ts
+++ b/crypto/ss58.test.ts
@@ -99,6 +99,11 @@ for (
       "PtpysyAc2jKD3ehyryi5dkj",
       [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 8],
     ],
+    [
+      "substrate 33 byte payload",
+      "KVqMLDzVyHChtJ8imRTkP22Tuz8Yd7X9MABUhz1rHNpHny12V",
+      [42, new Uint8Array(33)],
+    ],
   ] as const
 ) {
   Deno.test(`ss58.encode ${networkName}`, () => {

--- a/crypto/ss58.test.ts
+++ b/crypto/ss58.test.ts
@@ -3,7 +3,7 @@ import * as ss58 from "./ss58.ts"
 import { alice } from "./test_pairs.ts"
 
 for (
-  const [networkName, address, [prefix, publicKey]] of [
+  const [networkName, address, [prefix, payload]] of [
     [
       "polkadot",
       "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5",
@@ -19,20 +19,40 @@ for (
       "cLxkfNUiCYsb57YLhTJdNVKxUTB1VTpeygYZNhYuFc83KrFy7",
       [65, alice.publicKey],
     ],
+    [
+      "substrate 1 byte payload",
+      "F7NZ",
+      [42, Uint8Array.from([1])],
+    ],
+    [
+      "substrate 2 byte payload",
+      "25GpW4",
+      [42, Uint8Array.from([1, 2])],
+    ],
+    [
+      "substrate 4 byte payload",
+      "MvAtmUea",
+      [42, Uint8Array.from([1, 2, 3, 4])],
+    ],
+    [
+      "substrate 8 byte payload",
+      "3MsZWNhRvzMGK9",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8])],
+    ],
   ] as const
 ) {
   Deno.test(`ss58.encode ${networkName}`, () => {
-    const actual = ss58.encode(prefix, publicKey)
+    const actual = ss58.encode(prefix, payload)
     assertEquals(actual, address)
   })
   Deno.test(`ss58.decode ${networkName}`, () => {
     const actual = ss58.decode(address)
-    assertEquals(actual, [prefix, publicKey])
+    assertEquals(actual, [prefix, payload])
   })
 }
 
-Deno.test("ss58.encode invalid public key length", () => {
-  assertThrows(() => ss58.encode(0, alice.publicKey.slice(0, 30)), ss58.InvalidPublicKeyLengthError)
+Deno.test("ss58.encode invalid payload length", () => {
+  assertThrows(() => ss58.encode(0, alice.publicKey.slice(0, 30)), ss58.InvalidPayloadLengthError)
 })
 
 Deno.test("ss58.encode invalid network prefix", () => {

--- a/crypto/ss58.test.ts
+++ b/crypto/ss58.test.ts
@@ -3,7 +3,7 @@ import * as ss58 from "./ss58.ts"
 import { alice } from "./test_pairs.ts"
 
 for (
-  const [networkName, address, [prefix, payload]] of [
+  const [networkName, address, [prefix, payload, checksumLength]] of [
     [
       "polkadot",
       "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5",
@@ -30,19 +30,74 @@ for (
       [42, Uint8Array.from([1, 2])],
     ],
     [
+      "substrate 2 byte payload + 2 byte checksum",
+      "5jrpfEX",
+      [42, Uint8Array.from([1, 2]), 2],
+    ],
+    [
       "substrate 4 byte payload",
       "MvAtmUea",
       [42, Uint8Array.from([1, 2, 3, 4])],
+    ],
+    [
+      "substrate 4 byte payload + 2 byte checksum",
+      "2bKgfVK2sN",
+      [42, Uint8Array.from([1, 2, 3, 4]), 2],
+    ],
+    [
+      "substrate 4 byte payload + 3 byte checksum",
+      "82VU4sxbFKh",
+      [42, Uint8Array.from([1, 2, 3, 4]), 3],
+    ],
+    [
+      "substrate 4 byte payload + 4 byte checksum",
+      "Y1aeU7vNADWR",
+      [42, Uint8Array.from([1, 2, 3, 4]), 4],
     ],
     [
       "substrate 8 byte payload",
       "3MsZWNhRvzMGK9",
       [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8])],
     ],
+    [
+      "substrate 8 byte payload + 2 byte checksum",
+      "BR8AUemT3J8Sb7o",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 2],
+    ],
+    [
+      "substrate 8 byte payload + 3 byte checksum",
+      "nyUcq3hBw8bqwazt",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 3],
+    ],
+    [
+      "substrate 8 byte payload + 4 byte checksum",
+      "4VvGu94tPFvYo1w4XE",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 4],
+    ],
+    [
+      "substrate 8 byte payload + 5 byte checksum",
+      "GSe9B8c9oEsML77cYU6",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 5],
+    ],
+    [
+      "substrate 8 byte payload + 6 byte checksum",
+      "2BAAw5ia9q6DEjKzBstZe",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 6],
+    ],
+    [
+      "substrate 8 byte payload + 7 byte checksum",
+      "6BqUqhpVKyG11bpoR1cb8R",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 7],
+    ],
+    [
+      "substrate 8 byte payload + 8 byte checksum",
+      "PtpysyAc2jKD3ehyryi5dkj",
+      [42, Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]), 8],
+    ],
   ] as const
 ) {
   Deno.test(`ss58.encode ${networkName}`, () => {
-    const actual = ss58.encode(prefix, payload)
+    const actual = ss58.encode(prefix, payload, { checksumLength })
     assertEquals(actual, address)
   })
   Deno.test(`ss58.decode ${networkName}`, () => {
@@ -56,7 +111,10 @@ Deno.test("ss58.encode invalid payload length", () => {
 })
 
 Deno.test("ss58.encode invalid network prefix", () => {
-  assertThrows(() => ss58.encode(46, alice.publicKey, [0]), ss58.InvalidNetworkPrefixError)
+  assertThrows(
+    () => ss58.encode(46, alice.publicKey, { validNetworkPrefixes: [0] }),
+    ss58.InvalidNetworkPrefixError,
+  )
 })
 
 Deno.test("ss58.decodeRaw long address", () => {

--- a/crypto/ss58.ts
+++ b/crypto/ss58.ts
@@ -19,10 +19,9 @@ export function encodeRaw(
   payload: Uint8Array,
   props?: EncodeProps,
 ): Uint8Array {
-  const checksumLength = props?.checksumLength ?? VALID_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
+  const checksumLength = props?.checksumLength ?? DEFAULT_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
   if (!checksumLength) throw new InvalidPayloadLengthError()
-  const isValidNetworkPrefix = !props?.validNetworkPrefixes
-    || props.validNetworkPrefixes.includes(prefix)
+  const isValidNetworkPrefix = props?.validNetworkPrefixes?.includes(prefix) ?? true
   if (!isValidNetworkPrefix) throw new InvalidNetworkPrefixError()
   const prefixBytes = prefix < 64
     ? Uint8Array.of(prefix)
@@ -109,7 +108,7 @@ const VALID_ADDRESS_CHECKSUM_LENGTHS: Record<number, number | undefined> = {
   36: 2,
   37: 2,
 }
-const VALID_PAYLOAD_CHECKSUM_LENGTHS: Record<number, number | undefined> = {
+const DEFAULT_PAYLOAD_CHECKSUM_LENGTHS: Record<number, number | undefined> = {
   1: 1,
   2: 1,
   4: 1,

--- a/crypto/ss58.ts
+++ b/crypto/ss58.ts
@@ -1,22 +1,28 @@
 import * as base58 from "../deps/std/encoding/base58.ts"
 import { Blake2b } from "../deps/wat_the_crypto.ts"
 
+export interface EncodeProps {
+  validNetworkPrefixes?: readonly number[]
+  checksumLength?: number
+}
+
 export function encode(
   prefix: number,
   payload: Uint8Array,
-  validNetworkPrefixes?: readonly number[],
+  props?: EncodeProps,
 ): string {
-  return base58.encode(encodeRaw(prefix, payload, validNetworkPrefixes))
+  return base58.encode(encodeRaw(prefix, payload, props))
 }
 
 export function encodeRaw(
   prefix: number,
   payload: Uint8Array,
-  validNetworkPrefixes?: readonly number[],
+  props?: EncodeProps,
 ): Uint8Array {
-  const checksumLength = VALID_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
+  const checksumLength = props?.checksumLength ?? VALID_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
   if (!checksumLength) throw new InvalidPayloadLengthError()
-  const isValidNetworkPrefix = !validNetworkPrefixes || validNetworkPrefixes.includes(prefix)
+  const isValidNetworkPrefix = !props?.validNetworkPrefixes
+    || props.validNetworkPrefixes.includes(prefix)
   if (!isValidNetworkPrefix) throw new InvalidNetworkPrefixError()
   const prefixBytes = prefix < 64
     ? Uint8Array.of(prefix)

--- a/crypto/ss58.ts
+++ b/crypto/ss58.ts
@@ -1,28 +1,21 @@
 import * as base58 from "../deps/std/encoding/base58.ts"
 import { Blake2b } from "../deps/wat_the_crypto.ts"
 
-export interface EncodeProps {
-  validNetworkPrefixes?: readonly number[]
-  checksumLength?: number
-}
-
 export function encode(
   prefix: number,
   payload: Uint8Array,
-  props?: EncodeProps,
+  checksumLength?: number,
 ): string {
-  return base58.encode(encodeRaw(prefix, payload, props))
+  return base58.encode(encodeRaw(prefix, payload, checksumLength))
 }
 
 export function encodeRaw(
   prefix: number,
   payload: Uint8Array,
-  props?: EncodeProps,
+  checksumLength?: number,
 ): Uint8Array {
-  const checksumLength = props?.checksumLength ?? DEFAULT_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
+  checksumLength ??= DEFAULT_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
   if (!checksumLength) throw new InvalidPayloadLengthError()
-  const isValidNetworkPrefix = props?.validNetworkPrefixes?.includes(prefix) ?? true
-  if (!isValidNetworkPrefix) throw new InvalidNetworkPrefixError()
   const prefixBytes = prefix < 64
     ? Uint8Array.of(prefix)
     : Uint8Array.of(
@@ -43,12 +36,9 @@ export function encodeRaw(
   return address
 }
 
-export type EncodeError = InvalidPayloadLengthError | InvalidNetworkPrefixError
+export type EncodeError = InvalidPayloadLengthError
 export class InvalidPayloadLengthError extends Error {
   override readonly name = "InvalidPayloadLengthError"
-}
-export class InvalidNetworkPrefixError extends Error {
-  override readonly name = "InvalidNetworkPrefixError"
 }
 
 export type DecodeResult = [prefix: number, pubKey: Uint8Array]

--- a/crypto/ss58.ts
+++ b/crypto/ss58.ts
@@ -3,46 +3,38 @@ import { Blake2b } from "../deps/wat_the_crypto.ts"
 
 export function encode(
   prefix: number,
-  pubKey: Uint8Array,
+  payload: Uint8Array,
   validNetworkPrefixes?: readonly number[],
 ): string {
-  return base58.encode(encodeRaw(prefix, pubKey, validNetworkPrefixes))
+  return base58.encode(encodeRaw(prefix, payload, validNetworkPrefixes))
 }
 
 export function encodeRaw(
   prefix: number,
-  pubKey: Uint8Array,
+  payload: Uint8Array,
   validNetworkPrefixes?: readonly number[],
 ): Uint8Array {
-  const isValidPublicKeyLength = !!VALID_PUBLIC_KEY_LENGTHS[pubKey.length]
-  if (!isValidPublicKeyLength) throw new InvalidPublicKeyLengthError()
-
+  const checksumLength = VALID_PAYLOAD_CHECKSUM_LENGTHS[payload.length]
+  if (!checksumLength) throw new InvalidPublicKeyLengthError()
   const isValidNetworkPrefix = !validNetworkPrefixes || validNetworkPrefixes.includes(prefix)
   if (!isValidNetworkPrefix) throw new InvalidNetworkPrefixError()
-
   const prefixBytes = prefix < 64
     ? Uint8Array.of(prefix)
     : Uint8Array.of(
       ((prefix & 0b0000_0000_1111_1100) >> 2) | 0b0100_0000,
       (prefix >> 8) | ((prefix & 0b0000_0000_0000_0011) << 6),
     )
-
   const hasher = new Blake2b()
-
   hasher.update(SS58PRE)
   hasher.update(prefixBytes)
-  hasher.update(pubKey)
-
+  hasher.update(payload)
   const digest = hasher.digest()
-  const checksum = digest.subarray(0, CHECKSUM_LENGTH)
+  const checksum = digest.subarray(0, checksumLength)
   hasher.dispose()
-
-  const address = new Uint8Array(prefixBytes.length + pubKey.length + CHECKSUM_LENGTH)
-
+  const address = new Uint8Array(prefixBytes.length + payload.length + checksumLength)
   address.set(prefixBytes, 0)
-  address.set(pubKey, prefixBytes.length)
-  address.set(checksum, prefixBytes.length + pubKey.length)
-
+  address.set(payload, prefixBytes.length)
+  address.set(checksum, prefixBytes.length + payload.length)
   return address
 }
 
@@ -61,31 +53,23 @@ export function decode(address: string): DecodeResult {
 }
 
 export function decodeRaw(address: Uint8Array): DecodeResult {
-  const isValidAddressLength = !!VALID_ADDRESS_LENGTHS[address.length]
-  if (!isValidAddressLength) throw new InvalidAddressLengthError()
-
+  const checksumLength = VALID_ADDRESS_CHECKSUM_LENGTHS[address.length]
+  if (!checksumLength) throw new InvalidAddressLengthError()
   const prefixLength = address[0]! & 0b0100_0000 ? 2 : 1
-
   const prefix: number = prefixLength === 1
     ? address[0]!
     : ((address[0]! & 0b0011_1111) << 2) | (address[1]! >> 6)
       | ((address[1]! & 0b0011_1111) << 8)
-
   const hasher = new Blake2b()
-
   hasher.update(SS58PRE)
-  hasher.update(address.subarray(0, address.length - CHECKSUM_LENGTH))
-
+  hasher.update(address.subarray(0, address.length - checksumLength))
   const digest = hasher.digest()
-  const checksum = address.subarray(address.length - CHECKSUM_LENGTH)
+  const checksum = address.subarray(address.length - checksumLength)
   hasher.dispose()
-
   if (digest[0] !== checksum[0] || digest[1] !== checksum[1]) {
     throw new InvalidAddressChecksumError()
   }
-
-  const pubKey = address.subarray(prefixLength, address.length - CHECKSUM_LENGTH)
-
+  const pubKey = address.subarray(prefixLength, address.length - checksumLength)
   return [prefix, pubKey]
 }
 
@@ -99,14 +83,31 @@ export class InvalidAddressChecksumError extends Error {
 
 // SS58PRE string (0x53533538505245 hex) encoded as Uint8Array
 const SS58PRE = Uint8Array.of(83, 83, 53, 56, 80, 82, 69)
-const CHECKSUM_LENGTH = 2
-const VALID_ADDRESS_LENGTHS: Record<number, boolean | undefined> = {
-  35: true,
-  36: true,
-  37: true,
-  38: true,
+const VALID_ADDRESS_CHECKSUM_LENGTHS: Record<number, number | undefined> = {
+  3: 1,
+  4: 1,
+  5: 2,
+  6: 1,
+  7: 2,
+  8: 3,
+  9: 4,
+  10: 1,
+  11: 2,
+  12: 3,
+  13: 4,
+  14: 5,
+  15: 6,
+  16: 7,
+  17: 8,
+  35: 2,
+  36: 2,
+  37: 2,
 }
-const VALID_PUBLIC_KEY_LENGTHS: Record<number, boolean | undefined> = {
-  32: true,
-  33: true,
+const VALID_PAYLOAD_CHECKSUM_LENGTHS: Record<number, number | undefined> = {
+  1: 1,
+  2: 1,
+  4: 1,
+  8: 1,
+  32: 2,
+  33: 2,
 }

--- a/patterns/signature/polkadot.ts
+++ b/patterns/signature/polkadot.ts
@@ -49,7 +49,7 @@ export function signature<X>(_props: RunicArgs<X, SignatureProps>) {
           }
         }
       })
-      .throws(ss58.InvalidPublicKeyLengthError, ss58.InvalidNetworkPrefixError)
+      .throws(ss58.InvalidPayloadLengthError, ss58.InvalidNetworkPrefixError)
     const nonce = Rune.resolve(props.nonce)
       .unhandle(undefined)
       .rehandle(undefined, () => chain.connection.call("system_accountNextIndex", senderSs58))

--- a/patterns/signature/polkadot.ts
+++ b/patterns/signature/polkadot.ts
@@ -49,7 +49,7 @@ export function signature<X>(_props: RunicArgs<X, SignatureProps>) {
           }
         }
       })
-      .throws(ss58.InvalidPayloadLengthError, ss58.InvalidNetworkPrefixError)
+      .throws(ss58.InvalidPayloadLengthError)
     const nonce = Rune.resolve(props.nonce)
       .unhandle(undefined)
       .rehandle(undefined, () => chain.connection.call("system_accountNextIndex", senderSs58))


### PR DESCRIPTION
Resolves #619 

Add ss58 encoding and decoding for different payload and checksum lengths (see [ss58-format](https://docs.substrate.io/reference/address-formats/)).

Note: `MultiAdress.Index` use formats whose checksum length is `1` provided that the index is of type `u8`, `u16`, `u32` or `u64` (`1`, `2`, `4` or `8` byte payload).

<img width="386" alt="image" src="https://user-images.githubusercontent.com/1209171/225370802-c4c5b25c-5236-4a50-b445-96137cbea971.png">
 