### PR TITLE
fix: shim isomorphic-ws for WebSocket

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -79,12 +79,12 @@ await Promise.all([
       custom: [{
         package: {
           name: "isomorphic-ws",
-          version: "5.0.0"
+          version: "5.0.0",
         },
         globalNames: [{
           name: "WebSocket",
-          exportName: "default"
-        }]
+          exportName: "default",
+        }],
       }],
     },
     test: false,

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -75,8 +75,17 @@ await Promise.all([
       deno: {
         test: true,
       },
-      webSocket: true,
       crypto: true,
+      custom: [{
+        package: {
+          name: "isomorphic-ws",
+          version: "5.0.0"
+        },
+        globalNames: [{
+          name: "WebSocket",
+          exportName: "default"
+        }]
+      }],
     },
     test: false,
     typeCheck: false,


### PR DESCRIPTION
Fixes https://github.com/paritytech/capi/issues/778

Works for both Node.js environment and the browser

`isomorphic-ws` lib uses:
- [ws](https://github.com/websockets/ws) on Node
- [global.WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) in browsers