### PR TITLE
feat: CLI `init` command

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -134,7 +134,6 @@ await Promise.all([
   fs.copy("LICENSE", path.join(outDir, "LICENSE")),
   fs.copy("Readme.md", path.join(outDir, "Readme.md")),
   fs.copy("server/static/", path.join(outDir, "esm/server/static/")),
-  writeTsLoader(path.join(outDir, "ts-loader.js")),
 ])
 
 await Promise.all([
@@ -147,7 +146,7 @@ await Promise.all([
     "target/npm/esm/main.js",
     (content) =>
       content
-        .replace(/^#!.+/, "#!/usr/bin/env -S node --loader capi/ts-loader"),
+        .replace(/^#!.+/, "#!/usr/bin/env -S node --loader ts-node/esm"),
   ),
   editFile(
     "target/npm/esm/_dnt.shims.js",
@@ -155,20 +154,8 @@ await Promise.all([
       content
         .replace(/"@deno\/shim-deno"/g, `"./deps/shims/Deno.node.js"`),
   ),
-  editFile(
-    "target/npm/package.json",
-    (content) => {
-      const packageJson = JSON.parse(content)
-      packageJson.exports["./ts-loader"] = "./ts-loader.js"
-      return JSON.stringify(packageJson, undefined, 2)
-    },
-  ),
 ])
 
 async function editFile(path: string, modify: (content: string) => string) {
   await Deno.writeTextFile(path, modify(await Deno.readTextFile(path)))
-}
-
-async function writeTsLoader(path: string) {
-  await Deno.writeTextFile(path, `export * from "ts-node/esm"`)
 }

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -170,12 +170,5 @@ async function editFile(path: string, modify: (content: string) => string) {
 }
 
 async function writeTsLoader(path: string) {
-  const content = `
-import tsNode from "ts-node"
-
-const service = tsNode.create({ transpileOnly: true, compilerOptions: { module: "ESNext" } })
-
-export const { resolve, load, getFormat, transformSource } = tsNode.createEsmHooks(service)
-`
-  await Deno.writeTextFile(path, content)
+  await Deno.writeTextFile(path, `export * from "ts-node/esm"`)
 }

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -56,12 +56,15 @@ await Promise.all([
       description: "Capi is a framework for crafting interactions with Substrate chains",
       license: "Apache-2.0",
       repository: "github:paritytech/capi",
-      dependencies: Object.fromEntries(
-        Object.keys(nets).map((key) => {
-          const name = normalizePackageName(key)
-          return [`@capi/${name}`, `${server}${hash}/${name}.tar`]
-        }),
-      ),
+      dependencies: {
+        ...Object.fromEntries(
+          Object.keys(nets).map((key) => {
+            const name = normalizePackageName(key)
+            return [`@capi/${name}`, `${server}${hash}/${name}.tar`]
+          }),
+        ),
+        "ts-node": "^10.9.1",
+      },
     },
     compilerOptions: {
       importHelpers: true,

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -34,8 +34,8 @@ async function runInitNode(packageJsonPath: string) {
   }
   assertManifest(packageJson)
   const devDependencies = packageJson.devDependencies ??= {}
-  if (!devDependencies["ts-node"]) devDependencies["ts-node"] = "*"
   const dependencies = packageJson.dependencies ??= {}
+  if (!(dependencies["ts-node"] || devDependencies["ts-node"])) devDependencies["ts-node"] = "*"
   dependencies.capi = detectVersion() ?? "*"
   const scripts = packageJson.scripts ??= {}
   scripts["capi:sync"] = "capi sync node"

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -34,7 +34,7 @@ async function runInitNode(packageJsonPath: string) {
     }
   }
   const dependencies = packageJson.dependencies ??= {}
-  dependencies.capi = detectVersion()
+  dependencies.capi = detectVersion() ?? "*"
   const scripts = packageJson.scripts ??= {}
   scripts["capi:sync"] = "capi sync node"
   scripts["capi:serve"] = "capi serve"
@@ -46,11 +46,13 @@ async function runInitDeno(denoJsonPath: string) {
   const denoJson = parse(Deno.readTextFileSync(denoJsonPath))
   assertManifest(denoJson)
   const tasks = denoJson.tasks ??= {}
-  tasks["capi"] = "deno run -A http://deno.land/x/capi/main.ts"
+  const version = detectVersion()
+  const versioned = `http://deno.land/x/capi${version ? `@${version}` : ""}/main.ts`
+  tasks["capi"] = `deno run -A ${versioned}`
   tasks["capi:sync"] = "deno task capi sync node"
   tasks["capi:serve"] = "deno task capi serve"
   Deno.writeTextFileSync(denoJsonPath, JSON.stringify(denoJson, null, 2))
-  await Promise.all([netsInit("https://deno.land/x/capi/mod.ts", true), updateGitignore()])
+  await Promise.all([netsInit(versioned, true), updateGitignore()])
 }
 
 async function netsInit(specifier: string, isTs: boolean) {

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -38,7 +38,7 @@ async function runInitNode(packageJsonPath: string) {
   const scripts = packageJson.scripts ??= {}
   scripts["capi:sync"] = "capi sync node"
   scripts["capi:serve"] = "capi serve"
-  Deno.writeTextFileSync(packageJsonPath, JSON.stringify(packageJsonPath, null, 2))
+  Deno.writeTextFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
   await Promise.all([netsInit("capi", isTs), updateGitignore()])
 }
 

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -1,4 +1,5 @@
 import { Command } from "../deps/cliffy.ts"
+import * as fs from "../deps/std/fs.ts"
 import { parse } from "../deps/std/jsonc.ts"
 import { detectVersion } from "../server/detectVersion.ts"
 
@@ -16,7 +17,7 @@ async function runInit() {
       ["deno.jsonc", runInitDeno],
     ] as const
   ) {
-    if (await isFile(file)) {
+    if (await fs.exists(file)) {
       return await runInit(file)
     }
   }
@@ -92,13 +93,5 @@ function assertManifest(
 ): asserts inQuestion is Record<string, Record<string, string>> {
   if (typeof inQuestion !== "object" || inQuestion === null) {
     throw new Error("Malformed manifest.")
-  }
-}
-
-async function isFile(path: string) {
-  try {
-    return (await Deno.stat(path)).isFile
-  } catch (_) {
-    return false
   }
 }

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -3,6 +3,8 @@ import * as fs from "../deps/std/fs.ts"
 import { parse } from "../deps/std/jsonc.ts"
 import * as path from "../deps/std/path.ts"
 
+// TODO: write to .gitignore
+
 export const init = new Command()
   .description("Configure Capi in the current working directory")
   .stopEarly()
@@ -11,11 +13,12 @@ export const init = new Command()
 
 async function runInit() {
   const packageJsonPath = path.join(Deno.cwd(), "package.json")
-  if (fs.existsSync(packageJsonPath)) runInitNode(packageJsonPath)
+  if (fs.existsSync(packageJsonPath)) return runInitNode(packageJsonPath)
   let denoJsonPath = path.join(Deno.cwd(), "deno.json")
-  if (fs.existsSync(denoJsonPath)) runInitDeno(denoJsonPath)
+  if (fs.existsSync(denoJsonPath)) return runInitDeno(denoJsonPath)
   denoJsonPath += "c"
-  if (fs.existsSync(denoJsonPath)) runInitDeno(denoJsonPath)
+  if (fs.existsSync(denoJsonPath)) return runInitDeno(denoJsonPath)
+  throw new Error("Could not find neither a `package.json` nor `deno.json`/`deno.jsonc`.")
 }
 
 function runInitNode(packageJsonPath: string) {
@@ -75,6 +78,6 @@ function assertManifest(
   inQuestion: unknown,
 ): asserts inQuestion is Record<string, Record<string, string>> {
   if (typeof inQuestion !== "object" || inQuestion === null) {
-    throw new Error("Malformed `package.json`")
+    throw new Error("Malformed manifest.")
   }
 }

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -25,8 +25,7 @@ async function runInit() {
 }
 
 async function runInitNode(packageJsonPath: string) {
-  const packageJsonContents = await Deno.readTextFile(packageJsonPath)
-  const packageJson = JSON.parse(packageJsonContents)
+  const packageJson = JSON.parse(await Deno.readTextFile(packageJsonPath))
   if (!packageJson.type || packageJson.type !== "module") {
     throw new Error(
       "Cannot use Capi in a non-esm project. Set `package.json`'s `type` field to `\"module\"`",
@@ -72,7 +71,8 @@ export const polkadot = net.ws({
   targets: { dev: polkadotDev },
 })
 `
-  await Deno.writeTextFile("nets.ts", code)
+  const netsExtension = await fs.exists("tsconfig.json") ? "ts" : "js"
+  await Deno.writeTextFile(`nets.${netsExtension}`, code)
 }
 
 const rTarget = /^target$/gm

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -1,0 +1,80 @@
+import { Command } from "../deps/cliffy.ts"
+import * as fs from "../deps/std/fs.ts"
+import { parse } from "../deps/std/jsonc.ts"
+import * as path from "../deps/std/path.ts"
+
+export const init = new Command()
+  .description("Configure Capi in the current working directory")
+  .stopEarly()
+  .example("Configure Capi in the current directory", "capi init .")
+  .action(runInit)
+
+async function runInit() {
+  const packageJsonPath = path.join(Deno.cwd(), "package.json")
+  if (fs.existsSync(packageJsonPath)) runInitNode(packageJsonPath)
+  let denoJsonPath = path.join(Deno.cwd(), "deno.json")
+  if (fs.existsSync(denoJsonPath)) runInitDeno(denoJsonPath)
+  denoJsonPath += "c"
+  if (fs.existsSync(denoJsonPath)) runInitDeno(denoJsonPath)
+}
+
+function runInitNode(packageJsonPath: string) {
+  const packageJson = JSON.parse(Deno.readTextFileSync(packageJsonPath))
+  assertManifest(packageJson)
+  const isTs = confirm("Are you using TypeScript?")
+  const devDependencies = packageJson.devDependencies ??= {}
+  if (isTs && !devDependencies["ts-node"]) {
+    const addTsNode = confirm(
+      `To define your net specs in TypeScript, we'll need to install the \`ts-node\` loader. Can we add it to your \`package.json\`?`,
+    )
+    if (addTsNode) {
+      devDependencies["ts-node"] = "*"
+    }
+  }
+  const dependencies = packageJson.dependencies ??= {}
+  dependencies.capi = "*"
+  const scripts = packageJson.scripts ??= {}
+  scripts["capi:sync"] = "capi sync node"
+  scripts["capi:serve"] = "capi serve"
+  Deno.writeTextFileSync(packageJsonPath, JSON.stringify(packageJsonPath, null, 2))
+  netsInit("capi", isTs)
+}
+
+function runInitDeno(denoJsonPath: string) {
+  const denoJson = parse(Deno.readTextFileSync(denoJsonPath))
+  assertManifest(denoJson)
+  const tasks = denoJson.tasks ??= {}
+  tasks["capi"] = "deno run -A http://deno.land/x/capi/main.ts"
+  tasks["capi:sync"] = "deno task capi sync node"
+  tasks["capi:serve"] = "deno task capi serve"
+  Deno.writeTextFileSync(denoJsonPath, JSON.stringify(denoJson, null, 2))
+  netsInit("https://deno.land/x/capi/mod.ts", true)
+}
+
+function netsInit(specifier: string, isTs: boolean) {
+  const code = `import { bins, net } from "${specifier}"
+
+const bin = bins({
+  polkadot: ["polkadot-fast", "v0.9.38"],
+})
+
+export const polkadotDev = net.dev({
+  bin: bin.polkadot,
+  chain: "polkadot-dev",
+})
+
+export const polkadot = net.ws({
+  url: "wss://rpc.polkadot.io/",
+  targets: { dev: polkadotDev },
+})
+`
+  Deno.writeTextFileSync("nets." + (isTs ? "ts" : "js"), code)
+}
+
+function assertManifest(
+  inQuestion: unknown,
+): asserts inQuestion is Record<string, Record<string, string>> {
+  if (typeof inQuestion !== "object" || inQuestion === null) {
+    throw new Error("Malformed `package.json`")
+  }
+}

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -32,9 +32,7 @@ async function runInitNode(packageJsonPath: string) {
     )
   }
   assertManifest(packageJson)
-  const devDependencies = packageJson.devDependencies ??= {}
   const dependencies = packageJson.dependencies ??= {}
-  if (!(dependencies["ts-node"] || devDependencies["ts-node"])) devDependencies["ts-node"] = "*"
   dependencies.capi = detectVersion() ?? "*"
   const scripts = packageJson.scripts ??= {}
   scripts["capi:sync"] = "capi sync node"

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -2,6 +2,7 @@ import { Command } from "../deps/cliffy.ts"
 import * as fs from "../deps/std/fs.ts"
 import { parse } from "../deps/std/jsonc.ts"
 import * as path from "../deps/std/path.ts"
+import { detectVersion } from "../server/detectVersion.ts"
 
 export const init = new Command()
   .description("Configure Capi in the current working directory")
@@ -33,7 +34,7 @@ async function runInitNode(packageJsonPath: string) {
     }
   }
   const dependencies = packageJson.dependencies ??= {}
-  dependencies.capi = "*"
+  dependencies.capi = detectVersion()
   const scripts = packageJson.scripts ??= {}
   scripts["capi:sync"] = "capi sync node"
   scripts["capi:serve"] = "capi serve"

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -1,4 +1,4 @@
-import { Command, EnumType } from "../deps/cliffy.ts"
+import { Command } from "../deps/cliffy.ts"
 import { blue, gray } from "../deps/std/fmt/colors.ts"
 import { assertEquals } from "../deps/std/testing/asserts.ts"
 import { detectVersion } from "../server/detectVersion.ts"
@@ -7,86 +7,96 @@ import { normalizePackageName } from "../util/mod.ts"
 import { tempDir } from "../util/tempDir.ts"
 import { resolveNets } from "./resolveNets.ts"
 
-export const sync = new Command()
-  .type("runtime", new EnumType(["deno", "node"]))
-  .description("Sync net specs and update your manifest")
-  .arguments("<runtime:runtime>")
-  .option("-n, --nets <nets:file>", "nets.ts file path", { default: "./nets.ts" })
-  .option("--check", "ensures that metadata and codegen are in sync")
-  .option("-o, --out <out:string>", "Metadata and codegen output directory", {
-    default: "target/capi",
-  })
-  .option("-s, --server <server:string>", "")
-  .option(
-    "--runtime-config <runtimeConfig:string>",
-    "the import_map.json or package.json file path",
-  )
-  .action(runSync)
+const descriptionLeading = "Sync net specs and update your "
 
-export interface RunSyncOptions {
-  nets: string
-  check?: true
-  out: string
-  server?: string
-  runtimeConfig?: string
+const syncNode = withCommonOptions(new Command()
+  .description(`${descriptionLeading} \`package.json\``))
+  .action(runSyncNode)
+
+const syncDeno = withCommonOptions(new Command()
+  .description(`${descriptionLeading} import map`))
+  .option("--import-map <import-map:string>", "the import map path", {
+    default: "import_map.json",
+  })
+  .action(runSyncDeno)
+
+export const sync = new Command()
+  .description("Sync net specs and update your manifest")
+  .command("node", syncNode)
+  .command("deno", syncDeno)
+
+function withCommonOptions(command: Command) {
+  return command
+    .option("-n, --nets <nets:file>", "Path to net-spec-containing file")
+    .option("--check", "ensures that metadata and codegen are in sync", { default: false })
+    .option("-o, --out <out:string>", "Metadata and codegen output directory", {
+      default: "target/capi",
+    })
+    .option("-s, --server <server:string>", "", { default: "https://capi.dev/" })
 }
 
-async function runSync({
-  nets: netsFile,
-  check,
-  out,
-  server,
-  runtimeConfig,
-}: RunSyncOptions, runtime: string) {
-  const netSpecs = await resolveNets(netsFile)
-  const devnetTempDir = await tempDir(out, "devnet")
+interface SyncProps {
+  nets?: string
+  check: boolean
+  out: string
+  server?: string
+}
+async function runSyncNode(props: SyncProps) {
+  const { netSpecs, baseUrl } = await setup(props)
+  syncFile("package.json", (packageJson) => {
+    const addedPackages = new Set()
+    for (const rawName of Object.keys(netSpecs ?? {})) {
+      const name = normalizePackageName(rawName)
+      const packageName = `@capi/${name}`
+      addedPackages.add(packageName)
+      packageJson.dependencies[packageName] = `${baseUrl}${name}.tar`
+    }
+    for (const packageName of Object.keys(packageJson.dependencies)) {
+      if (packageName.startsWith("@capi/") && !addedPackages.has(packageName)) {
+        delete packageJson.dependencies[packageName]
+      }
+    }
+    packageJson.dependencies = Object.fromEntries(Object.entries(packageJson.dependencies).sort())
+  }, props.check)
+}
+
+interface RunSyncDenoProps extends SyncProps {
+  importMap: string
+}
+async function runSyncDeno(props: RunSyncDenoProps) {
+  const { baseUrl } = await setup(props)
+  syncFile(props.importMap, (importMap) => {
+    importMap.imports["@capi/"] = baseUrl
+  }, props.check)
+}
+
+async function setup(props: SyncProps) {
+  const netSpecs = await resolveNets(props.nets)
+  const devnetTempDir = await tempDir(props.out, "devnet")
   const version = detectVersion()
-  if (!server && !version) {
+  if (!props.server && !version) {
     throw new Error(
       "Could not auto-detect version; please re-run `sync` with \`--server\` specified.",
     )
   }
   const baseUrl = await syncNets(
-    server ?? `https://capi.dev/${version}/`,
+    props.server ?? `https://capi.dev/${version}/`,
     devnetTempDir,
     netSpecs,
   )
-  if (runtime === "deno") {
-    runtimeConfig ??= "import_map.json"
-    syncFile(runtimeConfig, (importMap) => {
-      importMap.imports["@capi/"] = baseUrl
-    })
-  } else if (runtime === "node") {
-    runtimeConfig ??= "package.json"
-    syncFile(runtimeConfig, (packageJson) => {
-      const addedPackages = new Set()
-      for (const rawName of Object.keys(netSpecs ?? {})) {
-        const name = normalizePackageName(rawName)
-        const packageName = `@capi/${name}`
-        addedPackages.add(packageName)
-        packageJson.dependencies[packageName] = `${baseUrl}${name}.tar`
-      }
-      for (const packageName of Object.keys(packageJson.dependencies)) {
-        if (packageName.startsWith("@capi/") && !addedPackages.has(packageName)) {
-          delete packageJson.dependencies[packageName]
-        }
-      }
+  return { netSpecs, baseUrl }
+}
 
-      packageJson.dependencies = Object.fromEntries(Object.entries(packageJson.dependencies).sort())
-    })
-  }
-
-  async function syncFile(filePath: string, modify: (value: any) => void) {
-    const text = await Deno.readTextFile(filePath)
-    const newJson = JSON.parse(text)
-    modify(newJson)
-    try {
-      assertEquals(JSON.parse(text), newJson)
-      console.log(gray("Unchanged"), filePath)
-    } catch (e) {
-      if (check) throw e
-      await Deno.writeTextFile(filePath, JSON.stringify(newJson, null, 2) + "\n")
-      console.log(blue("Updated"), filePath)
-    }
+async function syncFile(filePath: string, modify: (value: any) => void, check: boolean) {
+  const text = await Deno.readTextFile(filePath)
+  const newJson = JSON.parse(text)
+  modify(newJson)
+  try {
+    assertEquals(JSON.parse(text), newJson)
+    console.log(gray("Unchanged"), filePath)
+  } catch (e) {
+    if (check) throw e
+    await Deno.writeTextFile(filePath, JSON.stringify(newJson, null, 2) + "\n")
+    console.log(blue("Updated"), filePath)
   }
 }

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -22,6 +22,9 @@ const syncDeno = withCommonOptions(new Command()
 
 export const sync = new Command()
   .description("Sync net specs and update your manifest")
+  .action(function() {
+    this.showHelp()
+  })
   .command("node", syncNode)
   .command("deno", syncDeno)
 

--- a/deps/std/jsonc.ts
+++ b/deps/std/jsonc.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.187.0/jsonc/mod.ts"

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import "./deps/shims/register.ts"
 import { bin } from "./cli/bin.ts"
+import { init } from "./cli/init.ts"
 import { serve } from "./cli/serve.ts"
 import { sync } from "./cli/sync.ts"
 import { Command } from "./deps/cliffy.ts"
@@ -12,4 +13,5 @@ new Command()
   .command("bin", bin)
   .command("sync", sync)
   .command("serve", serve)
+  .command("init", init)
   .parse(Deno.args)


### PR DESCRIPTION
Resolves #940

In a Deno project, simply do the following.

```sh
deno run -A https://deno.land/x/capi/main.ts init
```

Or in a Node project

```sh
npm i capi
npx capi init
npm run capi:sync
```

**How to test this locally with Node?**

```sh
# in Capi
deno task dnt
cd target/npm
npm pack
# in a Node project
npm i /path/to/target/npm/capi-v0.0.0-local.tgz
npx capi init
npm run capi:sync
```
Then, validate that
- `nets.ts` has been created
- `@capi/polkadot` and `@capi/polkadot-dev` have been added to `package.json` dependencies
- `capi:sync` and `capi:serve` npm scripts have been added