### PR TITLE
feat: destructure Rune

### DIFF
--- a/rune/Rune.ts
+++ b/rune/Rune.ts
@@ -40,10 +40,13 @@ export class Batch {
 
 declare const _T: unique symbol
 declare const _U: unique symbol
+declare const _objectSpread: unique symbol
+declare const _arraySpread: unique symbol
 
 export namespace Rune {
   export type T<R> = R extends { [_T]: infer T } ? T : R
   export type U<R> = R extends { [_U]: infer U } ? U : never
+  export type Destructure<R, T, U> = { [K in keyof T]: Rune<T[K], U> }
 }
 
 export interface Rune<out T, out U = never> {
@@ -124,6 +127,31 @@ export class Rune<out T, out U = never> {
 
   static fn<A extends any[], T, X>(...[fn]: RunicArgs<X, [(...args: A) => T]>) {
     return Rune.resolve(fn).into(FnRune)
+  }
+
+  static access<T extends Record<any, any> | any[], U>(
+    rune: ValueRune<T, U>,
+  ): Rune.Destructure<ValueRune<T, U>, T, U> {
+    const obj = new Proxy(
+      rune as any,
+      {
+        get(obj, prop) {
+          if (obj[prop]) return obj[prop]
+          if (prop == Symbol.iterator) {
+            return function*() {
+              let i = 0
+              while (true) {
+                yield rune.access(i)
+                i++
+              }
+            }
+          }
+          return rune.access(prop as keyof T)
+        },
+      },
+    )
+
+    return obj
   }
 
   static rec<R extends {}>(


### PR DESCRIPTION
Adds `static Rune.access()` and `valueRune.access()` 

We should document that this makes use of a proxy, so trying to use `Object.values` or a `for of` loop on the returned values would break

```ts
// rec: ValueRune<{ a: number, b: number, c: number }, never>
const rec = Rune.rec({ a: 1, b: 2, c: 3 })
// rec: ValueRune<[number, number, number], never>
const tuple = Rune.tuple([1, 2, 3])

// { a: Rune<number, never>, b: Rune<number, never>, c: Rune<number, never> }
const { a, b, c } = Rune.access(rec)
// [ Rune<number, never>, Rune<number, never>, Rune<number, never> ]
const [d, e, f] = tuple.access()
```

Empty `valueRune.access()` doesn't break `valueRune.access(...keys)` typechecking, even with `any` or `unknown` type:
```ts
declare const x: ValueRune<any, never>

// prop: ValueRune<any, never>
const prop = x.access("anyProp")

// obj: Rune.Destructure<any, never> (type alias for `{ [K in keyof T]: Rune<T[K], U> }`)
const obj = x.access()

// a: Rune<any, never> | undefined (can't get rid of `undefined` since it's a `{ [P in keyof any] }`)
const { y } = x.access()
```

---

I was wondering, we could probably also have this function return something that's a mix of a rune *and* the underlying object with its properties, maybe a DestructuredRune that uses a proxy to retrieve specific props but also has functions such as `.length` (for arrays) `.keys` (for records) which would return `Rune<value>` instead of plain values (like the underlying object does). I think it could work really nicely, even replace `.access(...keys)` as a whole, but we'd need to rethink how we interact with rune values.