### PR TITLE
fix: multisig rune proof size

### DIFF
--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -58,7 +58,9 @@ export class MultisigRune<out C extends Chain, out U>
           call,
           otherSignatories: this.otherSignatories(sender),
           storeCall: false,
-          maxWeight: call.feeEstimate().access("weight"),
+          maxWeight: call.feeEstimate().access("weight")
+            // TODO: revert when this is merged https://github.com/paritytech/substrate/pull/13766
+            .map((weight) => ({ ...weight, proofSize: 200_000_000n })),
           maybeTimepoint: this.maybeTimepoint(call.hash),
         }),
       })


### PR DESCRIPTION
resolves: #827

https://github.com/paritytech/substrate/pull/13268

broke the weight calculation causing the proof size requirement to exceed 0 

need to wait for this to be merged and released is my understanding

https://github.com/paritytech/substrate/pull/13766