### PR TITLE
feat: remove dnt crypto shim

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -116,7 +116,6 @@ await Promise.all([
     scriptModule: false,
     shims: {
       deno: true,
-      crypto: true,
       custom: [{
         package: {
           name: "isomorphic-ws",


### PR DESCRIPTION
This `dnt` shim is no longer necessary since both modern browsers and Node (since `v20`) have the `crypto` global.

See https://nodejs.org/api/globals.html#crypto_1