### PR TITLE
chore: delete duplicate vmultisig state console log

### DIFF
--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -41,7 +41,6 @@ if (!state) {
     }, signature({ sender: alexa }))
     .hex
     .run()
-  console.log(`Virtual multisig state: ${state}`)
 }
 
 console.log("State:", state)


### PR DESCRIPTION
its always printed after the `if` statement so no need to print it twice.