### PR TITLE
feat: improve bundle size

### DIFF
--- a/_tasks/generate_artifacts.ts
+++ b/_tasks/generate_artifacts.ts
@@ -3,7 +3,7 @@ import * as $ from "../deps/scale.ts"
 import { emptyDir } from "../deps/std/fs.ts"
 import * as path from "../deps/std/path.ts"
 import dprintConfig from "../dprint.json" assert { type: "json" }
-import { devUser } from "../nets/chain_spec/addDevUsers.ts"
+import { devUser } from "../mod.ts"
 import { compress } from "../util/compression.ts"
 
 export const DEV_USER_COUNT = 10_000

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -38,7 +38,7 @@ async function runInitNode(packageJsonPath: string) {
   scripts["capi:sync"] = "capi sync node"
   scripts["capi:serve"] = "capi serve"
   Deno.writeTextFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
-  await Promise.all([netsInit("capi"), updateGitignore()])
+  await Promise.all([netsInit("capi/nets"), updateGitignore()])
 }
 
 async function runInitDeno(denoJsonPath: string) {
@@ -46,12 +46,12 @@ async function runInitDeno(denoJsonPath: string) {
   assertManifest(denoJson)
   const tasks = denoJson.tasks ??= {}
   const version = detectVersion()
-  const versioned = `http://deno.land/x/capi${version ? `@${version}` : ""}/main.ts`
-  tasks["capi"] = `deno run -A ${versioned}`
+  const versioned = `http://deno.land/x/capi${version ? `@${version}` : ""}`
+  tasks["capi"] = `deno run -A ${versioned}/main.ts`
   tasks["capi:sync"] = "deno task capi sync node"
   tasks["capi:serve"] = "deno task capi serve"
   Deno.writeTextFileSync(denoJsonPath, JSON.stringify(denoJson, null, 2))
-  await Promise.all([netsInit(versioned), updateGitignore()])
+  await Promise.all([netsInit(`${versioned}/nets/mod.ts`), updateGitignore()])
 }
 
 async function netsInit(specifier: string) {

--- a/mod.ts
+++ b/mod.ts
@@ -6,6 +6,7 @@ if (CAPI_MARKER in globalThis) {
 
 export * as $ from "./deps/scale.ts"
 export { BitSequence } from "./deps/scale.ts"
+export * from "./server/client/createDevUsers.ts"
 export * from "./server/client/detectConnect.ts"
 
 // moderate --exclude main.ts nets.ts util server

--- a/mod.ts
+++ b/mod.ts
@@ -6,14 +6,13 @@ if (CAPI_MARKER in globalThis) {
 
 export * as $ from "./deps/scale.ts"
 export { BitSequence } from "./deps/scale.ts"
-export * from "./server/client/mod.ts"
+export * from "./server/client/detectConnect.ts"
 
 // moderate --exclude main.ts nets.ts util server
 
 export * from "./crypto/mod.ts"
 export * from "./fluent/mod.ts"
 export * from "./frame_metadata/mod.ts"
-export * from "./nets/mod.ts"
 export * from "./rpc/mod.ts"
 export * from "./rune/mod.ts"
 export * from "./scale_info/mod.ts"

--- a/mod.ts
+++ b/mod.ts
@@ -9,7 +9,7 @@ export { BitSequence } from "./deps/scale.ts"
 export * from "./server/client/createDevUsers.ts"
 export * from "./server/client/detectConnect.ts"
 
-// moderate --exclude main.ts nets.ts util server
+// moderate --exclude main.ts nets.ts util server nets
 
 export * from "./crypto/mod.ts"
 export * from "./fluent/mod.ts"

--- a/nets.ts
+++ b/nets.ts
@@ -1,4 +1,4 @@
-import { bins, net } from "./mod.ts"
+import { bins, net } from "./nets/mod.ts"
 
 const bin = bins({
   polkadot: ["polkadot-fast", "v0.9.38"],

--- a/nets/chain_spec/addDevUsers.ts
+++ b/nets/chain_spec/addDevUsers.ts
@@ -1,4 +1,4 @@
-import { blake2_512, Sr25519, ss58 } from "../../crypto/mod.ts"
+import { ss58 } from "../../crypto/mod.ts"
 import * as $ from "../../deps/scale.ts"
 import { devUserPublicKeysData } from "../../util/_artifacts/devUserPublicKeysData.ts"
 import { GenesisConfig } from "./ChainSpec.ts"
@@ -14,8 +14,4 @@ export function addDevUsers(genesisConfig: GenesisConfig) {
   for (const publicKey of devUserPublicKeys) {
     balances.push([ss58.encode(networkPrefix, publicKey), devUserInitialFunds])
   }
-}
-
-export function devUser(userId: number) {
-  return Sr25519.fromSeed64(blake2_512.hash(new TextEncoder().encode(`capi-dev-user-${userId}`)))
 }

--- a/server/client/createDevUsers.ts
+++ b/server/client/createDevUsers.ts
@@ -1,7 +1,10 @@
-import { Sr25519 } from "../../crypto/mod.ts"
-import { devUser } from "../../nets/mod.ts"
+import { blake2_512, Sr25519 } from "../../crypto/mod.ts"
 import { ArrayOfLength } from "../../util/ArrayOfLength.ts"
 import { detectServer } from "./detectServer.ts"
+
+export function devUser(userId: number) {
+  return Sr25519.fromSeed64(blake2_512.hash(new TextEncoder().encode(`capi-dev-user-${userId}`)))
+}
 
 export function createDevUsers(): Promise<Record<typeof devUserNames[number], Sr25519>>
 export function createDevUsers<N extends number>(count: N): Promise<ArrayOfLength<Sr25519, N>>


### PR DESCRIPTION
Closes https://github.com/paritytech/capi/issues/1053 https://github.com/paritytech/capi/issues/1038

This PR improves 
- the bundle size for web
- `webpack` configuration because `externals["node:*"]` is no longer required
- `vite` configuration because `build.rollupOptions.shimMissingExports` is no longer required  

Webpack Bundle Analyzer before and after this change

![image](https://github.com/paritytech/capi/assets/1209171/f79318ec-ff8e-41b3-90ec-8a386b9a5710)

![image](https://github.com/paritytech/capi/assets/1209171/489d1106-93a6-4c31-8f33-68c207805a73)

`vite-bundle-visualizer` after this change

<img width="1512" alt="image" src="https://github.com/paritytech/capi/assets/1209171/89e04af1-7006-4b62-9d35-2c47fd059602">

 