### PR TITLE
fix: mutlisig rune approve

### DIFF
--- a/fluent/ChainRune.ts
+++ b/fluent/ChainRune.ts
@@ -81,6 +81,13 @@ export class ChainRune<out C extends Chain, out U> extends Rune<C, U> {
     .unsafeAs<string>()
     .into(BlockHashRune, this)
 
+  blockHashFromNumber<X>(...[blockNumber]: RunicArgs<X, [blockNumber?: string]>) {
+    return this.connection
+      .call("chain_getBlockHash", blockNumber)
+      .unsafeAs<string>()
+      .into(BlockHashRune, this)
+  }
+
   blockHash<X>(...[blockHash]: RunicArgs<X, [blockHash?: string]>) {
     return Rune
       .resolve(blockHash)

--- a/fluent/ChainRune.ts
+++ b/fluent/ChainRune.ts
@@ -81,13 +81,6 @@ export class ChainRune<out C extends Chain, out U> extends Rune<C, U> {
     .unsafeAs<string>()
     .into(BlockHashRune, this)
 
-  blockHashFromNumber<X>(...[blockNumber]: RunicArgs<X, [blockNumber?: string]>) {
-    return this.connection
-      .call("chain_getBlockHash", blockNumber)
-      .unsafeAs<string>()
-      .into(BlockHashRune, this)
-  }
-
   blockHash<X>(...[blockHash]: RunicArgs<X, [blockHash?: string]>) {
     return Rune
       .resolve(blockHash)

--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -11,6 +11,7 @@ export interface MultisigRatifyProps<C extends Chain> {
 export interface MultisigVoteProps {
   sender: MultiAddress
   callHash: Uint8Array
+  blockHash?: string
 }
 
 export interface Multisig {
@@ -61,7 +62,7 @@ export class MultisigRune<out C extends Chain, out U> extends PatternRune<Multis
     )
   }
 
-  approve<X>({ sender, callHash }: RunicArgs<X, MultisigVoteProps>) {
+  approve<X>({ sender, callHash, blockHash }: RunicArgs<X, MultisigVoteProps>) {
     return this.chain.extrinsic(
       Rune
         .object({
@@ -73,7 +74,7 @@ export class MultisigRune<out C extends Chain, out U> extends PatternRune<Multis
             otherSignatories: this.otherSignatories(sender),
             storeCall: false,
             maxWeight: { refTime: 0n, proofSize: 0n },
-            maybeTimepoint: this.maybeTimepoint(callHash),
+            maybeTimepoint: this.maybeTimepoint(callHash, blockHash),
           }),
         })
         .unsafeAs<Chain.Call<C>>(),


### PR DESCRIPTION
https://github.com/paritytech/capi/issues/906

Fixes the above issue and also adds a utility method to get block hash from block number. Can't really be tested since approvals don't count towards the mutlisig threshold count.