### PR TITLE
fix: MultisigRune - `depositor` as `Uint8Array`

### DIFF
--- a/patterns/multisig/MultisigRune.ts
+++ b/patterns/multisig/MultisigRune.ts
@@ -152,7 +152,7 @@ export class MultisigRune<out C extends Chain, out U> extends PatternRune<Multis
         undefined | {
           when: { height: number; index: number }
           approvals: Uint8Array[]
-          depositor: bigint
+          depositor: Uint8Array
         }
       >()
       .into(ValueRune)


### PR DESCRIPTION
Changes type of `depositor` from `bigint` to `Uint8Array` as it's an `AccountId`.

I think this is the wrong type here in capi. It's supposed to be an `AccountId` so it should also be a Uint8Array, like everywhere else.

<img width="718" alt="Screenshot 2023-06-06 at 16 16 09" src="https://github.com/paritytech/capi/assets/839848/6857fd60-c38c-4d62-bec1-b344b083ba84">


https://github.com/paritytech/substrate/blob/master/frame/multisig/src/lib.rs#LL107C1-L119C2

