### PR TITLE
fix: typegen typo

### DIFF
--- a/codegen/TypeCodegen.ts
+++ b/codegen/TypeCodegen.ts
@@ -154,7 +154,7 @@ ${
         ? `export type ${name} = ${this.nativeVisitor.visit(_codec)}
 export function ${name}<X>(fields: C.RunicArgs<X, ${name}>): C.ValueRune<${name}, C.RunicArgs.U<X>>`
         : `export function ${name}(fields) {
-  return Rune.object(fields)
+  return C.Rune.object(fields)
 }`
     }`)
     .add($.tuple, (_codec, ..._element) => (name, isTypes) =>


### PR DESCRIPTION
Used `Rune.object` without the leading `C.` in codegen.

Not sure why #893's CI didn't fail

**EDIT**:

Didn't error bc the XCM example (the only example which currently makes use of the factories) is ignored. Given that this is a runtime error and it's never run, slipped by CI.