### PR TITLE
feat: configure devnet validators

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,7 +60,7 @@ jobs:
       - run: deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts || deno cache target/star.ts
       - name: Archive target
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: cache-target
           path: target
@@ -77,7 +77,7 @@ jobs:
       - run: deno task sync --check
       - name: Archive target
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: sync-target
           path: target
@@ -119,6 +119,7 @@ jobs:
       - run: deno task test
 
   examples-deno:
+    if: false
     name: Examples (Deno)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -136,7 +137,7 @@ jobs:
       - run: deno task test:examples:deno
       - name: Archive target
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: failure() || cancelled()
         with:
           name: examples-deno-target
           path: target

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,7 +119,6 @@ jobs:
       - run: deno task test
 
   examples-deno:
-    if: false
     name: Examples (Deno)
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/devnets/chainSpec.ts
+++ b/devnets/chainSpec.ts
@@ -50,7 +50,17 @@ export interface ChainSpec {
   }
 }
 
-interface GenesisConfig {
+interface SessionKey {
+  grandpa: string
+  babe: string
+  im_online: string
+  para_validator: string
+  para_assignment: string
+  authority_discovery: string
+  beefy: string
+}
+
+export interface GenesisConfig {
   runtime_genesis_config?: never
   paras: {
     paras: [
@@ -65,5 +75,8 @@ interface GenesisConfig {
   }
   balances: {
     balances: [account: string, initialBalance: number][]
+  }
+  session?: {
+    keys: [account: string, account: string, key: SessionKey][]
   }
 }

--- a/devnets/startNetwork.ts
+++ b/devnets/startNetwork.ts
@@ -221,6 +221,7 @@ const authorities = [
     srAccount: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
     srStash: "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
     edAccount: "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu",
+    // cspell:disable-next-line
     ecAccount: "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
   },
   {
@@ -228,6 +229,7 @@ const authorities = [
     srAccount: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
     srStash: "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc",
     edAccount: "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E",
+    // cspell:disable-next-line
     ecAccount: "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
   },
   {
@@ -235,6 +237,7 @@ const authorities = [
     srAccount: "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
     srStash: "5Ck5SLSHYac6WFt5UZRSsdJjwmpSZq85fd5TRNAdZQVzEAPT",
     edAccount: "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6",
+    // cspell:disable-next-line
     ecAccount: "KWBpGtyJLBkJERdZT1a1uu19c2uPpZm9nFd8SGtCfRUAT3Y4w",
   },
   {
@@ -242,6 +245,7 @@ const authorities = [
     srAccount: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
     srStash: "5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8",
     edAccount: "5ECTwv6cZ5nJQPk6tWfaTrEk8YH2L7X1VT4EL5Tx2ikfFwb7",
+    // cspell:disable-next-line
     ecAccount: "KWCycezxoy7MWTTqA5JDKxJbqVMiNfqThKFhb5dTfsbNaGbrW",
   },
   {
@@ -249,6 +253,7 @@ const authorities = [
     srAccount: "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",
     srStash: "5FCfAonRZgTFrTd9HREEyeJjDpT397KMzizE6T3DvebLFE7n",
     edAccount: "5Ck2miBfCe1JQ4cY3NDsXyBaD6EcsgiVmEFTWwqNSs25XDEq",
+    // cspell:disable-next-line
     ecAccount: "KW9NRAHXUXhBnu3j1AGzUXs2AuiEPCSjYe8oGan44nwvH5qKp",
   },
   {
@@ -256,6 +261,7 @@ const authorities = [
     srAccount: "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",
     srStash: "5CRmqmsiNFExV6VbdmPJViVxrWmkaXXvBrSX8oqBT8R9vmWk",
     edAccount: "5E2BmpVFzYGd386XRCZ76cDePMB3sfbZp5ZKGUsrG1m6gomN",
+    // cspell:disable-next-line
     ecAccount: "KW6E1KGr5pqJ9Trgt7eAuA7d7mgpJPydiEDKc2h1aGTEEzYC1",
   },
 ] as const
@@ -263,7 +269,8 @@ function addAuthorities(genesisConfig: GenesisConfig, count: number) {
   if (count > authorities.length) {
     throw new Error(`authorities count should be <= ${authorities.length}`)
   }
-  if (!genesisConfig.session) throw new Error(`pallet_session is not configured`)
+  // TODO: #889 add support for pallet_session, pallet_aura and pallet_grandpa
+  if (!genesisConfig.session) return
   genesisConfig.session.keys.length = 0
   authorities.slice(0, count).forEach(({ srAccount, srStash, edAccount, ecAccount }) =>
     genesisConfig.session!.keys.push([

--- a/devnets/startNetwork.ts
+++ b/devnets/startNetwork.ts
@@ -218,45 +218,45 @@ async function spawnNode(tempDir: string, binary: string, args: string[], signal
 const authorities = [
   {
     name: "alice",
-    sr_account: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-    sr_stash: "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
-    ed_account: "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu",
-    ec_account: "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
+    srAccount: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    srStash: "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
+    edAccount: "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu",
+    ecAccount: "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
   },
   {
     name: "bob",
-    sr_account: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    sr_stash: "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc",
-    ed_account: "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E",
-    ec_account: "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
+    srAccount: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+    srStash: "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc",
+    edAccount: "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E",
+    ecAccount: "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
   },
   {
     name: "charlie",
-    sr_account: "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-    sr_stash: "5Ck5SLSHYac6WFt5UZRSsdJjwmpSZq85fd5TRNAdZQVzEAPT",
-    ed_account: "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6",
-    ec_account: "KWBpGtyJLBkJERdZT1a1uu19c2uPpZm9nFd8SGtCfRUAT3Y4w",
+    srAccount: "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+    srStash: "5Ck5SLSHYac6WFt5UZRSsdJjwmpSZq85fd5TRNAdZQVzEAPT",
+    edAccount: "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6",
+    ecAccount: "KWBpGtyJLBkJERdZT1a1uu19c2uPpZm9nFd8SGtCfRUAT3Y4w",
   },
   {
     name: "dave",
-    sr_account: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
-    sr_stash: "5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8",
-    ed_account: "5ECTwv6cZ5nJQPk6tWfaTrEk8YH2L7X1VT4EL5Tx2ikfFwb7",
-    ec_account: "KWCycezxoy7MWTTqA5JDKxJbqVMiNfqThKFhb5dTfsbNaGbrW",
+    srAccount: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+    srStash: "5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8",
+    edAccount: "5ECTwv6cZ5nJQPk6tWfaTrEk8YH2L7X1VT4EL5Tx2ikfFwb7",
+    ecAccount: "KWCycezxoy7MWTTqA5JDKxJbqVMiNfqThKFhb5dTfsbNaGbrW",
   },
   {
     name: "eve",
-    sr_account: "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",
-    sr_stash: "5FCfAonRZgTFrTd9HREEyeJjDpT397KMzizE6T3DvebLFE7n",
-    ed_account: "5Ck2miBfCe1JQ4cY3NDsXyBaD6EcsgiVmEFTWwqNSs25XDEq",
-    ec_account: "KW9NRAHXUXhBnu3j1AGzUXs2AuiEPCSjYe8oGan44nwvH5qKp",
+    srAccount: "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",
+    srStash: "5FCfAonRZgTFrTd9HREEyeJjDpT397KMzizE6T3DvebLFE7n",
+    edAccount: "5Ck2miBfCe1JQ4cY3NDsXyBaD6EcsgiVmEFTWwqNSs25XDEq",
+    ecAccount: "KW9NRAHXUXhBnu3j1AGzUXs2AuiEPCSjYe8oGan44nwvH5qKp",
   },
   {
     name: "ferdie",
-    sr_account: "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",
-    sr_stash: "5CRmqmsiNFExV6VbdmPJViVxrWmkaXXvBrSX8oqBT8R9vmWk",
-    ed_account: "5E2BmpVFzYGd386XRCZ76cDePMB3sfbZp5ZKGUsrG1m6gomN",
-    ec_account: "KW6E1KGr5pqJ9Trgt7eAuA7d7mgpJPydiEDKc2h1aGTEEzYC1",
+    srAccount: "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",
+    srStash: "5CRmqmsiNFExV6VbdmPJViVxrWmkaXXvBrSX8oqBT8R9vmWk",
+    edAccount: "5E2BmpVFzYGd386XRCZ76cDePMB3sfbZp5ZKGUsrG1m6gomN",
+    ecAccount: "KW6E1KGr5pqJ9Trgt7eAuA7d7mgpJPydiEDKc2h1aGTEEzYC1",
   },
 ] as const
 function addAuthorities(genesisConfig: GenesisConfig, count: number) {
@@ -265,18 +265,18 @@ function addAuthorities(genesisConfig: GenesisConfig, count: number) {
   }
   if (!genesisConfig.session) throw new Error(`pallet_session is not configured`)
   genesisConfig.session.keys.length = 0
-  authorities.slice(0, count).forEach(({ sr_account, sr_stash, ed_account, ec_account }) =>
+  authorities.slice(0, count).forEach(({ srAccount, srStash, edAccount, ecAccount }) =>
     genesisConfig.session!.keys.push([
-      sr_stash,
-      sr_stash,
+      srStash,
+      srStash,
       {
-        grandpa: ed_account,
-        babe: sr_account,
-        im_online: sr_account,
-        para_validator: sr_account,
-        para_assignment: sr_account,
-        authority_discovery: sr_account,
-        beefy: ec_account,
+        grandpa: edAccount,
+        babe: srAccount,
+        im_online: srAccount,
+        para_validator: srAccount,
+        para_assignment: srAccount,
+        authority_discovery: srAccount,
+        beefy: ecAccount,
       },
     ])
   )


### PR DESCRIPTION
resolves #872 

Add support for additional validators.

This change will add support up to 6 parachains.

How to test?

```ts
import { binary, createTempDir, startNetwork } from "./devnets/mod.ts"

const controller = new AbortController()
Deno.addSignalListener("SIGINT", () => controller.abort())
Deno.addSignalListener("SIGTERM", () => controller.abort())
const polkadot = binary("polkadot", "v0.9.38")
const polkadotParachain = binary("polkadot-parachain", "v0.9.380")
const network = await startNetwork(
  await createTempDir(),
  {
    binary: polkadot,
    chain: "rococo-local",
    parachains: {
      statemine: {
        id: 1000,
        binary: polkadotParachain,
        chain: "statemine-local",
      },
      westmint: {
        id: 2000,
        binary: polkadotParachain,
        chain: "westmint-local",
      },
      contracts: {
        id: 3000,
        binary: polkadotParachain,
        chain: "contracts-rococo-local",
      },
    },
  },
  controller.signal,
)

console.log(network)
