### PR TITLE
feat: update libp2p peerId derivation

### DIFF
--- a/deps/ed25519.ts
+++ b/deps/ed25519.ts
@@ -1,1 +1,1 @@
-export * from "https://esm.sh/@noble/ed25519@1.7.3"
+export * from "https://esm.sh/@noble/ed25519@2.0.0"

--- a/deps/ed25519.ts
+++ b/deps/ed25519.ts
@@ -1,0 +1,1 @@
+export * from "https://esm.sh/@noble/ed25519@1.7.3"

--- a/deps/npm/noble/ed25519.ts
+++ b/deps/npm/noble/ed25519.ts
@@ -1,0 +1,1 @@
+export * from "npm:@noble/ed25519"

--- a/deps/npm/noble/ed25519.ts
+++ b/deps/npm/noble/ed25519.ts
@@ -1,1 +1,0 @@
-export * from "npm:@noble/ed25519"

--- a/devnets/startNetwork.ts
+++ b/devnets/startNetwork.ts
@@ -174,7 +174,7 @@ async function exportParachainGenesis(
 }
 
 async function generateBootnodeString(port: number, privateKey: Uint8Array) {
-  const publicKey = await ed25519.getPublicKey(privateKey)
+  const publicKey = await ed25519.getPublicKeyAsync(privateKey)
   // Peer IDs are derived by hashing the encoded public key with multihash.
   // See https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
   // For any 32 byte ed25519 public key the first 6 bytes are always [0, 36, 8, 1, 18, 32]

--- a/devnets/startNetwork.ts
+++ b/devnets/startNetwork.ts
@@ -1,5 +1,5 @@
 import { hex } from "../crypto/mod.ts"
-import * as ed25519 from "../deps/npm/noble/ed25519.ts"
+import * as ed25519 from "../deps/ed25519.ts"
 import { Narrow } from "../deps/scale.ts"
 import * as base58 from "../deps/std/encoding/base58.ts"
 import * as path from "../deps/std/path.ts"
@@ -173,7 +173,15 @@ async function exportParachainGenesis(
   })) satisfies string[] as [state: string, wasm: string]
 }
 
-function generateBootnodeString(port: number, peerId: string) {
+async function generateBootnodeString(port: number, privateKey: Uint8Array) {
+  const publicKey = await ed25519.getPublicKey(privateKey)
+  // Peer IDs are derived by hashing the encoded public key with multihash.
+  // See https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
+  // For any 32 byte ed25519 public key the first 6 bytes are always [0, 36, 8, 1, 18, 32]
+  // PeerId = [0, 36, 8, 1, 18, 32, ...publicKey]
+  //                  -------------------------- > protobuf encoded ed25519 public key (36 bytes)
+  //           --------------------------------- > identity multihash of the protobuf encoded ed25519 public key (38 bytes)
+  const peerId = base58.encode(new Uint8Array([0, 36, 8, 1, 18, 32, ...publicKey]))
   return `/ip4/127.0.0.1/tcp/${port}/p2p/${peerId}`
 }
 
@@ -212,10 +220,9 @@ async function spawnChain(
     if (bootnodes) {
       args.push("--bootnodes", bootnodes)
     } else {
-      const nodeKey = ed25519.utils.randomPrivateKey()
-      const peerId = await getLibp2pPeerId(nodeKey)
+      const nodeKey = crypto.getRandomValues(new Uint8Array(32))
       args.push("--node-key", hex.encode(nodeKey))
-      bootnodes = generateBootnodeString(httpPort, peerId)
+      bootnodes = await generateBootnodeString(httpPort, nodeKey)
     }
     args.push(...extraArgs)
     spawnNode(nodeDir, binary, args, signal)
@@ -345,9 +352,4 @@ function addXcmHrmpChannels(
       ])
     }
   }
-}
-
-async function getLibp2pPeerId(privateKey: Uint8Array) {
-  const publicKey = await ed25519.getPublicKeyAsync(privateKey)
-  return base58.encode(new Uint8Array([0, 36, 8, 1, 18, 32, ...publicKey]))
 }

--- a/examples/sign/ed25519.eg.ts
+++ b/examples/sign/ed25519.eg.ts
@@ -8,7 +8,7 @@ import { Balances, MultiAddress, System } from "@capi/westend-dev"
 import { assert } from "asserts"
 import { createDevUsers, ExtrinsicSender } from "capi"
 import { signature } from "capi/patterns/signature/polkadot.ts"
-import * as ed from "https://esm.sh/@noble/ed25519@1.7.3"
+import * as ed from "../../deps/ed25519.ts"
 
 const { alexa, billy } = await createDevUsers()
 
@@ -24,13 +24,13 @@ console.log("Billy free initial:", billyFreeInitial)
 const secret = crypto.getRandomValues(new Uint8Array(32))
 
 /// Get a Rune of the secret-corresponding multiaddress.
-const address = MultiAddress.Id(await ed.getPublicKey(secret))
+const address = MultiAddress.Id(await ed.getPublicKeyAsync(secret))
 
 /// Define a `sign` function for later use.
 async function sign(msg: Uint8Array) {
   return {
     type: "Ed25519" as const,
-    value: await ed.sign(msg, secret),
+    value: await ed.signAsync(msg, secret),
   }
 }
 

--- a/words.txt
+++ b/words.txt
@@ -50,6 +50,7 @@ multiaddress
 multiasset
 multichain
 multilocation
+multihash
 multisigs
 multistep
 noninteractive
@@ -65,6 +66,7 @@ precommits
 preopen
 prevotes
 procps
+protobuf
 relaychain
 runtimes
 ryann

--- a/words.txt
+++ b/words.txt
@@ -38,6 +38,7 @@ inherents
 instanceof
 instantiator
 kiera
+libp
 lparachain
 ltex
 lxkf


### PR DESCRIPTION
Resolves https://github.com/paritytech/capi/issues/869

Libp2p encodes keys in a [protobuf](https://github.com/libp2p/go-libp2p/blob/master/core/crypto/pb/crypto.proto) containing a key *type* and the encoded key (where the encoding depends on the type).
Peer IDs are derived by hashing the encoded public key with [multihash](https://github.com/multiformats/multihash). Keys that serialize to more than 42 bytes must be hashed using sha256 multihash, keys that serialize to at most 42 bytes must be hashed using the "identity" multihash codec. See [docs](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#keys).

Therefore, the `peerId` is derived as follows
```
peerId = multihash(protobuf.encode(ed25519PublicKey))
```
The first 6 bytes of `[0, 36, 8, 1, 18, 32, ...publicKey]` are constant for a 32-byte ed25519 public key and it is derived from
```
// for [0, 36]
> import { identity } from 'npm:multiformats/hashes/identity'
undefined
> identity.digest(new Uint8Array(36))
Digest {
  code: 0,
  size: 36,
  digest: Uint8Array(36) [
    0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0
  ],
  bytes: Uint8Array(38) [ // this is the peerId
    0, 36, 0, 0, 0, 0, 0, 0, 0, 0,
    0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
    0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
    0,  0, 0, 0, 0, 0, 0, 0
  ]
}

// for [8, 1, 18, 32]
> import {keysPBM} from "npm:@libp2p/crypto/keys"
undefined
> keysPBM.PublicKey.encode({Type:"Ed25519",Data:new Uint8Array(32)})
Buffer(36) [ // this will be the input for identity.digest
  8, 1, 18, 32, 0, 0, 0, 0, 0,
  0, 0,  0,  0, 0, 0, 0, 0, 0,
  0, 0,  0,  0, 0, 0, 0, 0, 0,
  0, 0,  0,  0, 0, 0, 0, 0, 0
]
```
