### PR TITLE
ci: unpin deno in examples job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@9db7f66e8e16b5699a514448ce994936c63f0d54 # v1.1.0
         with:
-          deno-version: v1.32.3
+          deno-version: v1.x
       - uses: actions/cache@v3
         with:
           path: ~/.cache/deno


### PR DESCRIPTION
https://github.com/denoland/deno/pull/18705 was released in [v1.32.5](https://github.com/denoland/deno/releases/tag/v1.32.5)

Resolves #892 