### PR TITLE
feat: add `SignedExtrinsicRune` `from` and `fromHex` methods

### DIFF
--- a/examples/sign/offline.ts
+++ b/examples/sign/offline.ts
@@ -1,8 +1,7 @@
 /**
  * @title Offline Signing
  * @stability nearing
- *
- * Create and sign an extrinsic, then serialize it into a hex for later use.
+ * @description Create and sign an extrinsic, then serialize it into a hex for later use.
  * Finally, rehydrate the extrinsic and submit it.
  */
 

--- a/examples/sign/offline.ts
+++ b/examples/sign/offline.ts
@@ -1,0 +1,44 @@
+/**
+ * @title Offline Signing
+ * @stability nearing
+ *
+ * Create and sign an extrinsic, then serialize it into a hex for later use.
+ * Finally, rehydrate the extrinsic and submit it.
+ */
+
+import { $, SignedExtrinsicRune } from "capi"
+import { signature } from "capi/patterns/signature/polkadot.ts"
+import { Balances, chain, createUsers } from "westend_dev/mod.js"
+
+const { alexa, billy } = await createUsers()
+
+// Create and sign the extrinsic. Extract the hex.
+const hex = await Balances
+  .transfer({
+    value: 12345n,
+    dest: billy.address,
+  })
+  .signed(signature({ sender: alexa }))
+  .hex()
+  .run()
+
+// Save `hex` however you'd like (potentially sending to a relayer service,
+// writing to disk, etc.).
+save(hex)
+
+// Hydrate the signed extrinsic, submit it and await finalization.
+const hash = await SignedExtrinsicRune
+  .fromHex(chain, hex)
+  .sent()
+  .dbgStatus("Tx status:")
+  .finalized()
+  .run()
+
+// Ensure the extrinsic has been finalized.
+$.assert($.str, hash)
+
+// egdoc-ignore-start
+// The following noop is solely for explanation. Swap this out with your
+// own signed-hex-representation-consuming code.
+function save(_hex: string) {}
+// egdoc-ignore-end

--- a/fluent/SignedExtrinsicRune.ts
+++ b/fluent/SignedExtrinsicRune.ts
@@ -1,10 +1,24 @@
 import { hex } from "../crypto/mod.ts"
-import { ValueRune } from "../rune/mod.ts"
-import { Chain } from "./ChainRune.ts"
+import { Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
+import { Chain, ChainRune } from "./ChainRune.ts"
 import { ExtrinsicStatusRune } from "./ExtrinsicStatusRune.ts"
 import { PatternRune } from "./PatternRune.ts"
 
 export class SignedExtrinsicRune<out C extends Chain, out U> extends PatternRune<Uint8Array, C, U> {
+  static from<C extends Chain, U, X>(
+    chain: ChainRune<C, U>,
+    ...[value]: RunicArgs<X, [value: Uint8Array]>
+  ) {
+    return Rune.resolve(value).into(SignedExtrinsicRune, chain)
+  }
+
+  static fromHex<C extends Chain, U, X>(
+    chain: ChainRune<C, U>,
+    ...[value]: RunicArgs<X, [value: string]>
+  ) {
+    return this.from(chain, Rune.resolve(value).map(hex.decode))
+  }
+
   hex() {
     return this.into(ValueRune).map(hex.encode)
   }

--- a/words.txt
+++ b/words.txt
@@ -62,6 +62,7 @@ dispatchable
 dprint
 edgeware
 efinity
+egdoc
 esbenp
 esque
 extrinsics


### PR DESCRIPTION
A follow-up to #756

Simplifies taking a signed extrinsic hex and turning it into a `SignedExtrinsicRune` (ostensibly for submission).

```ts
// Create and sign the extrinsic. Extract the hex.
const hex = await Balances
  .transfer({
    value: 12345n,
    dest: billy.address,
  })
  .signed(signature({ sender: alexa }))
  .hex()
  .run()

// Save `hex` however you'd like (potentially sending to a relayer service,
// writing to disk, etc.).
save(hex)

// Hydrate the signed extrinsic, submit it and await finalization.
await SignedExtrinsicRune
  .fromHex(chain, hex)
  .sent()
  .dbgStatus("Tx status:")
  .finalized()
  .run()
```