### PR TITLE
fix: generated para name

### DIFF
--- a/devnets/syncConfig.ts
+++ b/devnets/syncConfig.ts
@@ -42,7 +42,7 @@ export async function syncConfig(tempDir: string, config: CapiConfig) {
                 {
                   type: "frame",
                   metadata: metadata,
-                  chainName: normalizeTypeName(name),
+                  chainName: normalizeTypeName(paraName ?? name),
                   connection: {
                     type: "DevnetConnection",
                     discovery: name + (paraName ? `/${paraName}` : ""),

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@capi/": "http://localhost:4646/5a2452ab3d4473be/"
+    "@capi/": "http://localhost:4646/83c55703f1c9f367/"
   },
   "scopes": {
     "examples/": {


### PR DESCRIPTION
Before, was incorrect / reflected the relay chain name.

```diff
- import { RococoDev } from "@capi/rococo-dev/statemine"
+ import { Statemine } from "@capi/rococo-dev/statemine"
```