### PR TITLE
fix: codegen ts keyword

### DIFF
--- a/util/normalize.ts
+++ b/util/normalize.ts
@@ -21,7 +21,54 @@ export function normalizeVariableName(name: string) {
   return normalizeIdent(name).replace(/^./, (x) => x.toLowerCase())
 }
 
-const keywords = ["import"]
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words
+const keywords = [
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "let",
+  "static",
+  "yield",
+  "await",
+  "enum",
+  "implements",
+  "interface",
+  "package",
+  "private",
+  "protected",
+  "public",
+]
 function normalizeKeyword(ident: string) {
   return keywords.includes(ident) ? ident + "_" : ident
 }

--- a/util/normalize.ts
+++ b/util/normalize.ts
@@ -1,6 +1,8 @@
 export function normalizeIdent(ident: string) {
   if (ident.startsWith("r#")) ident = ident.slice(2)
-  return ident.replace(/(?:[^\p{ID_Continue}]|_)+(.)/gu, (_, $1: string) => $1.toUpperCase())
+  return normalizeKeyword(
+    ident.replace(/(?:[^\p{ID_Continue}]|_)+(.)/gu, (_, $1: string) => $1.toUpperCase()),
+  )
 }
 
 export function normalizeDocs(docs: string[] | undefined): string {
@@ -17,4 +19,9 @@ export function normalizeTypeName(name: string) {
 
 export function normalizeVariableName(name: string) {
   return normalizeIdent(name).replace(/^./, (x) => x.toLowerCase())
+}
+
+const keywords = ["import"]
+function normalizeKeyword(ident: string) {
+  return keywords.includes(ident) ? ident + "_" : ident
 }


### PR DESCRIPTION
Resolves #1033 

Note:
I noticed that sometimes a request to `http://localhost:4646/hash/some-chain/types.d.ts` runs out of memory when `shiki` is doing the code rendering

```
<--- Last few GCs --->

[13812:0x140018000]   419196 ms: Mark-Compact 1398.0 (1425.3) -> 1396.8 (1425.3) MB, 310.00 / 0.00 ms  (average mu = 0.095, current mu = 0.001) allocation failure; scavenge might not succeed
[13812:0x140018000]   419508 ms: Mark-Compact 1397.8 (1425.3) -> 1396.8 (1425.3) MB, 312.58 / 0.00 ms  (average mu = 0.050, current mu = 0.001) allocation failure; scavenge might not succeed


<--- JS stacktrace --->


#
# Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit
#
