### PR TITLE
feat: optional stash for virtual multisig

### DIFF
--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -23,7 +23,6 @@ import { $, createDevUsers, Rune, Sr25519 } from "capi"
 import { VirtualMultisigRune } from "capi/patterns/multisig/mod.ts"
 import { signature } from "capi/patterns/signature/polkadot.ts"
 import { parse } from "../../deps/std/flags.ts"
-import { filterPureCreatedEvents } from "../../patterns/proxy/mod.ts"
 
 const { alexa, billy, carol, david } = await createDevUsers()
 
@@ -32,30 +31,13 @@ const { alexa, billy, carol, david } = await createDevUsers()
 /// With this state, we can hydrate from / use an existing virtual multisig.
 /// Let's see if we can hydrate the virtual multisig state from command line arguments.
 /// If we haven't specified any virtual multisig state, we deploy a new virtual multisig.
-const { "use-stash": useStash, ...args } = parse(
-  Deno.args,
-  { string: ["state"], boolean: ["use-stash"] },
-)
-let state = args.state
-
+let { state } = parse(Deno.args, { string: ["state"] })
 if (!state) {
-  const stashAccountId = useStash
-    ? await polkadotDev.Proxy
-      .createPure({ proxyType: "Any", delay: 0, index: 0 })
-      .signed(signature({ sender: alexa }))
-      .sent()
-      .finalizedEvents()
-      .pipe(filterPureCreatedEvents)
-      .access(0, "pure")
-      .run()
-    : undefined
-
   state = await VirtualMultisigRune
     .deployment(polkadotDev, {
       founders: [alexa.publicKey, billy.publicKey, carol.publicKey],
       threshold: 2,
       deployer: alexa.address,
-      stash: stashAccountId,
     }, signature({ sender: alexa }))
     .hex
     .run()

--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -32,9 +32,11 @@ const { alexa, billy, carol, david } = await createDevUsers()
 /// With this state, we can hydrate from / use an existing virtual multisig.
 /// Let's see if we can hydrate the virtual multisig state from command line arguments.
 /// If we haven't specified any virtual multisig state, we deploy a new virtual multisig.
-const args = parse(Deno.args, { string: ["state"], boolean: ["use-stash"] })
+const { "use-stash": useStash, ...args } = parse(
+  Deno.args,
+  { string: ["state"], boolean: ["use-stash"] },
+)
 let state = args.state
-const useStash = args["use-stash"]
 
 if (!state) {
   const stashAccountId = useStash

--- a/examples/multisig/virtual.eg.ts
+++ b/examples/multisig/virtual.eg.ts
@@ -38,11 +38,9 @@ const useStash = args["use-stash"]
 
 if (!state) {
   const stashAccountId = useStash
-    ? await polkadotDev.Proxy.createPure({
-      proxyType: "Any",
-      delay: 0,
-      index: 0,
-    }).signed(signature({ sender: alexa }))
+    ? await polkadotDev.Proxy
+      .createPure({ proxyType: "Any", delay: 0, index: 0 })
+      .signed(signature({ sender: alexa }))
       .sent()
       .finalizedEvents()
       .pipe(filterPureCreatedEvents)

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -126,10 +126,12 @@ export class VirtualMultisigRune<out C extends Chain, out U>
         undefined,
         () => chain.pallet("Balances").constant("ExistentialDeposit").decoded,
       )
+    const suppliedStash = Rune.resolve(props.stash)
+
     const memberAccountIds = Rune.resolve(props.founders)
     const deployer = Rune.resolve(props.deployer)
     const membersCount = memberAccountIds.map((members) => members.length)
-    const proxyCreationCalls = membersCount.map((n) =>
+    const proxyCreationCalls = Rune.tuple([membersCount, suppliedStash]).map(([n, stash]) =>
       Rune.array(Array.from({ length: n + (stash ? 0 : 1) }, (_, index) =>
         chain.extrinsic(
           Rune
@@ -171,8 +173,8 @@ export class VirtualMultisigRune<out C extends Chain, out U>
       )
 
     const proxiesGrouped = Rune
-      .tuple([proxies, membersCount])
-      .map(([proxies, membersCount]) =>
+      .tuple([proxies, membersCount, suppliedStash])
+      .map(([proxies, membersCount, stash]) =>
         [
           proxies.slice(0, membersCount),
           stash ?? proxies[membersCount],

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -118,7 +118,7 @@ export class VirtualMultisigRune<out C extends Chain, out U>
     props: RunicArgs<X, VirtualMultisigDeploymentProps>,
     signature: SignatureDataFactory<C, any, SU>,
   ) {
-    const { threshold, stash } = props
+    const { threshold } = props
     const existentialDepositAmount = Rune
       .resolve(props.existentialDepositAmount)
       .unhandle(undefined)

--- a/patterns/multisig/VirtualMultisigRune.ts
+++ b/patterns/multisig/VirtualMultisigRune.ts
@@ -127,7 +127,6 @@ export class VirtualMultisigRune<out C extends Chain, out U>
         () => chain.pallet("Balances").constant("ExistentialDeposit").decoded,
       )
     const suppliedStash = Rune.resolve(props.stash)
-
     const memberAccountIds = Rune.resolve(props.founders)
     const deployer = Rune.resolve(props.deployer)
     const membersCount = memberAccountIds.map((members) => members.length)


### PR DESCRIPTION
Allows you to specify an existing stash for a virtual multisig. This feature was requested by capi multisig app team.

Tested with `deno task run examples/multisig/virtual.eg.ts --use-stash`