### PR TITLE
chore(deps): use smoldot 1.0

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -91,13 +91,13 @@ await Promise.all([
         name: "scale-codec",
         version: "0.11.2",
       },
-      "https://deno.land/x/smoldot@light-js-deno-v0.7.6/index-deno.js": {
-        name: "@substrate/smoldot-light",
-        version: "0.7.6",
+      "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/index-deno.js": {
+        name: "smoldot",
+        version: "1.0.6",
       },
-      "https://deno.land/x/smoldot@light-js-deno-v0.7.6/client.d.ts": {
-        name: "@substrate/smoldot-light",
-        version: "0.7.6",
+      "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/public-types.d.ts": {
+        name: "smoldot",
+        version: "1.0.6",
       },
       "https://esm.sh/v113/shiki@0.14.1?bundle": {
         name: "shiki",

--- a/deps/smoldot.ts
+++ b/deps/smoldot.ts
@@ -1,5 +1,5 @@
 export type {
   Client,
   ClientOptions,
-} from "https://deno.land/x/smoldot@light-js-deno-v0.7.6/client.d.ts"
-export * from "https://deno.land/x/smoldot@light-js-deno-v0.7.6/index-deno.js"
+} from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/public-types.d.ts";
+export * from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/index-deno.js";

--- a/deps/smoldot.ts
+++ b/deps/smoldot.ts
@@ -1,5 +1,5 @@
+export * from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/index-deno.js"
 export type {
   Client,
   ClientOptions,
-} from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/public-types.d.ts";
-export * from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/index-deno.js";
+} from "https://deno.land/x/smoldot2@light-js-deno-v1.0.6/public-types.d.ts"


### PR DESCRIPTION
After migrating from https://github.com/paritytech/smoldot to https://github.com/smol-dot/smoldot, the package name has changed from `smoldot` to `smoldot2`.
This PR removes the deprecated package and replaces it with the new version.