### PR TITLE
feat: enable handling of signer error within rune system

### DIFF
--- a/fluent/ExtrinsicRune.ts
+++ b/fluent/ExtrinsicRune.ts
@@ -1,8 +1,8 @@
 import { blake2_256, hex } from "../crypto/mod.ts"
 import * as $ from "../deps/scale.ts"
 import { concat } from "../deps/std/bytes.ts"
-import { Signer } from "../frame_metadata/Extrinsic.ts"
-import { Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
+import { Signer, SignerError } from "../frame_metadata/Extrinsic.ts"
+import { is, Rune, RunicArgs, ValueRune } from "../rune/mod.ts"
 import { Chain, ChainRune } from "./ChainRune.ts"
 import { CodecRune } from "./CodecRune.ts"
 import { PatternRune } from "./PatternRune.ts"
@@ -75,6 +75,7 @@ export class ExtrinsicRune<out C extends Chain, out U> extends PatternRune<Chain
         call: this,
         signature: signatureFactory(this.chain),
       }))
+      .throws(is(SignerError))
       .into(SignedExtrinsicRune, this.chain)
   }
 

--- a/frame_metadata/Extrinsic.ts
+++ b/frame_metadata/Extrinsic.ts
@@ -115,3 +115,11 @@ export function $extrinsic<M extends FrameMetadata>(metadata: M): $.Codec<Extrin
     $.lenPrefixed($baseExtrinsic),
   )
 }
+
+export class SignerError extends Error {
+  override readonly name = "SignerError"
+
+  constructor(readonly inner: unknown) {
+    super()
+  }
+}

--- a/patterns/compat/pjs_sender.ts
+++ b/patterns/compat/pjs_sender.ts
@@ -1,7 +1,7 @@
 import { hex, ss58 } from "../../crypto/mod.ts"
 import * as $ from "../../deps/scale.ts"
-import { AddressPrefixChain, Chain, ChainRune } from "../../fluent/ChainRune.ts"
-import { ExtrinsicSender } from "../../fluent/ExtrinsicRune.ts"
+import { AddressPrefixChain, Chain, ChainRune, ExtrinsicSender } from "../../fluent/mod.ts"
+import { SignerError } from "../../frame_metadata/mod.ts"
 import { Rune, RunicArgs } from "../../rune/mod.ts"
 
 export type PjsSigner = { signPayload(payload: any): Promise<{ signature: string }> }
@@ -41,7 +41,12 @@ export function pjsSender<C extends AddressPrefixChain, CU>(
           sign: async (_: Uint8Array, fullData: Uint8Array) => {
             const payload = $pjsExtrinsic.decode(fullData)
             payload.address = address
-            const sig = await pjsSigner.signPayload(payload)
+            let sig
+            try {
+              sig = await pjsSigner.signPayload(payload)
+            } catch (e) {
+              throw new SignerError(e)
+            }
             return $sig.decode(hex.decode(sig.signature))
           },
         }


### PR DESCRIPTION
Fixes #1041

```ts
import { is, SignerError } from "capi"

await polkadotDev.Balances
  .transfer({
    value: 12345n,
    dest: billy.address,
  })
  .signed(signature({ sender: sender(alexaSs58) }))
  .sent()
  .dbgStatus("Transfer:")
  .finalized()
  .handle(is(SignerError), (error) => error.access("inner").dbg("Likely a cancellation!"))
  .run()
```