### PR TITLE
feat: `from` method on all rune classes

### DIFF
--- a/examples/multisig_transfer.ts
+++ b/examples/multisig_transfer.ts
@@ -1,4 +1,4 @@
-import { Rune, ValueRune } from "capi"
+import { ValueRune } from "capi"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 import { Balances, chain, System, users } from "polkadot_dev/mod.js"

--- a/examples/multisig_transfer.ts
+++ b/examples/multisig_transfer.ts
@@ -5,12 +5,11 @@ import { Balances, chain, System, users } from "polkadot_dev/mod.js"
 
 const [alexa, billy, carol, david] = await users(4)
 
-const multisig = Rune
-  .constant({
-    signatories: [alexa, billy, carol].map(({ publicKey }) => publicKey),
-    threshold: 2,
-  })
-  .into(MultisigRune, chain)
+const multisig = MultisigRune.from({
+  signatories: [alexa, billy, carol]
+    .map(({ publicKey }) => publicKey),
+  threshold: 2,
+}, chain)
 
 // Read dave's initial balance (to-be changed by the call)
 console.log("Dave initial balance:", await System.Account.value(david.publicKey).run())

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -3,6 +3,7 @@ import { MultiAddress } from "polkadot/types/sp_runtime/multiaddress.js"
 // const MultiAddress = null! as any
 import * as bytes from "../../deps/std/bytes.ts"
 import { Chain, ChainRune, ExtrinsicRune, Rune, RunicArgs, ValueRune } from "../../mod.ts"
+import { PolkadotSignatureChain } from "../signature/polkadot.ts"
 import { multisigAccountId } from "./multisigAccountId.ts"
 
 export interface MultisigRatifyProps<C extends Chain> {
@@ -21,7 +22,7 @@ export interface Multisig {
 }
 
 // TODO: swap out `Chain` constraints upon subset gen issue resolution... same for other patterns
-export class MultisigRune<out C extends Chain, out U> extends Rune<Multisig, U> {
+export class MultisigRune<out C extends PolkadotSignatureChain, out U> extends Rune<Multisig, U> {
   private storage
   threshold
   accountId

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -28,7 +28,9 @@ export const $virtualMultisig: $.Codec<VirtualMultisig> = $.object(
   $.field("stash", $.sizedUint8Array(32)),
 )
 
-export class VirtualMultisigRune<out C extends Chain, out U> extends Rune<VirtualMultisig, U> {
+export class VirtualMultisigRune<out C extends PolkadotSignatureChain, out U>
+  extends Rune<VirtualMultisig, U>
+{
   inner
   proxies
   stash
@@ -104,7 +106,7 @@ export class VirtualMultisigRune<out C extends Chain, out U> extends Rune<Virtua
       .into(ExtrinsicRune, this.chain)
   }
 
-  static hydrate<C extends Chain, U, X>(
+  static hydrate<C extends PolkadotSignatureChain, U, X>(
     chain: ChainRune<C, U>,
     ...[state]: RunicArgs<X, [state: string]>
   ) {
@@ -114,7 +116,7 @@ export class VirtualMultisigRune<out C extends Chain, out U> extends Rune<Virtua
       .into(VirtualMultisigRune, chain)
   }
 
-  static deployment<C extends Chain, U, X>(
+  static deployment<C extends PolkadotSignatureChain, U, X>(
     chain: ChainRune<C, U>,
     props: RunicArgs<X, VirtualMultisigDeploymentProps>,
   ) {

--- a/rune/ArrayRune.ts
+++ b/rune/ArrayRune.ts
@@ -13,4 +13,6 @@ export class ArrayRune<T, U> extends Rune<T[], U> {
       .flat(fn(Rune._placeholder().into(ValueRune)))
       .into(ArrayRune)
   }
+
+  static of() {}
 }

--- a/rune/ArrayRune.ts
+++ b/rune/ArrayRune.ts
@@ -13,6 +13,4 @@ export class ArrayRune<T, U> extends Rune<T[], U> {
       .flat(fn(Rune._placeholder().into(ValueRune)))
       .into(ArrayRune)
   }
-
-  static of() {}
 }

--- a/rune/Rune.ts
+++ b/rune/Rune.ts
@@ -66,6 +66,14 @@ export class Rune<out T, out U = never> {
     return fn().into(ValueRune)
   }
 
+  static from<T, V extends T | Rune<T>, A extends unknown[], C>(
+    this: new(_prime: (batch: Batch) => Run<T, Rune.U<V> | RunicArgs.U<A>>, ...args: A) => C,
+    value: V,
+    ...args: A
+  ): C {
+    return (Rune.resolve(value) as ValueRune<T, Rune.U<V>>).into(this, ...args)
+  }
+
   async run(batch = new Batch()): Promise<T> {
     for await (const value of this.iter(batch)) {
       return value


### PR DESCRIPTION
Currently, we instantiate Rune subclasses from constants as follows.

```ts
const multisig = Rune
  .constant({
    signatories: [alexa, billy, carol]
      .map(({ publicKey }) => publicKey),
    threshold: 2,
  })
  .into(MultisigRune, chain)
```

Following this PR we can express this as...

```ts
const multisig = MultisigRune.from({
  signatories: [alexa, billy, carol]
    .map(({ publicKey }) => publicKey),
  threshold: 2,
}, chain)
```