### PR TITLE
fix: dnt shims

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -33,11 +33,8 @@ for await (
 ) allFiles.push(`./${path}`)
 
 for (const pathname of allFiles) {
-  if (
-    !(pathname.endsWith(".node.ts")
-      // TODO: group shims
-      || pathname.startsWith("./deps/shims/")
-  ) {
+  // TODO: group shims
+  if (!pathname.endsWith(".node.ts") || pathname.startsWith("./deps/shims/")) {
     entryPoints.push({
       name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),
       path: pathname,

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -36,8 +36,7 @@ for (const pathname of allFiles) {
   if (
     !(pathname.endsWith(".node.ts")
       // TODO: group shims
-      || pathname.endsWith("deps/shims/ws.ts")
-      || pathname.endsWith("deps/shims/shim-deno.ts"))
+      || pathname.startsWith("./deps/shims/")
   ) {
     entryPoints.push({
       name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -34,7 +34,7 @@ for await (
 
 for (const pathname of allFiles) {
   // TODO: group shims
-  if (!pathname.endsWith(".node.ts") || pathname.startsWith("./deps/shims/")) {
+  if (!(pathname.endsWith(".node.ts") || pathname.startsWith("./deps/shims/"))) {
     entryPoints.push({
       name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),
       path: pathname,

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -27,13 +27,18 @@ const allFiles = []
 for await (
   const { path } of fs.walkSync(".", {
     exts: [".ts"],
-    skip: [/\.test\.ts$/, /^\.\/target\//, /\/_/],
+    skip: [/\.test\.ts$/, /^(target|_tasks|examples)\//],
     includeDirs: false,
   })
 ) allFiles.push(`./${path}`)
 
 for (const pathname of allFiles) {
-  if (!pathname.endsWith(".node.ts")) {
+  if (
+    !(pathname.endsWith(".node.ts")
+      // TODO: group shims
+      || pathname.endsWith("deps/shims/ws.ts")
+      || pathname.endsWith("deps/shims/shim-deno.ts"))
+  ) {
     entryPoints.push({
       name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),
       path: pathname,
@@ -68,6 +73,10 @@ await Promise.all([
       lib: ["es2022.error"],
     },
     entryPoints: [
+      {
+        name: ".",
+        path: "./mod.ts",
+      },
       {
         kind: "bin",
         name: "capi",

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -33,15 +33,16 @@ for await (
 ) allFiles.push(`./${path}`)
 
 for (const pathname of allFiles) {
-  // TODO: group shims
-  if (!(pathname.endsWith(".node.ts") || pathname.startsWith("./deps/shims/"))) {
-    entryPoints.push({
-      name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),
-      path: pathname,
-    })
+  if (!pathname.endsWith(".node.ts")) {
     const nodePath = pathname.slice(0, -".ts".length) + ".node.ts"
     if (allFiles.includes(nodePath)) {
       mappings[pathname] = nodePath
+    }
+    if (!pathname.startsWith("./deps/")) {
+      entryPoints.push({
+        name: pathname.slice(0, -(pathname.endsWith("mod.ts") ? "/mod.ts".length : ".ts".length)),
+        path: pathname,
+      })
     }
   }
 }

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -37,7 +37,7 @@ export default async function(...args: string[]) {
   if (packageJsonFile) {
     syncFile(packageJsonFile, (packageJson) => {
       const addedPackages = new Set()
-      for (const rawName of Object.keys(config.chains ?? {})) {
+      for (const rawName of Object.keys(config ?? {})) {
         const name = normalizePackageName(rawName)
         const packageName = `@capi/${name}`
         addedPackages.add(packageName)

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -22,11 +22,11 @@ export default async function(...args: string[]) {
     },
   })
 
-  const config = await resolveNets(...args)
+  const netSpecs = await resolveNets(...args)
 
   const devnetTempDir = await tempDir(out, "devnet")
 
-  const baseUrl = await syncNets(server, devnetTempDir, config)
+  const baseUrl = await syncNets(server, devnetTempDir, netSpecs)
 
   if (importMapFile) {
     syncFile(importMapFile, (importMap) => {
@@ -37,7 +37,7 @@ export default async function(...args: string[]) {
   if (packageJsonFile) {
     syncFile(packageJsonFile, (packageJson) => {
       const addedPackages = new Set()
-      for (const rawName of Object.keys(config ?? {})) {
+      for (const rawName of Object.keys(netSpecs ?? {})) {
         const name = normalizePackageName(rawName)
         const packageName = `@capi/${name}`
         addedPackages.add(packageName)

--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 export * as $ from "./deps/scale.ts"
 export { BitSequence } from "./deps/scale.ts"
 
-// moderate --exclude main.ts nets.ts util
+// moderate --exclude main.ts nets.ts util server
 
 export * from "./crypto/mod.ts"
 export * from "./fluent/mod.ts"
@@ -10,4 +10,3 @@ export * from "./nets/mod.ts"
 export * from "./rpc/mod.ts"
 export * from "./rune/mod.ts"
 export * from "./scale_info/mod.ts"
-export * from "./server/mod.ts"

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 export * as $ from "./deps/scale.ts"
 export { BitSequence } from "./deps/scale.ts"
+export * from "./server/client/mod.ts"
 
 // moderate --exclude main.ts nets.ts util server
 


### PR DESCRIPTION
Fix `dnt` shims by excluding
- files from `target|_tasks|examples`
- `deps/shims/ws.ts` and `deps/shims/shim-deno.ts` from the entry points

This PR also fixes `capi sync --package-json package.json` which is needed for https://github.com/paritytech/capi-vite-example/pull/1