### PR TITLE
feat: use polkadot/polkadot-parachain patched

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@capi/": "http://localhost:4646/01a459230d968c6e/"
+    "@capi/": "http://localhost:4646/c203f477e2a88c37/"
   },
   "scopes": {
     "examples/": {

--- a/nets.ts
+++ b/nets.ts
@@ -1,8 +1,8 @@
 import { bins, net } from "./mod.ts"
 
 const bin = bins({
-  polkadot: ["polkadot", "v0.9.38"],
-  polkadotParachain: ["polkadot-parachain", "v0.9.380"],
+  polkadot: ["polkadot-fast", "v0.9.38"],
+  polkadotParachain: ["polkadot-parachain-fast", "v0.9.380"],
   substrateContractsNode: ["substrate-contracts-node", "v0.24.0"],
   trappistPolkadot: ["polkadot", "v0.9.37"],
   trappistPolkadotParachain: ["polkadot-parachain", "v0.9.370"],


### PR DESCRIPTION
Companion PR https://github.com/paritytech/capi-binary-builds/pull/36

Use the `polkadot` and `polkadot-parachain` patched version with 2s and 4s block times.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/1209171/234879503-a889b5ae-05d5-4577-986e-4dc23719109f.png">

FYI, I did see an improvement in individual example runs but I did not see an improvement in the `deno task test:eg` timings.
