### PR TITLE
fix: dynamic eg ts

### DIFF
--- a/examples/dynamic.eg.ts
+++ b/examples/dynamic.eg.ts
@@ -44,8 +44,8 @@ $.assert(
           $.object(
             $.field("free", $.u128),
             $.field("reserved", $.u128),
-            $.field("miscFrozen", $.u128),
-            $.field("feeFrozen", $.u128),
+            $.field("frozen", $.u128),
+            $.field("flags", $.u128),
           ),
         ),
       ),


### PR DESCRIPTION
Metadata looks to have changed since the output is now 

```ts
  [
    Uint8Array(32) [
      162, 172, 141, 147, 140, 204, 243,
      177, 197, 143, 124, 133, 234, 156,
      255, 206, 246, 179, 179, 199, 217,
      227, 245, 236, 136, 136, 126,  17,
       18,  26,   4, 112
    ],
    {
      nonce: 3,
      consumers: 0,
      providers: 1,
      sufficients: 0,
      data: {
        free: 10572099951n,
        reserved: 0n,
        frozen: 0n,
        flags: 170141183460469231731687303715884105728n
      }
    }
  ],
```