### PR TITLE
fix: make npm pkg nets importable

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -38,7 +38,7 @@ const allFiles = []
 for await (
   const { path } of fs.walkSync(".", {
     exts: [".ts"],
-    skip: [/\.test\.ts$/, /^(target|_tasks|examples)\//, /nets\.ts/],
+    skip: [/\.test\.ts$/, /^(target|_tasks|examples)\//, /^nets\.ts$/],
     includeDirs: false,
   })
 ) allFiles.push(`./${path}`)

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -38,7 +38,7 @@ const allFiles = []
 for await (
   const { path } of fs.walkSync(".", {
     exts: [".ts"],
-    skip: [/\.test\.ts$/, /^(target|_tasks|examples)\//],
+    skip: [/\.test\.ts$/, /^(target|_tasks|examples)\//, /nets\.ts/],
     includeDirs: false,
   })
 ) allFiles.push(`./${path}`)


### PR DESCRIPTION
I think it makes sense for a file to take precedence over a same-named dir's `mod.ts`, hence, let's just exclude the `nets.ts` from being matched by the fs walker.