### PR TITLE
feat: flat codegen

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,8 +56,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: deno run -A _tasks/use_remote.ts
       - run: deno task run _tasks/star.ts
-      # Attempt caching thrice; #856
-      - run: deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts
+      # Attempt caching many times; #856
+      - run: deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts
 
   sync:
     name: Sync

--- a/Readme.md
+++ b/Readme.md
@@ -42,8 +42,6 @@ import { System } from "@capi/polkadot"
 const accounts = await System.Account.entryPage(10, null).run()
 ```
 
-> Note: to run with Deno, import from `@capi/polkadot/mod.js`
-
 ## Running Examples
 
 Within a fresh clone of this repository...

--- a/cli/serve.ts
+++ b/cli/serve.ts
@@ -30,7 +30,7 @@ export default async function(...args: string[]) {
   const { signal } = controller
 
   const dataCache = new FsCache(out, signal)
-  const tempCache = new FsCache("target/capi", signal)
+  const tempCache = new InMemoryCache(signal)
 
   const running = await fetch(`${href}capi_cwd`)
     .then((r) => r.text())

--- a/cli/serve.ts
+++ b/cli/serve.ts
@@ -30,7 +30,7 @@ export default async function(...args: string[]) {
   const { signal } = controller
 
   const dataCache = new FsCache(out, signal)
-  const tempCache = new InMemoryCache(signal)
+  const tempCache = new FsCache("target/capi", signal)
 
   const running = await fetch(`${href}capi_cwd`)
     .then((r) => r.text())

--- a/codegen/FrameCodegen.ts
+++ b/codegen/FrameCodegen.ts
@@ -26,7 +26,7 @@ export class FrameCodegen {
 import * as _codecs from "./codecs.js"
 import { connect } from "./connection.js"
 import * as C from "./capi.js"
-import * as t from "./types/mod.js"
+import * as t from "./types.js"
 
 export const metadata = ${this.codecCodegen.print(this.metadata)}
 
@@ -38,7 +38,7 @@ export const chain = C.ChainRune.from(connect, metadata)
       `
 import * as _codecs from "./codecs.js"
 import * as C from "./capi.js"
-import * as t from "./types/mod.js"
+import * as t from "./types.js"
 
 export const metadata: ${this.typeCodegen.print(this.metadata)}
 
@@ -58,7 +58,7 @@ export const chain: C.ChainRune<${this.chainName}, never>
 export * from "./connection.js"
 export * from "./chain.js"
 export * from "./pallets.js"
-export * as types from "./types/mod.js"
+export * from "./types.js"
 `,
       )
 
@@ -68,7 +68,7 @@ export * as types from "./types/mod.js"
 import { chain, ${isTypes ? this.chainName : ""} } from "./chain.js"
 import * as C from "./capi.js"
 import * as _codecs from "./codecs.js"
-import * as t from "./types/mod.js"
+import * as t from "./types.js"
 
 ${
           Object.values(this.metadata.pallets).map((pallet) => {

--- a/codegen/TypeCodegen.ts
+++ b/codegen/TypeCodegen.ts
@@ -187,38 +187,22 @@ is${variant.tag}(value) {
     } }`
   }
 
-  _write(files: Map<string, string>, path: string[], entries: [string[], $.Codec<any>][]): boolean {
-    const groups = new Map<string, [string[], $.Codec<any>][]>()
-    const codecs = []
-    for (const entry of entries) {
-      const name = entry[0][path.length]!
-      if (entry[0].length === path.length + 1) {
-        codecs.push([name, entry[1]] as const)
-      } else {
-        getOrInit(groups, name, () => []).push(entry)
-      }
-    }
-    const isFolder = !!groups.size
-    const rootDir = "../".repeat(path.length + +isFolder)
+  _write(files: Map<string, string>, entries: [string, $.Codec<any>][]): boolean {
+    return false
+  }
+
+  write(files: Map<string, string>) {
     for (const isTypes of [false, true]) {
       const ext = isTypes ? "d.ts" : "js"
       files.set(
-        `${["types", ...path].join("/")}${isFolder ? "/mod" : ""}.${ext}`,
+        `types.${ext}`,
         `
-import * as C from "${rootDir}capi.js"
-import * as _codecs from "${rootDir}codecs.js"
-import * as t from "${rootDir}types/mod.js"
+import * as C from "./capi.js"
+import * as _codecs from "./codecs.js"
+import * as t from "./types.js"
 
 ${
-          [...groups].map(([name, entries]) => {
-            const isFolder = this._write(files, [...path, name], entries)
-            return `
-export * as ${name} from ${JSON.stringify(`./${name}${isFolder ? "/mod" : ""}.js`)}`
-          }).join("\n")
-        }
-
-${
-          codecs.map(([name, codec]) => `
+          Object.entries(this.types).map(([name, codec]) => `
 export const $${name.replace(/^./, (x) => x.toLowerCase())}${
             isTypes ? `: C.$.Codec<${name}>` : `= ${this.codecCodegen.print(codec)}`
           }
@@ -229,16 +213,11 @@ ${this.declVisitor.visit(codec)(name, isTypes)}
 `,
       )
     }
-    return isFolder
-  }
-
-  write(files: Map<string, string>) {
-    this._write(files, [], Object.entries(this.types).map((x) => [x[0].split("."), x[1]]))
     files.set(
       "codecs.d.ts",
       `
 import * as C from "./capi.js"
-import * as t from "./types/mod.js"
+import * as t from "./types.js"
 
 ${
         [...this.codecCodegen.codecIds.entries()].filter((x) => x[1] != null).map(([codec, id]) => `

--- a/codegen/TypeCodegen.ts
+++ b/codegen/TypeCodegen.ts
@@ -8,7 +8,7 @@ import {
   $storageKey,
 } from "../frame_metadata/key_codecs.ts"
 import { $era, $null, ChainError } from "../scale_info/mod.ts"
-import { getOrInit, stringifyKey, stringifyPropertyAccess } from "../util/mod.ts"
+import { stringifyKey, stringifyPropertyAccess } from "../util/mod.ts"
 import { CodecCodegen } from "./CodecCodegen.ts"
 
 export class TypeCodegen {
@@ -185,10 +185,6 @@ is${variant.tag}(value) {
       Object.entries(value!).map(([key, value]) => `${stringifyKey(key)}: ${this.print(value)}`)
         .join(", ")
     } }`
-  }
-
-  _write(files: Map<string, string>, entries: [string, $.Codec<any>][]): boolean {
-    return false
   }
 
   write(files: Map<string, string>) {

--- a/examples/blocks.eg.ts
+++ b/examples/blocks.eg.ts
@@ -6,7 +6,7 @@
  * various pieces of data pertaining to that block.
  */
 
-import { chain, metadata, types } from "@capi/polkadot/mod.js"
+import { $eventRecord, chain, metadata } from "@capi/polkadot"
 import { $, $extrinsic, known, Rune } from "capi"
 import { babeBlockAuthor } from "capi/patterns/consensus/mod.ts"
 
@@ -48,7 +48,7 @@ $.assert(
     $.field("block", known.$signedBlock),
     $.field("extrinsics", $.array($extrinsic(metadata))),
     $.field("extrinsicsRaw", $.array($.str)),
-    $.field("events", $.array(types.frame_system.$eventRecord)),
+    $.field("events", $.array($eventRecord)),
     $.field("author", $.str),
   ),
   collection,

--- a/examples/dev/metadata.eg.ts
+++ b/examples/dev/metadata.eg.ts
@@ -10,7 +10,7 @@
  * chances are that you don't need to work with the metadata directly.
  */
 
-import { chain } from "@capi/polkadot-dev/mod.js"
+import { chain } from "@capi/polkadot-dev"
 
 // Execute the metadata Rune.
 const metadata = await chain.metadata.run()

--- a/examples/dev/storage_sizes.eg.ts
+++ b/examples/dev/storage_sizes.eg.ts
@@ -7,7 +7,7 @@
  * this can be helpful in the context of chain development.
  */
 
-import { chain } from "@capi/polkadot-dev/mod.js"
+import { chain } from "@capi/polkadot-dev"
 import { $ } from "capi"
 import { storageSizes } from "capi/patterns/storage_sizes.ts"
 

--- a/examples/dev/test_users.eg.ts
+++ b/examples/dev/test_users.eg.ts
@@ -6,7 +6,7 @@
  * funds. This simplifies signing extrinsics for submission to the given test chain.
  */
 
-import { createUsers } from "@capi/polkadot-dev/mod.js"
+import { createUsers } from "@capi/polkadot-dev"
 import { $, $sr25519 } from "capi"
 
 // Test users can be initialized with no count. The resulting collection is

--- a/examples/dynamic.eg.ts
+++ b/examples/dynamic.eg.ts
@@ -18,39 +18,6 @@ import { $, ChainRune, WsConnection } from "capi"
 // We could also initialize a `ChainRune` with `WsConnection` and an RPC node WebSocket URL.
 const wsChain = ChainRune.from(WsConnection.bind("wss://rpc.polkadot.io"))
 
-// Create a binding to the `System` pallet.
-const System = wsChain.pallet("System")
+const metadata = await wsChain.metadata.run()
 
-// Create a binding to the `Account` storage map.
-const Account = System.storage("Account")
-
-// Read the first ten entries of the `Account` storage map.
-// Note how the lack of partial key is communicated via `null`.
-const entries = await Account.entryPage(10, null).run()
-
-// The result should contain a `[Uint8Array, AccountInfo]` tuple of length 10.
-console.log("Entries page:", entries)
-$.assert(
-  $.sizedArray(
-    $.tuple(
-      $.sizedUint8Array(32),
-      $.object(
-        $.field("nonce", $.u32),
-        $.field("consumers", $.u32),
-        $.field("providers", $.u32),
-        $.field("sufficients", $.u32),
-        $.field(
-          "data",
-          $.object(
-            $.field("free", $.u128),
-            $.field("reserved", $.u128),
-            $.field("miscFrozen", $.u128),
-            $.field("feeFrozen", $.u128),
-          ),
-        ),
-      ),
-    ),
-    10,
-  ),
-  entries,
-)
+console.log(metadata.types)

--- a/examples/dynamic.eg.ts
+++ b/examples/dynamic.eg.ts
@@ -18,6 +18,39 @@ import { $, ChainRune, WsConnection } from "capi"
 // We could also initialize a `ChainRune` with `WsConnection` and an RPC node WebSocket URL.
 const wsChain = ChainRune.from(WsConnection.bind("wss://rpc.polkadot.io"))
 
-const metadata = await wsChain.metadata.run()
+// Create a binding to the `System` pallet.
+const System = wsChain.pallet("System")
 
-console.log(metadata.types)
+// Create a binding to the `Account` storage map.
+const Account = System.storage("Account")
+
+// Read the first ten entries of the `Account` storage map.
+// Note how the lack of partial key is communicated via `null`.
+const entries = await Account.entryPage(10, null).run()
+
+// The result should contain a `[Uint8Array, AccountInfo]` tuple of length 10.
+console.log("Entries page:", entries)
+$.assert(
+  $.sizedArray(
+    $.tuple(
+      $.sizedUint8Array(32),
+      $.object(
+        $.field("nonce", $.u32),
+        $.field("consumers", $.u32),
+        $.field("providers", $.u32),
+        $.field("sufficients", $.u32),
+        $.field(
+          "data",
+          $.object(
+            $.field("free", $.u128),
+            $.field("reserved", $.u128),
+            $.field("miscFrozen", $.u128),
+            $.field("feeFrozen", $.u128),
+          ),
+        ),
+      ),
+    ),
+    10,
+  ),
+  entries,
+)

--- a/examples/ink/deploy.eg.ts
+++ b/examples/ink/deploy.eg.ts
@@ -7,7 +7,7 @@
  * @todo utilize `createUsers` instead of `alice`
  */
 
-import { chain, System } from "@capi/contracts-dev/mod.js"
+import { chain, System } from "@capi/contracts-dev"
 import { $, alice, ss58 } from "capi"
 import { InkMetadataRune } from "capi/patterns/ink/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/ink/interact.eg.ts
+++ b/examples/ink/interact.eg.ts
@@ -7,7 +7,7 @@
  * @todo utilize `createUsers` instead of `alice` and `bob`.
  */
 
-import { chain } from "@capi/contracts-dev/mod.js"
+import { chain } from "@capi/contracts-dev"
 import { assert } from "asserts"
 import { $, alice, bob } from "capi"
 import { InkMetadataRune } from "capi/patterns/ink/mod.ts"

--- a/examples/misc/identity.eg.ts
+++ b/examples/misc/identity.eg.ts
@@ -6,7 +6,7 @@
  * @description Set a user's identity, potentially with metadata of arbitrary user-defined shape.
  */
 
-import { createUsers, Identity } from "@capi/polkadot-dev/mod.js"
+import { createUsers, Identity } from "@capi/polkadot-dev"
 import { $ } from "capi"
 import { IdentityInfoTranscoders } from "capi/patterns/identity.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/misc/indices.eg.ts
+++ b/examples/misc/indices.eg.ts
@@ -5,7 +5,7 @@
  * the user's account id using the index.
  */
 
-import { createUsers, Indices } from "@capi/polkadot-dev/mod.js"
+import { createUsers, Indices } from "@capi/polkadot-dev"
 import { assertEquals } from "asserts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 

--- a/examples/multisig/basic.eg.ts
+++ b/examples/multisig/basic.eg.ts
@@ -5,7 +5,7 @@
  * that multisig.
  */
 
-import { Balances, chain, createUsers, System } from "@capi/polkadot-dev/mod.js"
+import { Balances, chain, createUsers, System } from "@capi/polkadot-dev"
 import { assert } from "asserts"
 import { $ } from "capi"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"

--- a/examples/multisig/stash.eg.ts
+++ b/examples/multisig/stash.eg.ts
@@ -5,14 +5,7 @@
  * three signatories.
  */
 
-import {
-  Balances,
-  chain,
-  createUsers,
-  MultiAddress,
-  Proxy,
-  System,
-} from "@capi/polkadot-dev/mod.js"
+import { Balances, chain, createUsers, MultiAddress, Proxy, System } from "@capi/polkadot-dev"
 import { assert } from "asserts"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { filterPureCreatedEvents } from "capi/patterns/proxy/mod.ts"

--- a/examples/multisig/stash.eg.ts
+++ b/examples/multisig/stash.eg.ts
@@ -5,8 +5,14 @@
  * three signatories.
  */
 
-import { Balances, chain, createUsers, Proxy, System } from "@capi/polkadot-dev/mod.js"
-import { MultiAddress } from "@capi/polkadot-dev/types/mod.js"
+import {
+  Balances,
+  chain,
+  createUsers,
+  MultiAddress,
+  Proxy,
+  System,
+} from "@capi/polkadot-dev/mod.js"
 import { assert } from "asserts"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { filterPureCreatedEvents } from "capi/patterns/proxy/mod.ts"

--- a/examples/multisig/stash.eg.ts
+++ b/examples/multisig/stash.eg.ts
@@ -6,7 +6,7 @@
  */
 
 import { Balances, chain, createUsers, Proxy, System } from "@capi/polkadot-dev/mod.js"
-import { MultiAddress } from "@capi/polkadot-dev/types/sp_runtime/multiaddress.js"
+import { MultiAddress } from "@capi/polkadot-dev/types/mod.js"
 import { assert } from "asserts"
 import { MultisigRune } from "capi/patterns/multisig/mod.ts"
 import { filterPureCreatedEvents } from "capi/patterns/proxy/mod.ts"

--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -17,14 +17,7 @@
  * members ratify a call to give ownership of the stash account to the new multisig.
  */
 
-import {
-  Balances,
-  chain,
-  createUsers,
-  MultiAddress,
-  System,
-  Utility,
-} from "@capi/polkadot-dev/mod.js"
+import { Balances, chain, createUsers, MultiAddress, System, Utility } from "@capi/polkadot-dev"
 import { assert } from "asserts"
 import { $, Rune, Sr25519 } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"

--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -18,7 +18,7 @@
  */
 
 import { Balances, chain, createUsers, System, Utility } from "@capi/polkadot-dev/mod.js"
-import { MultiAddress } from "@capi/polkadot-dev/types/sp_runtime/multiaddress.js"
+import { MultiAddress } from "@capi/polkadot-dev/types/mod.js"
 import { assert } from "asserts"
 import { $, Rune, Sr25519 } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"

--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -17,8 +17,14 @@
  * members ratify a call to give ownership of the stash account to the new multisig.
  */
 
-import { Balances, chain, createUsers, System, Utility } from "@capi/polkadot-dev/mod.js"
-import { MultiAddress } from "@capi/polkadot-dev/types/mod.js"
+import {
+  Balances,
+  chain,
+  createUsers,
+  MultiAddress,
+  System,
+  Utility,
+} from "@capi/polkadot-dev/mod.js"
 import { assert } from "asserts"
 import { $, Rune, Sr25519 } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"

--- a/examples/paginate.eg.ts
+++ b/examples/paginate.eg.ts
@@ -4,7 +4,7 @@
  * @description Read pages (either of keys or entries) from storage maps.
  */
 
-import { System, types } from "@capi/polkadot-dev/mod.js"
+import { $accountInfo, System } from "@capi/polkadot-dev"
 import { $ } from "capi"
 
 // Reference the first 10 keys of a polkadot dev chain's system account map.
@@ -20,6 +20,6 @@ const accountEntries = await System.Account.entryPage(10, null).run()
 // Each entry should be of type `[Uint8Array, AccountInfo]`
 console.log("Account entries:", accountEntries)
 $.assert(
-  $.sizedArray($.tuple($.uint8Array, types.frame_system.$accountInfo), 10),
+  $.sizedArray($.tuple($.uint8Array, $accountInfo), 10),
   accountEntries,
 )

--- a/examples/raw_rpc/call.eg.ts
+++ b/examples/raw_rpc/call.eg.ts
@@ -4,7 +4,7 @@
  * @description Interact directly with the RPC node's call methods.
  */
 
-import { chain } from "@capi/polkadot-dev/mod.js"
+import { chain } from "@capi/polkadot-dev"
 import { $ } from "capi"
 
 // Make a call.

--- a/examples/raw_rpc/subscription.eg.ts
+++ b/examples/raw_rpc/subscription.eg.ts
@@ -4,7 +4,7 @@
  * @description Interact directly with the RPC node's subscription methods.
  */
 
-import { chain } from "@capi/polkadot-dev/mod.js"
+import { chain } from "@capi/polkadot-dev"
 import { $, known } from "capi"
 
 // Get an async iterator, which yields subscription events.

--- a/examples/read/account_info.eg.ts
+++ b/examples/read/account_info.eg.ts
@@ -4,7 +4,7 @@
  * @description Read the value (an `AccountInfo`) from the system account map.
  */
 
-import { createUsers, System, types } from "@capi/polkadot-dev/mod.js"
+import { $accountInfo, createUsers, System } from "@capi/polkadot-dev"
 import { $ } from "capi"
 
 const { alexa } = await createUsers()
@@ -12,4 +12,4 @@ const { alexa } = await createUsers()
 const accountInfo = await System.Account.value(alexa.publicKey).run()
 
 console.log("Account info:", accountInfo)
-$.assert(types.frame_system.$accountInfo, accountInfo)
+$.assert($accountInfo, accountInfo)

--- a/examples/read/era_reward_points.eg.ts
+++ b/examples/read/era_reward_points.eg.ts
@@ -6,7 +6,7 @@
  * reward points).
  */
 
-import { Staking, types } from "@capi/westend/mod.js"
+import { $eraRewardPoints, Staking } from "@capi/westend"
 import { $ } from "capi"
 
 const idx = Staking.ActiveEra
@@ -18,4 +18,4 @@ const points = await Staking.ErasRewardPoints.value(idx).run()
 console.log("Era reward points:", points)
 
 // Ensure the era reward points is of the correct shape.
-$.assert(types.pallet_staking.$eraRewardPoints, points)
+$.assert($eraRewardPoints, points)

--- a/examples/read/now.eg.ts
+++ b/examples/read/now.eg.ts
@@ -4,7 +4,7 @@
  * @description Read the current timestamp as agreed upon by validators.
  */
 
-import { Timestamp } from "@capi/polkadot/mod.js"
+import { Timestamp } from "@capi/polkadot"
 import { $ } from "capi"
 
 const now = await Timestamp.Now.value().run()

--- a/examples/read/para_heads.eg.ts
+++ b/examples/read/para_heads.eg.ts
@@ -6,7 +6,7 @@
  * (the corresponding parachain heads).
  */
 
-import { Paras } from "@capi/polkadot/mod.js"
+import { Paras } from "@capi/polkadot"
 import { $, ArrayRune, ValueRune } from "capi"
 
 const heads = await Paras.Parachains

--- a/examples/sign/ed25519.eg.ts
+++ b/examples/sign/ed25519.eg.ts
@@ -4,7 +4,7 @@
  * @description Utilize an Ed25519 library for signing.
  */
 
-import { Balances, createUsers, System, types } from "@capi/westend-dev/mod.js"
+import { Balances, createUsers, MultiAddress, System } from "@capi/westend-dev"
 import { assert } from "asserts"
 import { Rune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"
@@ -24,8 +24,7 @@ console.log("Billy free initial:", billyFreeInitial)
 const secret = crypto.getRandomValues(new Uint8Array(32))
 
 // Get a Rune of the secret-corresponding multiaddress.
-const address = types.sp_runtime.multiaddress.MultiAddress
-  .Id(await ed.getPublicKey(secret))
+const address = MultiAddress.Id(await ed.getPublicKey(secret))
 
 // Define a `sign` function for later use.
 async function sign(msg: Uint8Array) {

--- a/examples/sign/offline.eg.ts
+++ b/examples/sign/offline.eg.ts
@@ -5,7 +5,7 @@
  * Finally, rehydrate the extrinsic and submit it.
  */
 
-import { Balances, chain, createUsers } from "@capi/westend-dev/mod.js"
+import { Balances, chain, createUsers } from "@capi/westend-dev"
 import { $, SignedExtrinsicRune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 

--- a/examples/sign/pjs.eg.ts
+++ b/examples/sign/pjs.eg.ts
@@ -5,7 +5,7 @@
  * extension) to sign a Capi extrinsic.
  */
 
-import { Balances, chain, createUsers, System } from "@capi/polkadot-dev/mod.js"
+import { Balances, chain, createUsers, System } from "@capi/polkadot-dev"
 import { ss58 } from "capi"
 import { pjsSender, PjsSigner } from "capi/patterns/compat/pjs_sender.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/tx/balances_transfer.eg.ts
+++ b/examples/tx/balances_transfer.eg.ts
@@ -4,7 +4,7 @@
  * @description Transfer some funds from one user to another.
  */
 
-import { Balances, createUsers, System } from "@capi/westend-dev/mod.js"
+import { Balances, createUsers, System } from "@capi/westend-dev"
 import { assert } from "asserts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 

--- a/examples/tx/handle_errors.eg.ts
+++ b/examples/tx/handle_errors.eg.ts
@@ -5,7 +5,7 @@
  * easy decoding (and handling) of dispatch errors.
  */
 
-import { Balances } from "@capi/contracts-dev/mod.js"
+import { Balances } from "@capi/contracts-dev"
 import { assertInstanceOf } from "asserts"
 import { alice, bob, ExtrinsicError } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/tx/utility_batch.eg.ts
+++ b/examples/tx/utility_batch.eg.ts
@@ -4,7 +4,7 @@
  * @description Sign and submit multiple calls within a single extrinsic.
  */
 
-import { Balances, createUsers, System, Utility } from "@capi/westend-dev/mod.js"
+import { Balances, createUsers, System, Utility } from "@capi/westend-dev"
 import { assert } from "asserts"
 import { Rune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/watch.eg.ts
+++ b/examples/watch.eg.ts
@@ -6,7 +6,7 @@
  * produce promises resolving to subsequent states.
  */
 
-import { chain, Timestamp } from "@capi/polkadot/mod.js"
+import { chain, Timestamp } from "@capi/polkadot"
 import { $ } from "capi"
 
 // Specifying `chain.latestBlockHash` indicates that (A) this Rune tree

--- a/examples/xcm/asset_teleportation.eg.ts
+++ b/examples/xcm/asset_teleportation.eg.ts
@@ -6,20 +6,23 @@
  * the new balance of the user to whom the asset was transferred.
  */
 
-import { XcmPallet } from "@capi/rococo-dev/mod.js"
-import { chain as parachain, System } from "@capi/rococo-dev/statemine/mod.js"
-import { CumulusPalletParachainSystemEvent } from "@capi/rococo-dev/statemine/types/mod.js"
-import { RuntimeEvent } from "@capi/rococo-dev/statemine/types/mod.js"
 import {
   VersionedMultiAssets,
   VersionedMultiLocation,
+  XcmPallet,
   XcmV2AssetId,
   XcmV2Fungibility,
   XcmV2Junction,
   XcmV2Junctions,
   XcmV2NetworkId,
   XcmV2WeightLimit,
-} from "@capi/rococo-dev/types/mod.js"
+} from "@capi/rococo-dev/mod.js"
+import {
+  chain as parachain,
+  CumulusPalletParachainSystemEvent,
+  RuntimeEvent,
+  System,
+} from "@capi/rococo-dev/statemine/mod.js"
 import { assert } from "asserts"
 import { alice, Rune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/examples/xcm/asset_teleportation.eg.ts
+++ b/examples/xcm/asset_teleportation.eg.ts
@@ -16,13 +16,13 @@ import {
   XcmV2Junctions,
   XcmV2NetworkId,
   XcmV2WeightLimit,
-} from "@capi/rococo-dev/mod.js"
+} from "@capi/rococo-dev"
 import {
   chain as parachain,
   CumulusPalletParachainSystemEvent,
   RuntimeEvent,
   System,
-} from "@capi/rococo-dev/statemine/mod.js"
+} from "@capi/rococo-dev/statemine"
 import { assert } from "asserts"
 import { alice, Rune } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"

--- a/fluent/ExtrinsicRune.ts
+++ b/fluent/ExtrinsicRune.ts
@@ -67,7 +67,7 @@ export class ExtrinsicRune<out C extends Chain, out U> extends PatternRune<Chain
       .call("state_call", "TransactionPaymentApi_query_info", arg)
       .map(hex.decode)
     return this.chain.metadata
-      .access("types", "sp_weights::weight_v2::Weight")
+      .access("paths", "sp_weights::weight_v2::Weight")
       .map(($c) => $.field("weight", $c))
       .into(CodecRune)
       .decoded(data)

--- a/fluent/ExtrinsicRune.ts
+++ b/fluent/ExtrinsicRune.ts
@@ -67,7 +67,7 @@ export class ExtrinsicRune<out C extends Chain, out U> extends PatternRune<Chain
       .call("state_call", "TransactionPaymentApi_query_info", arg)
       .map(hex.decode)
     return this.chain.metadata
-      .access("types", "sp_weights.weight_v2.Weight")
+      .access("types", "sp_weights::weight_v2::Weight")
       .map(($c) => $.field("weight", $c))
       .into(CodecRune)
       .decoded(data)

--- a/frame_metadata/FrameMetadata.ts
+++ b/frame_metadata/FrameMetadata.ts
@@ -2,6 +2,7 @@ import * as $ from "../deps/scale.ts"
 
 export interface FrameMetadata {
   types: Record<string, $.AnyCodec>
+  paths: Record<string, $.AnyCodec>
   pallets: Record<string, Pallet>
   extrinsic: {
     call: $.AnyCodec

--- a/frame_metadata/raw/v14.ts
+++ b/frame_metadata/raw/v14.ts
@@ -106,9 +106,9 @@ export const $metadata = $.object(
 )
 
 export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMetadata {
-  const [types, paths] = transformTys(metadata.tys)
+  const [types, names] = transformTys(metadata.tys)
   return {
-    types: paths,
+    types: names,
     pallets: Object.fromEntries(metadata.pallets.map((pallet): [string, Pallet] => [pallet.name, {
       id: pallet.id,
       name: pallet.name,

--- a/frame_metadata/raw/v14.ts
+++ b/frame_metadata/raw/v14.ts
@@ -106,9 +106,10 @@ export const $metadata = $.object(
 )
 
 export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMetadata {
-  const [types, names] = transformTys(metadata.tys)
+  const { ids, types, paths } = transformTys(metadata.tys)
   return {
-    types: names,
+    types,
+    paths,
     pallets: Object.fromEntries(metadata.pallets.map((pallet): [string, Pallet] => [pallet.name, {
       id: pallet.id,
       name: pallet.name,
@@ -120,10 +121,10 @@ export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMe
             key = $emptyKey
             partialKey = $partialEmptyKey
           } else if (storage.hashers.length === 1) {
-            key = hashers[storage.hashers[0]!].$hash(types[storage.key]!)
+            key = hashers[storage.hashers[0]!].$hash(ids[storage.key]!)
             partialKey = $partialSingleKey(key)
           } else {
-            const codecs = extractTupleMembersVisitor.visit(types[storage.key]!).map((codec, i) =>
+            const codecs = extractTupleMembersVisitor.visit(ids[storage.key]!).map((codec, i) =>
               hashers[storage.hashers[i]!].$hash(codec)
             )
             key = $.tuple(...codecs)
@@ -134,7 +135,7 @@ export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMe
             name: storage.name,
             key: $storageKey(pallet.name, storage.name, key),
             partialKey: $storageKey(pallet.name, storage.name, partialKey),
-            value: types[storage.value]!,
+            value: ids[storage.value]!,
             docs: normalizeDocs(storage.docs),
             default: storage.modifier === "Default" ? storage.default : undefined,
           }]
@@ -143,15 +144,15 @@ export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMe
       constants: Object.fromEntries(
         pallet.constants.map((constant): [string, Constant] => [constant.name, {
           name: constant.name,
-          codec: types[constant.ty]!,
+          codec: ids[constant.ty]!,
           value: constant.value,
           docs: normalizeDocs(constant.docs),
         }]),
       ),
       types: {
-        call: types[pallet.calls!],
-        error: types[pallet.error!],
-        event: types[pallet.event!],
+        call: ids[pallet.calls!],
+        error: ids[pallet.error!],
+        event: ids[pallet.event!],
       },
       docs: "",
     }])),
@@ -164,13 +165,13 @@ export function transformMetadata(metadata: $.Native<typeof $metadata>): FrameMe
     },
   }
   function getExtrinsicParameter(key: "call" | "signature" | "address") {
-    return types[
+    return ids[
       metadata.tys[metadata.extrinsic.ty]!.params.find((x) => x.name.toLowerCase() === key)!.ty!
     ]!
   }
   function getExtensionsCodec(key: "ty" | "additionalSigned") {
     return $.object(...metadata.extrinsic.signedExtensions.flatMap((ext) => {
-      const codec = types[ext[key]]!
+      const codec = ids[ext[key]]!
       if (codec === $null) return []
       return [$.field(normalizeIdent(ext.ident), codec)]
     }))

--- a/patterns/consensus/babeBlockAuthor.ts
+++ b/patterns/consensus/babeBlockAuthor.ts
@@ -1,4 +1,4 @@
-import { $preDigest } from "@capi/polkadot/types/mod.js"
+import { $preDigest } from "@capi/polkadot/mod.js"
 import { AddressPrefixChain, ChainRune } from "../../fluent/mod.ts"
 import { AccountIdRune } from "../../fluent/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/consensus/babeBlockAuthor.ts
+++ b/patterns/consensus/babeBlockAuthor.ts
@@ -1,4 +1,4 @@
-import { $preDigest } from "@capi/polkadot/types/sp_consensus_babe/digests.js"
+import { $preDigest } from "@capi/polkadot/types/mod.js"
 import { AddressPrefixChain, ChainRune } from "../../fluent/mod.ts"
 import { AccountIdRune } from "../../fluent/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/consensus/babeBlockAuthor.ts
+++ b/patterns/consensus/babeBlockAuthor.ts
@@ -1,4 +1,4 @@
-import { $preDigest } from "@capi/polkadot/mod.js"
+import { $preDigest } from "@capi/polkadot"
 import { AddressPrefixChain, ChainRune } from "../../fluent/mod.ts"
 import { AccountIdRune } from "../../fluent/mod.ts"
 import { Rune, RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/consensus/preRuntimeDigest.ts
+++ b/patterns/consensus/preRuntimeDigest.ts
@@ -1,4 +1,4 @@
-import { $digestItem, DigestItem } from "@capi/polkadot/types/mod.js"
+import { $digestItem, DigestItem } from "@capi/polkadot/mod.js"
 import { hex } from "../../crypto/mod.ts"
 import { Chain, ChainRune } from "../../fluent/mod.ts"
 import { RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/consensus/preRuntimeDigest.ts
+++ b/patterns/consensus/preRuntimeDigest.ts
@@ -1,4 +1,4 @@
-import { $digestItem, DigestItem } from "@capi/polkadot/types/sp_runtime/generic/digest.js"
+import { $digestItem, DigestItem } from "@capi/polkadot/types/mod.js"
 import { hex } from "../../crypto/mod.ts"
 import { Chain, ChainRune } from "../../fluent/mod.ts"
 import { RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/consensus/preRuntimeDigest.ts
+++ b/patterns/consensus/preRuntimeDigest.ts
@@ -1,4 +1,4 @@
-import { $digestItem, DigestItem } from "@capi/polkadot/mod.js"
+import { $digestItem, DigestItem } from "@capi/polkadot"
 import { hex } from "../../crypto/mod.ts"
 import { Chain, ChainRune } from "../../fluent/mod.ts"
 import { RunicArgs, ValueRune } from "../../rune/mod.ts"

--- a/patterns/identity.ts
+++ b/patterns/identity.ts
@@ -1,4 +1,4 @@
-import { Data, type IdentityInfo } from "@capi/polkadot-dev/types/mod.js"
+import { Data, type IdentityInfo } from "@capi/polkadot-dev/mod.js"
 import * as $ from "../deps/scale.ts"
 import { Rune, RunicArgs } from "../rune/mod.ts"
 

--- a/patterns/identity.ts
+++ b/patterns/identity.ts
@@ -1,4 +1,4 @@
-import { Data, type IdentityInfo } from "@capi/polkadot-dev/mod.js"
+import { Data, type IdentityInfo } from "@capi/polkadot-dev"
 import * as $ from "../deps/scale.ts"
 import { Rune, RunicArgs } from "../rune/mod.ts"
 

--- a/patterns/identity.ts
+++ b/patterns/identity.ts
@@ -1,4 +1,4 @@
-import { Data, type IdentityInfo } from "@capi/polkadot-dev/types/pallet_identity/types.js"
+import { Data, type IdentityInfo } from "@capi/polkadot-dev/types/mod.js"
 import * as $ from "../deps/scale.ts"
 import { Rune, RunicArgs } from "../rune/mod.ts"
 

--- a/patterns/ink/InkMetadataRune.ts
+++ b/patterns/ink/InkMetadataRune.ts
@@ -37,7 +37,7 @@ export class InkMetadataRune<out U> extends Rune<InkMetadata, U> {
     .into(ValueRune)
     .access("types")
     .map(transformTys)
-    .access(0)
+    .access("ids")
 
   $event = Rune
     .tuple([

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/mod.js"
+import { MultiAddress } from "@capi/polkadot/mod.js"
 import * as bytes from "../../deps/std/bytes.ts"
 import { $, Chain, ChainRune, PatternRune, Rune, RunicArgs, ValueRune } from "../../mod.ts"
 import { multisigAccountId } from "./multisigAccountId.ts"

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/mod.js"
+import { MultiAddress } from "@capi/polkadot"
 import * as bytes from "../../deps/std/bytes.ts"
 import { $, Chain, ChainRune, PatternRune, Rune, RunicArgs, ValueRune } from "../../mod.ts"
 import { multisigAccountId } from "./multisigAccountId.ts"

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/sp_runtime/multiaddress.js"
+import { MultiAddress } from "@capi/polkadot/types/mod.js"
 import * as bytes from "../../deps/std/bytes.ts"
 import { $, Chain, ChainRune, PatternRune, Rune, RunicArgs, ValueRune } from "../../mod.ts"
 import { multisigAccountId } from "./multisigAccountId.ts"

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/sp_runtime/multiaddress.js"
+import { MultiAddress } from "@capi/polkadot/types/mod.js"
 import { equals } from "../../deps/std/bytes.ts"
 import {
   $,

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/mod.js"
+import { MultiAddress } from "@capi/polkadot/mod.js"
 import { equals } from "../../deps/std/bytes.ts"
 import {
   $,

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/mod.js"
+import { MultiAddress } from "@capi/polkadot"
 import { equals } from "../../deps/std/bytes.ts"
 import {
   $,

--- a/patterns/proxy/events.ts
+++ b/patterns/proxy/events.ts
@@ -1,4 +1,4 @@
-import { PalletProxyEvent, RuntimeEvent } from "@capi/polkadot/mod.js"
+import { PalletProxyEvent, RuntimeEvent } from "@capi/polkadot"
 import { Rune, RunicArgs } from "../../mod.ts"
 
 export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [any[]]>) {

--- a/patterns/proxy/events.ts
+++ b/patterns/proxy/events.ts
@@ -1,5 +1,4 @@
-import { type Event as ProxyEvent } from "@capi/polkadot/types/pallet_proxy/pallet.js"
-import { type RuntimeEvent } from "@capi/polkadot/types/polkadot_runtime.js"
+import { PalletProxyEvent, RuntimeEvent } from "@capi/polkadot/types/mod.js"
 import { Rune, RunicArgs } from "../../mod.ts"
 
 export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [any[]]>) {
@@ -8,6 +7,6 @@ export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [any[]]>) {
       .map((e) => e.event)
       .filter((event): event is RuntimeEvent.Proxy => event.type === "Proxy")
       .map((e) => e.value)
-      .filter((event): event is ProxyEvent.PureCreated => event.type === "PureCreated")
+      .filter((event): event is PalletProxyEvent.PureCreated => event.type === "PureCreated")
   )
 }

--- a/patterns/proxy/events.ts
+++ b/patterns/proxy/events.ts
@@ -1,4 +1,4 @@
-import { PalletProxyEvent, RuntimeEvent } from "@capi/polkadot/types/mod.js"
+import { PalletProxyEvent, RuntimeEvent } from "@capi/polkadot/mod.js"
 import { Rune, RunicArgs } from "../../mod.ts"
 
 export function filterPureCreatedEvents<X>(...[events]: RunicArgs<X, [any[]]>) {

--- a/patterns/proxy/replaceDelegateCalls.ts
+++ b/patterns/proxy/replaceDelegateCalls.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/mod.js"
+import { MultiAddress } from "@capi/polkadot"
 import { Chain, ChainRune, Rune, RunicArgs } from "../../mod.ts"
 
 // TODO: constrain

--- a/patterns/proxy/replaceDelegateCalls.ts
+++ b/patterns/proxy/replaceDelegateCalls.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/mod.js"
+import { MultiAddress } from "@capi/polkadot/mod.js"
 import { Chain, ChainRune, Rune, RunicArgs } from "../../mod.ts"
 
 // TODO: constrain

--- a/patterns/proxy/replaceDelegateCalls.ts
+++ b/patterns/proxy/replaceDelegateCalls.ts
@@ -1,4 +1,4 @@
-import { MultiAddress } from "@capi/polkadot/types/sp_runtime/multiaddress.js"
+import { MultiAddress } from "@capi/polkadot/types/mod.js"
 import { Chain, ChainRune, Rune, RunicArgs } from "../../mod.ts"
 
 // TODO: constrain

--- a/patterns/signature/polkadot.ts
+++ b/patterns/signature/polkadot.ts
@@ -1,4 +1,4 @@
-import { Polkadot } from "@capi/polkadot/mod.js"
+import { Polkadot } from "@capi/polkadot"
 import { AddressPrefixChain, Chain, ChainRune } from "../../fluent/ChainRune.ts"
 import { ExtrinsicSender, SignatureData } from "../../fluent/ExtrinsicRune.ts"
 import { $, hex, ss58, ValueRune } from "../../mod.ts"

--- a/scale_info/transformTys.ts
+++ b/scale_info/transformTys.ts
@@ -1,7 +1,7 @@
 import * as $ from "../deps/scale.ts"
 import { Codec } from "../deps/scale.ts"
 import { getOrInit } from "../util/mod.ts"
-import { normalizeDocs, normalizeIdent } from "../util/normalize.ts"
+import { normalizeDocs, normalizeIdent, normalizeTypeName } from "../util/normalize.ts"
 import { overrides } from "./overrides/mod.ts"
 import { $field, Ty } from "./raw/Ty.ts"
 
@@ -50,8 +50,12 @@ export function transformTys(tys: Ty[]): [Codec<any>[], Record<string, Codec<any
     const name = parts.at(-1)!
     const map = nameCounts.get(name)!
     const pathLength = parts.findIndex((_, i) => map.get(parts.slice(0, i).join(".")) === 1)
-    remappedPaths.set(path, [...parts.slice(0, pathLength), name].join("."))
+    const newPath = [...parts.slice(0, pathLength), name].join(".")
+    const newName = normalizeTypeName(newPath)
+    remappedPaths.set(path, newName)
   }
+
+  paths["_._"] = $null
 
   return [tys.map((_, i) => visit(i)), paths]
 

--- a/server/codegenHandler.ts
+++ b/server/codegenHandler.ts
@@ -98,8 +98,11 @@ export function createCodegenHandler(dataCache: CacheBase, tempCache: CacheBase)
 
           let match: [string, CodegenEntry] | undefined = undefined
           for (const [key, value] of codegenSpec.codegen) {
+            if (path === `/${key}`) {
+              return `export * from "./${key.split("/").at(-1)!}/mod.js"`
+            }
             if (
-              path.startsWith(`/${key}/`)
+              (path === `/${key}` || path.startsWith(`/${key}/`))
               && key.length >= (match?.[0].length ?? 0)
             ) {
               match = [key, value]


### PR DESCRIPTION
- Resolves #864
- Resolves #849

This exposes all types from the codegen root sans namespaces. When type names conflict, relevant module sections are prepended to disambiguate (e.g. `PalletBalancesEvent` and `XcmV2Junctions`).

Additionally, this makes `@capi/foo` an alias for `@capi/foo/mod.js`, so we can use the same import paths for both deno and node.

