### PR TITLE
chore: improve users util

### DIFF
--- a/crypto/test_pairs.ts
+++ b/crypto/test_pairs.ts
@@ -38,7 +38,8 @@ export function testUser(userId: number) {
 }
 
 export function testUserFactory(url: string) {
-  return async function users<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>> {
+  return async <R extends [number?]>(...[count_]: R): Promise<TestUsers<R[0]>> => {
+    const count = count_ ?? 26
     const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -48,6 +49,39 @@ export function testUserFactory(url: string) {
     const { index }: { index: number } = await response.json()
     const userIds: Sr25519[] = []
     for (let i = index; i < index + count; i++) userIds.push(testUser(i))
-    return userIds as ArrayOfLength<Sr25519, N>
+    return (typeof count_ === "number"
+      ? userIds
+      : (Object.fromEntries(TEST_USER_NAMES.map((name, i) => [name, userIds[i]!])))) as never
   }
 }
+
+export type TestUsers<N extends number | undefined> = N extends number ? ArrayOfLength<Sr25519, N>
+  : Record<typeof TEST_USER_NAMES[number], Sr25519>
+const TEST_USER_NAMES = [
+  "alexa",
+  "billy",
+  "carol",
+  "david",
+  "ellie",
+  "felix",
+  "grace",
+  "harry",
+  "india",
+  "jason",
+  "kiera",
+  "laura",
+  "matty",
+  "nadia",
+  "oscar",
+  "piper",
+  "quinn",
+  "ryann",
+  "steff",
+  "teee6",
+  "usher",
+  "vicky",
+  "wendy",
+  "xenia",
+  "yetis",
+  "zelda",
+] as const

--- a/crypto/test_pairs.ts
+++ b/crypto/test_pairs.ts
@@ -38,25 +38,23 @@ export function testUser(userId: number) {
 }
 
 export function testUserFactory(url: string) {
-  return async <R extends [number?]>(...[count_]: R): Promise<TestUsers<R[0]>> => {
-    const count = count_ ?? 26
+  return users
+  function users(): Promise<Record<typeof TEST_USER_NAMES[number], Sr25519>>
+  function users<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>
+  async function users(count?: number): Promise<Record<string, Sr25519> | Sr25519[]> {
     const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ count }),
+      body: JSON.stringify({ count: count ?? TEST_USER_NAMES.length }),
     })
     if (!response.ok) throw new Error(await response.text())
     const { index }: { index: number } = await response.json()
-    const userIds: Sr25519[] = []
-    for (let i = index; i < index + count; i++) userIds.push(testUser(i))
-    return (typeof count_ === "number"
-      ? userIds
-      : (Object.fromEntries(TEST_USER_NAMES.map((name, i) => [name, userIds[i]!])))) as never
+    return typeof count === "number"
+      ? Array.from({ length: count }, (_, i) => testUser(index + i))
+      : Object.fromEntries(TEST_USER_NAMES.map((name, i) => [name, testUser(index + i)]))
   }
 }
 
-export type TestUsers<N extends number | undefined> = N extends number ? ArrayOfLength<Sr25519, N>
-  : Record<typeof TEST_USER_NAMES[number], Sr25519>
 const TEST_USER_NAMES = [
   "alexa",
   "billy",

--- a/crypto/test_pairs.ts
+++ b/crypto/test_pairs.ts
@@ -36,50 +36,51 @@ function pair(secret: string) {
 export function testUser(userId: number) {
   return Sr25519.fromSeed(blake2_256.hash(new TextEncoder().encode(`capi-test-user-${userId}`)))
 }
-
-export function testUserFactory(url: string) {
-  return users
-  function users(): Promise<Record<typeof TEST_USER_NAMES[number], Sr25519>>
-  function users<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>
-  async function users(count?: number): Promise<Record<string, Sr25519> | Sr25519[]> {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ count: count ?? TEST_USER_NAMES.length }),
-    })
-    if (!response.ok) throw new Error(await response.text())
-    const { index }: { index: number } = await response.json()
-    return typeof count === "number"
-      ? Array.from({ length: count }, (_, i) => testUser(index + i))
-      : Object.fromEntries(TEST_USER_NAMES.map((name, i) => [name, testUser(index + i)]))
+export namespace testUser {
+  export function factory(url: string) {
+    return createUsers
+    function createUsers(): Promise<Record<typeof NAMES[number], Sr25519>>
+    function createUsers<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>
+    async function createUsers(count?: number): Promise<Record<string, Sr25519> | Sr25519[]> {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ count: count ?? NAMES.length }),
+      })
+      if (!response.ok) throw new Error(await response.text())
+      const { index }: { index: number } = await response.json()
+      return typeof count === "number"
+        ? Array.from({ length: count }, (_, i) => testUser(index + i))
+        : Object.fromEntries(NAMES.map((name, i) => [name, testUser(index + i)]))
+    }
   }
-}
 
-const TEST_USER_NAMES = [
-  "alexa",
-  "billy",
-  "carol",
-  "david",
-  "ellie",
-  "felix",
-  "grace",
-  "harry",
-  "india",
-  "jason",
-  "kiera",
-  "laura",
-  "matty",
-  "nadia",
-  "oscar",
-  "piper",
-  "quinn",
-  "ryann",
-  "steff",
-  "teee6",
-  "usher",
-  "vicky",
-  "wendy",
-  "xenia",
-  "yetis",
-  "zelda",
-] as const
+  export const NAMES = [
+    "alexa",
+    "billy",
+    "carol",
+    "david",
+    "ellie",
+    "felix",
+    "grace",
+    "harry",
+    "india",
+    "jason",
+    "kiera",
+    "laura",
+    "matty",
+    "nadia",
+    "oscar",
+    "piper",
+    "quinn",
+    "ryann",
+    "steff",
+    "teee6",
+    "usher",
+    "vicky",
+    "wendy",
+    "xenia",
+    "yetis",
+    "zelda",
+  ] as const
+}

--- a/crypto/test_pairs.ts
+++ b/crypto/test_pairs.ts
@@ -36,51 +36,23 @@ function pair(secret: string) {
 export function testUser(userId: number) {
   return Sr25519.fromSeed(blake2_256.hash(new TextEncoder().encode(`capi-test-user-${userId}`)))
 }
-export namespace testUser {
-  export function factory(url: string) {
-    return createUsers
-    function createUsers(): Promise<Record<typeof NAMES[number], Sr25519>>
-    function createUsers<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>
-    async function createUsers(count?: number): Promise<Record<string, Sr25519> | Sr25519[]> {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ count: count ?? NAMES.length }),
-      })
-      if (!response.ok) throw new Error(await response.text())
-      const { index }: { index: number } = await response.json()
-      return typeof count === "number"
-        ? Array.from({ length: count }, (_, i) => testUser(index + i))
-        : Object.fromEntries(NAMES.map((name, i) => [name, testUser(index + i)]))
-    }
+export function testUserFactory(url: string) {
+  return createUsers
+  function createUsers(): Promise<Record<typeof NAMES[number], Sr25519>>
+  function createUsers<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>
+  async function createUsers(count?: number): Promise<Record<string, Sr25519> | Sr25519[]> {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ count: count ?? NAMES.length }),
+    })
+    if (!response.ok) throw new Error(await response.text())
+    const { index }: { index: number } = await response.json()
+    return typeof count === "number"
+      ? Array.from({ length: count }, (_, i) => testUser(index + i))
+      : Object.fromEntries(NAMES.map((name, i) => [name, testUser(index + i)]))
   }
-
-  export const NAMES = [
-    "alexa",
-    "billy",
-    "carol",
-    "david",
-    "ellie",
-    "felix",
-    "grace",
-    "harry",
-    "india",
-    "jason",
-    "kiera",
-    "laura",
-    "matty",
-    "nadia",
-    "oscar",
-    "piper",
-    "quinn",
-    "ryann",
-    "steff",
-    "teee6",
-    "usher",
-    "vicky",
-    "wendy",
-    "xenia",
-    "yetis",
-    "zelda",
-  ] as const
 }
+
+// dprint-ignore-next-line
+const NAMES = ["alexa", "billy", "carol", "david", "ellie", "felix", "grace", "harry", "india", "jason", "kiera", "laura", "matty", "nadia", "oscar", "piper", "quinn", "ryann", "steff", "tisix", "usher", "vicky", "wendy", "xenia", "yetis", "zelda"] as const

--- a/examples/balance.ts
+++ b/examples/balance.ts
@@ -1,6 +1,6 @@
-import { System, users } from "polkadot_dev/mod.js"
+import { createUsers, System } from "polkadot_dev/mod.js"
 
-const { alexa } = await users()
+const { alexa } = await createUsers()
 
 const result = await System.Account.value(alexa.publicKey).run()
 

--- a/examples/balance.ts
+++ b/examples/balance.ts
@@ -1,6 +1,6 @@
 import { System, users } from "polkadot_dev/mod.js"
 
-const [alexa] = await users(1)
+const { alexa } = await users()
 
 const result = await System.Account.value(alexa.publicKey).run()
 

--- a/examples/batch.ts
+++ b/examples/batch.ts
@@ -3,7 +3,7 @@ import { signature } from "capi/patterns/signature/polkadot.ts"
 import { Balances, System, users, Utility } from "westend_dev/mod.js"
 import { mapEntries } from "../deps/std/collections/map_entries.ts"
 
-const [alexa, billy, carol, david] = await users(4)
+const { alexa, billy, carol, david } = await users()
 
 const balances = Rune.rec(
   mapEntries({ billy, carol, david }, ([name, { publicKey }]) => {

--- a/examples/batch.ts
+++ b/examples/batch.ts
@@ -1,9 +1,9 @@
 import { Rune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import { Balances, System, users, Utility } from "westend_dev/mod.js"
+import { Balances, createUsers, System, Utility } from "westend_dev/mod.js"
 import { mapEntries } from "../deps/std/collections/map_entries.ts"
 
-const { alexa, billy, carol, david } = await users()
+const { alexa, billy, carol, david } = await createUsers()
 
 const balances = Rune.rec(
   mapEntries({ billy, carol, david }, ([name, { publicKey }]) => {

--- a/examples/fee_estimate.ts
+++ b/examples/fee_estimate.ts
@@ -1,6 +1,6 @@
-import { Balances, users } from "westend_dev/mod.js"
+import { Balances, createUsers } from "westend_dev/mod.js"
 
-const { alexa } = await users()
+const { alexa } = await createUsers()
 
 const result = await Balances
   .transfer({

--- a/examples/fee_estimate.ts
+++ b/examples/fee_estimate.ts
@@ -1,6 +1,6 @@
 import { Balances, users } from "westend_dev/mod.js"
 
-const [alexa] = await users(1)
+const { alexa } = await users()
 
 const result = await Balances
   .transfer({

--- a/examples/identity_cr.ts
+++ b/examples/identity_cr.ts
@@ -1,9 +1,9 @@
 import { $ } from "capi"
 import { IdentityInfoTranscoders } from "capi/patterns/identity.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import { Identity, users } from "polkadot_dev/mod.js"
+import { createUsers, Identity } from "polkadot_dev/mod.js"
 
-const { alexa } = await users()
+const { alexa } = await createUsers()
 
 const transcoders = new IdentityInfoTranscoders({ stars: $.u8 })
 

--- a/examples/identity_cr.ts
+++ b/examples/identity_cr.ts
@@ -3,7 +3,7 @@ import { IdentityInfoTranscoders } from "capi/patterns/identity.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 import { Identity, users } from "polkadot_dev/mod.js"
 
-const [alexa] = await users(1)
+const { alexa } = await users()
 
 const transcoders = new IdentityInfoTranscoders({ stars: $.u8 })
 

--- a/examples/indices.ts
+++ b/examples/indices.ts
@@ -1,8 +1,8 @@
 import { PublicKeyRune } from "capi"
-import { chain, Indices, users } from "polkadot_dev/mod.js"
+import { chain, createUsers, Indices } from "polkadot_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const { alexa } = await users()
+const { alexa } = await createUsers()
 
 const index = 254
 

--- a/examples/indices.ts
+++ b/examples/indices.ts
@@ -2,7 +2,7 @@ import { PublicKeyRune } from "capi"
 import { chain, Indices, users } from "polkadot_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const [alexa] = await users(1)
+const { alexa } = await users()
 
 const index = 254
 

--- a/examples/multisig_pure_proxy_stash.ts
+++ b/examples/multisig_pure_proxy_stash.ts
@@ -2,10 +2,10 @@ import { Rune } from "capi"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { filterPureCreatedEvents } from "capi/patterns/proxy/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import { Balances, chain, Proxy, System, users } from "polkadot_dev/mod.js"
+import { Balances, chain, createUsers, Proxy, System } from "polkadot_dev/mod.js"
 import { MultiAddress } from "polkadot_dev/types/sp_runtime/multiaddress.js"
 
-const { alexa, billy, carol } = await users()
+const { alexa, billy, carol } = await createUsers()
 
 const multisig = Rune
   .constant({

--- a/examples/multisig_pure_proxy_stash.ts
+++ b/examples/multisig_pure_proxy_stash.ts
@@ -5,7 +5,7 @@ import { signature } from "capi/patterns/signature/polkadot.ts"
 import { Balances, chain, Proxy, System, users } from "polkadot_dev/mod.js"
 import { MultiAddress } from "polkadot_dev/types/sp_runtime/multiaddress.js"
 
-const [alexa, billy, carol] = await users(3)
+const { alexa, billy, carol } = await users()
 
 const multisig = Rune
   .constant({

--- a/examples/multisig_transfer.ts
+++ b/examples/multisig_transfer.ts
@@ -1,9 +1,9 @@
 import { Rune, ValueRune } from "capi"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import { Balances, chain, System, users } from "polkadot_dev/mod.js"
+import { Balances, chain, createUsers, System } from "polkadot_dev/mod.js"
 
-const [alexa, billy, carol, david] = await users(4)
+const [alexa, billy, carol, david] = await createUsers(4)
 
 const multisig = Rune
   .constant({

--- a/examples/multisig_transfer.ts
+++ b/examples/multisig_transfer.ts
@@ -3,7 +3,7 @@ import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 import { Balances, chain, createUsers, System } from "polkadot_dev/mod.js"
 
-const [alexa, billy, carol, david] = await createUsers(4)
+const { alexa, billy, carol, david } = await createUsers()
 
 const multisig = Rune
   .constant({

--- a/examples/polkadot_js_signer.ts
+++ b/examples/polkadot_js_signer.ts
@@ -5,7 +5,7 @@ import { createPair } from "https://deno.land/x/polkadot@0.2.25/keyring/mod.ts"
 import { TypeRegistry } from "https://deno.land/x/polkadot@0.2.25/types/mod.ts"
 import { Balances, chain, users } from "polkadot_dev/mod.js"
 
-const [alexa, billy] = await users(2)
+const { alexa, billy } = await users()
 
 // Usually injected by an extension, e.g.
 // const pjsSigner = (await web3FromSource("polkadot-js")).signer!;

--- a/examples/polkadot_js_signer.ts
+++ b/examples/polkadot_js_signer.ts
@@ -3,9 +3,9 @@ import { pjsSender } from "capi/patterns/compat/pjs_sender.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 import { createPair } from "https://deno.land/x/polkadot@0.2.25/keyring/mod.ts"
 import { TypeRegistry } from "https://deno.land/x/polkadot@0.2.25/types/mod.ts"
-import { Balances, chain, users } from "polkadot_dev/mod.js"
+import { Balances, chain, createUsers } from "polkadot_dev/mod.js"
 
-const { alexa, billy } = await users()
+const { alexa, billy } = await createUsers()
 
 // Usually injected by an extension, e.g.
 // const pjsSigner = (await web3FromSource("polkadot-js")).signer!;

--- a/examples/transfer.ts
+++ b/examples/transfer.ts
@@ -1,7 +1,7 @@
 import { Balances, users } from "westend_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const [alexa, billy] = await users(2)
+const { alexa, billy } = await users()
 
 const result = await Balances
   .transfer({

--- a/examples/transfer.ts
+++ b/examples/transfer.ts
@@ -1,7 +1,7 @@
-import { Balances, users } from "westend_dev/mod.js"
+import { Balances, createUsers } from "westend_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const { alexa, billy } = await users()
+const { alexa, billy } = await createUsers()
 
 const result = await Balances
   .transfer({

--- a/examples/transfer_sequence.ts
+++ b/examples/transfer_sequence.ts
@@ -2,7 +2,7 @@ import { Rune, Sr25519 } from "capi"
 import { Balances, System, users } from "westend_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const [alexa, billy, carol] = await users(3)
+const { alexa, billy, carol } = await users()
 
 const balances = Rune.rec({
   alice: balance(alexa),

--- a/examples/transfer_sequence.ts
+++ b/examples/transfer_sequence.ts
@@ -1,8 +1,8 @@
 import { Rune, Sr25519 } from "capi"
-import { Balances, System, users } from "westend_dev/mod.js"
+import { Balances, createUsers, System } from "westend_dev/mod.js"
 import { signature } from "../patterns/signature/polkadot.ts"
 
-const { alexa, billy, carol } = await users()
+const { alexa, billy, carol } = await createUsers()
 
 const balances = Rune.rec({
   alice: balance(alexa),

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -1,11 +1,11 @@
 import { Rune, Sr25519 } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import { Balances, chain, System, users, Utility } from "polkadot_dev/mod.js"
+import { Balances, chain, createUsers, System, Utility } from "polkadot_dev/mod.js"
 import { MultiAddress } from "polkadot_dev/types/sp_runtime/multiaddress.js"
 import { parse } from "../deps/std/flags.ts"
 
-const { alexa, billy, carol, david } = await users()
+const { alexa, billy, carol, david } = await createUsers()
 
 let { state } = parse(Deno.args, { string: ["state"] })
 if (!state) {

--- a/examples/virtual_multisig.ts
+++ b/examples/virtual_multisig.ts
@@ -5,7 +5,7 @@ import { Balances, chain, System, users, Utility } from "polkadot_dev/mod.js"
 import { MultiAddress } from "polkadot_dev/types/sp_runtime/multiaddress.js"
 import { parse } from "../deps/std/flags.ts"
 
-const [alexa, billy, carol, david] = await users(4)
+const { alexa, billy, carol, david } = await users()
 
 let { state } = parse(Deno.args, { string: ["state"] })
 if (!state) {

--- a/providers/frame/common.ts
+++ b/providers/frame/common.ts
@@ -49,10 +49,10 @@ export function connectionCodeWithUsers(code: string, isTypes: boolean, url: str
   return `
 ${code}
 
-export const users ${
+export const createUsers ${
     isTypes
-      ? `: ReturnType<typeof C.testUserFactory>`
-      : `= C.testUserFactory(${JSON.stringify(url)})`
+      ? `: ReturnType<typeof C.testUser.factory>`
+      : `= C.testUser.factory(${JSON.stringify(url)})`
   }
   `
 }

--- a/providers/frame/common.ts
+++ b/providers/frame/common.ts
@@ -51,8 +51,8 @@ ${code}
 
 export const createUsers ${
     isTypes
-      ? `: ReturnType<typeof C.testUser.factory>`
-      : `= C.testUser.factory(${JSON.stringify(url)})`
+      ? `: ReturnType<typeof C.testUserFactory>`
+      : `= C.testUserFactory(${JSON.stringify(url)})`
   }
   `
 }

--- a/providers/frame/common.ts
+++ b/providers/frame/common.ts
@@ -45,11 +45,7 @@ export async function createCustomChainSpec(
   return customChainSpecRawPath
 }
 
-export function connectionCodeWithUsers(
-  code: string,
-  isTypes: boolean,
-  url: string,
-): string {
+export function connectionCodeWithUsers(code: string, isTypes: boolean, url: string): string {
   return `
 ${code}
 

--- a/words.txt
+++ b/words.txt
@@ -196,11 +196,11 @@ syncer
 syncstate
 tailaiw
 tcess
-teee
 teer
 tidefi
 tifi
 timepoint
+tisix
 tjjfvi
 tnkr
 todos

--- a/words.txt
+++ b/words.txt
@@ -91,6 +91,7 @@ katal
 katalchain
 keypair
 kico
+kiera
 kint
 kintsugi
 kton
@@ -106,6 +107,7 @@ ltex
 lxkf
 mathchain
 matklad
+matty
 merkle
 micnncim
 monomorphization
@@ -169,6 +171,7 @@ rotr
 runtimes
 rustc
 rustup
+ryann
 sastan
 schnorr
 schnorrkel
@@ -184,6 +187,7 @@ stalebot
 statemigration
 statemine
 statemint
+steff
 struct
 subpaths
 sufficients
@@ -192,6 +196,7 @@ syncer
 syncstate
 tailaiw
 tcess
+teee
 teer
 tidefi
 tifi


### PR DESCRIPTION
Fixes #760

Enables one to use `createUsers` (renamed from `users`) without specifying a count, which will cause it to default to a record (not a list) of 26 named `Sr25519`s.

```ts
const { alexa, billy, carol, david } = await createUsers()
```

Count specificity still works as is did before.

```ts
const [a, b, c, d] = await createUsers(4)
```