### PR TITLE
fix: misc. smoldot cleanup

### DIFF
--- a/.trunignore
+++ b/.trunignore
@@ -1,3 +1,2 @@
 examples/xcm/asset_teleportation.eg.ts
-examples/smoldot.eg.ts
 examples/ink/*.eg.ts

--- a/examples/smoldot.eg.ts
+++ b/examples/smoldot.eg.ts
@@ -6,7 +6,10 @@
  * a centralized intermediary. This is the future of unstoppable applications.
  */
 
-import { $, $extrinsic, ChainRune, Rune, SmoldotConnection } from "capi"
+import { $accountInfo, chain, createUsers } from "@capi/polkadot-dev"
+import { $, SmoldotConnection } from "capi"
+
+const { alexa } = await createUsers()
 
 // Bring the chainspec(s) into scope. Here, we'll fetch it from the Smoldot GitHub repository.
 const relayChainSpec = await (await fetch(
@@ -14,14 +17,13 @@ const relayChainSpec = await (await fetch(
 )).text()
 
 // Initialize a `ChainRune` with `SmoldotConnection` and the chainspec.
-const smoldotChain = ChainRune.from(SmoldotConnection.bind({ relayChainSpec }))
+const smoldotChain = chain.with(SmoldotConnection.bind({ relayChainSpec }))
 
-const [metadata, extrinsics] = await Rune
-  .tuple([
-    smoldotChain.metadata,
-    smoldotChain.blockHash().block().extrinsics(),
-  ])
+const accountInfo = await smoldotChain
+  .pallet("System")
+  .storage("Account")
+  .value(alexa.publicKey)
   .run()
 
-console.log("Extrinsics:", extrinsics)
-$.assert($.array($extrinsic(metadata)), extrinsics)
+console.log("Account info:", accountInfo)
+$.assert($accountInfo, accountInfo)

--- a/examples/smoldot.eg.ts
+++ b/examples/smoldot.eg.ts
@@ -6,10 +6,8 @@
  * a centralized intermediary. This is the future of unstoppable applications.
  */
 
-import { $accountInfo, chain, createUsers } from "@capi/polkadot-dev"
-import { $, SmoldotConnection } from "capi"
-
-const { alexa } = await createUsers()
+import { chain } from "@capi/polkadot-dev"
+import { $, known, SmoldotConnection } from "capi"
 
 // Bring the chainspec(s) into scope. Here, we'll fetch it from the Smoldot GitHub repository.
 const relayChainSpec = await (await fetch(
@@ -17,13 +15,11 @@ const relayChainSpec = await (await fetch(
 )).text()
 
 // Initialize a `ChainRune` with `SmoldotConnection` and the chainspec.
-const smoldotChain = chain.with(SmoldotConnection.bind({ relayChainSpec }))
-
-const accountInfo = await smoldotChain
-  .pallet("System")
-  .storage("Account")
-  .value(alexa.publicKey)
+const block = await chain
+  .with(SmoldotConnection.bind({ relayChainSpec }))
+  .blockHash()
+  .block()
   .run()
 
-console.log("Account info:", accountInfo)
-$.assert($accountInfo, accountInfo)
+console.log(block)
+$.assert(known.$block, block.block)

--- a/examples/smoldot.eg.ts
+++ b/examples/smoldot.eg.ts
@@ -10,16 +10,17 @@ import { chain } from "@capi/polkadot-dev"
 import { $, known, SmoldotConnection } from "capi"
 
 // Bring the chainspec(s) into scope. Here, we'll fetch it from the Smoldot GitHub repository.
-const relayChainSpec = await (await fetch(
+const relayChainSpec = await fetch(
   `https://raw.githubusercontent.com/smol-dot/smoldot/main/demo-chain-specs/polkadot.json`,
-)).text()
+).then((r) => r.text())
 
 // Initialize a `ChainRune` with `SmoldotConnection` and the chainspec.
-const block = await chain
+const { block } = await chain
   .with(SmoldotConnection.bind({ relayChainSpec }))
   .blockHash()
   .block()
   .run()
 
+// Ensure the block is of the expected shape.
 console.log(block)
-$.assert(known.$block, block.block)
+$.assert(known.$block, block)

--- a/fluent/ChainRune.ts
+++ b/fluent/ChainRune.ts
@@ -65,7 +65,7 @@ export class ChainRune<out C extends Chain, out U> extends Rune<C, U> {
 
   with(connect: (signal: AbortSignal) => Connection) {
     const connection = ConnectionRune.from(connect)
-    return Rune.rec({ connection, metadata: this.metadata } as C).into(ChainRune)
+    return Rune.rec({ connection, metadata: this.metadata }).into(ChainRune) as ChainRune<C, U>
   }
 
   connection = this.into(ValueRune<Chain, U>).access("connection").into(ConnectionRune)

--- a/fluent/ChainRune.ts
+++ b/fluent/ChainRune.ts
@@ -63,6 +63,11 @@ export class ChainRune<out C extends Chain, out U> extends Rune<C, U> {
     return Rune.rec({ connection, metadata }).into(this)
   }
 
+  with(connect: (signal: AbortSignal) => Connection) {
+    const connection = ConnectionRune.from(connect)
+    return Rune.rec({ connection, metadata: this.metadata }).into(ChainRune)
+  }
+
   connection = this.into(ValueRune<Chain, U>).access("connection").into(ConnectionRune)
 
   metadata = this.into(ValueRune).access("metadata")

--- a/fluent/ChainRune.ts
+++ b/fluent/ChainRune.ts
@@ -65,7 +65,7 @@ export class ChainRune<out C extends Chain, out U> extends Rune<C, U> {
 
   with(connect: (signal: AbortSignal) => Connection) {
     const connection = ConnectionRune.from(connect)
-    return Rune.rec({ connection, metadata: this.metadata }).into(ChainRune)
+    return Rune.rec({ connection, metadata: this.metadata } as C).into(ChainRune)
   }
 
   connection = this.into(ValueRune<Chain, U>).access("connection").into(ConnectionRune)

--- a/fluent/StorageRune.ts
+++ b/fluent/StorageRune.ts
@@ -22,7 +22,7 @@ export class StorageRune<
       blockHash?: string,
     ]>
   ) {
-    const storageKey = this.$key.encoded(key).map(hex.encode)
+    const storageKey = this.$key.encoded(key).map(hex.encodePrefixed)
     return this.chain.connection
       .call("state_getStorage", storageKey, blockHash)
       .unhandle(null)
@@ -48,7 +48,11 @@ export class StorageRune<
     ]>
   ) {
     return this.chain.connection
-      .call("state_getStorageSize", this.$partialKey.encoded(partialKey).map(hex.encode), blockHash)
+      .call(
+        "state_getStorageSize",
+        this.$partialKey.encoded(partialKey).map(hex.encodePrefixed),
+        blockHash,
+      )
       .unhandle(null)
       .rehandle(null, () => Rune.constant(undefined))
   }
@@ -102,10 +106,10 @@ export class StorageRune<
       blockHash?: string,
     ]>
   ) {
-    const storageKey = this.$partialKey.encoded(partialKey).map(hex.encode)
+    const storageKey = this.$partialKey.encoded(partialKey).map(hex.encodePrefixed)
     const startKey = this.$key
       .encoded(Rune.resolve(start).unhandle(undefined))
-      .map(hex.encode)
+      .map(hex.encodePrefixed)
       .rehandle(undefined)
     return this.chain.connection.call("state_getKeysPaged", storageKey, count, startKey, blockHash)
   }

--- a/rpc/smoldot.ts
+++ b/rpc/smoldot.ts
@@ -8,6 +8,7 @@ import { RpcEgressMessage } from "./rpc_messages.ts"
 export interface SmoldotRpcConnProps {
   relayChainSpec: string
   parachainSpec?: string
+  maxLogLevel?: number
 }
 
 let client: undefined | Client
@@ -29,6 +30,7 @@ export class SmoldotConnection extends Connection {
         forbidTcp: true,
         forbidNonLocalWs: true,
         cpuRateLimit: .25,
+        maxLogLevel: props.maxLogLevel,
       } as ClientOptions)
     }
     if (props.parachainSpec) {

--- a/rpc/smoldot.ts
+++ b/rpc/smoldot.ts
@@ -19,12 +19,10 @@ export class SmoldotConnection extends Connection {
   private smoldotChainPending
   listening
   stopListening
-  chainsCount
 
   constructor(readonly props: SmoldotRpcConnProps) {
     super()
-    this.chainsCount = props.parachainSpec ? 2 : 1
-    count += this.chainsCount
+    count++
     if (!client) {
       client = start({
         forbidTcp: true,
@@ -77,7 +75,7 @@ export class SmoldotConnection extends Connection {
   close() {
     this.stopListening()
     this.smoldotChainPending.then((chain) => {
-      count -= this.chainsCount
+      count--
       chain.remove()
       if (!count) {
         client?.terminate()


### PR DESCRIPTION
Fixes #865
Closes #871

- enable one to override a codegened `ChainRune` with a smoldot connection using the `with` method
- reference counting chain count for graceful smoldot exit
- use `hex.encodePrefixed` instead of `hex.encode` (otherwise, smoldot storage retrievals throw)