### PR TITLE
feat: improve node cli experience

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,32 +149,34 @@ jobs:
             target
             !target/**/db/full/*
             !target/**/paritydb/full/*
-  examples-node:
-    name: Examples (Node)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: cache
-    steps:
-      - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31 # v1.1.0
-        with:
-          deno-version: v1.33.3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/deno
-          key: cache-${{ env.CAPI_SHA }}
-      - run: deno run -A _tasks/use_remote.ts
-      - run: deno task dnt --server ${{ env.CAPI_SHA }} --examples
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "20"
-      - run: deno task test:eg:node
-      - name: Archive target
-        uses: actions/upload-artifact@v3
-        if: failure() || cancelled()
-        with:
-          name: examples-node-target
-          path: |
-            target
-            !target/**/db/full/*
-            !target/**/paritydb/full/*
+
+  # TODO: https://github.com/paritytech/capi/issues/1096
+  # examples-node:
+  #   name: Examples (Node)
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   needs: cache
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31 # v1.1.0
+  #       with:
+  #         deno-version: v1.33.3
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: ~/.cache/deno
+  #         key: cache-${{ env.CAPI_SHA }}
+  #     - run: deno run -A _tasks/use_remote.ts
+  #     - run: deno task dnt --server ${{ env.CAPI_SHA }} --examples
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: "20"
+  #     - run: deno task test:eg:node
+  #     - name: Archive target
+  #       uses: actions/upload-artifact@v3
+  #       if: failure() || cancelled()
+  #       with:
+  #         name: examples-node-target
+  #         path: |
+  #           target
+  #           !target/**/db/full/*
+  #           !target/**/paritydb/full/*

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -85,15 +85,9 @@ await Promise.all([
       lib: ["es2022.error"],
     },
     entryPoints: [
-      {
-        name: ".",
-        path: "./mod.ts",
-      },
-      {
-        kind: "bin",
-        name: "capi",
-        path: "./main.ts",
-      },
+      { name: ".", path: "./mod.ts" },
+      { name: "./loader", path: "./deps/shims/loader.node.ts" },
+      { kind: "bin", name: "capi", path: "./main.ts" },
       ...entryPoints,
     ],
     mappings: {
@@ -119,6 +113,7 @@ await Promise.all([
         version: "8.13.0",
       },
       "./deps/shims/shim-deno.ts": "@deno/shim-deno",
+      "./deps/shims/ts-node-esm.ts": "ts-node/esm",
       "node:net": "node:net",
       "node:http": "node:http",
       "node:stream": "node:stream",
@@ -159,7 +154,7 @@ await Promise.all([
     path.join(capiOutDir, "esm/main.js"),
     (content) =>
       content
-        .replace(/^#!.+/, "#!/usr/bin/env -S node --loader ts-node/esm"),
+        .replace(/^#!.+/, "#!/usr/bin/env -S node --loader capi/loader"),
   ),
   editFile(
     path.join(capiOutDir, "esm/_dnt.shims.js"),

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -211,7 +211,10 @@ if (buildExamples) {
       target: "ES2021",
       lib: ["ES2022", "DOM"],
     },
-    entryPoints: exampleEntryPoints,
+    entryPoints: [
+      ...exampleEntryPoints,
+      { name: "./deps/ed25519", path: "./deps/ed25519.ts" },
+    ],
     mappings: {
       "https://deno.land/x/polkadot@0.2.38/keyring/mod.ts": {
         name: "@polkadot/keyring",

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -81,8 +81,8 @@ await Promise.all([
     compilerOptions: {
       importHelpers: true,
       sourceMap: true,
-      target: "ES2021",
-      lib: ["ES2022.Error"],
+      target: "ES2022",
+      lib: ["ES2022", "DOM"],
     },
     entryPoints: [
       { name: ".", path: "./mod.ts" },
@@ -204,7 +204,7 @@ if (buildExamples) {
       importHelpers: true,
       sourceMap: true,
       target: "ES2021",
-      lib: ["ES2022.Error", "DOM.Iterable"],
+      lib: ["ES2022", "DOM"],
     },
     entryPoints: exampleEntryPoints,
     mappings: {

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -147,7 +147,12 @@ await Promise.all([
 await Promise.all([
   fs.copy(
     path.join(capiOutDir, "src/rune/_empty.d.ts"),
-    path.join(capiOutDir, "types/rune/_empty.d.ts"),
+    path.join(capiOutDir, "esm/rune/_empty.d.ts"),
+    { overwrite: true },
+  ),
+  fs.copy(
+    path.join(capiOutDir, "src/rune/_empty.d.ts"),
+    path.join(capiOutDir, "script/rune/_empty.d.ts"),
     { overwrite: true },
   ),
   editFile(

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -82,7 +82,7 @@ await Promise.all([
       importHelpers: true,
       sourceMap: true,
       target: "ES2021",
-      lib: ["es2022.error"],
+      lib: ["ES2022.Error"],
     },
     entryPoints: [
       { name: ".", path: "./mod.ts" },
@@ -204,7 +204,7 @@ if (buildExamples) {
       importHelpers: true,
       sourceMap: true,
       target: "ES2021",
-      lib: ["es2022.error", "dom.iterable"],
+      lib: ["ES2022.Error", "DOM.Iterable"],
     },
     entryPoints: exampleEntryPoints,
     mappings: {

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -35,7 +35,7 @@ function withCommonOptions(command: Command) {
     .option("-o, --out <out:string>", "Metadata and codegen output directory", {
       default: "target/capi",
     })
-    .option("-s, --server <server:string>", "", { default: "https://capi.dev/" })
+    .option("-s, --server <server:string>", "")
 }
 
 interface SyncProps {
@@ -83,7 +83,7 @@ async function setup(props: SyncProps) {
     )
   }
   const baseUrl = await syncNets(
-    props.server ?? `https://capi.dev/${version}/`,
+    props.server ?? `https://capi.dev/@${version}/`,
     devnetTempDir,
     netSpecs,
   )

--- a/deps/dnt.ts
+++ b/deps/dnt.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/dnt@0.34.0/mod.ts"
+export * from "https://deno.land/x/dnt@0.37.0/mod.ts"

--- a/deps/shims/loader.node.ts
+++ b/deps/shims/loader.node.ts
@@ -1,0 +1,1 @@
+export * from "./ts-node-esm.ts"

--- a/deps/shims/ts-node-esm.ts
+++ b/deps/shims/ts-node-esm.ts
@@ -1,0 +1,1 @@
+// This will be shimmed to `ts-node/esm` by DNT

--- a/server/detectVersion.node.ts
+++ b/server/detectVersion.node.ts
@@ -1,5 +1,5 @@
 export function detectVersion(): string | undefined {
-  const packageJsonPath = new URL("../package.json", import.meta.url)
+  const packageJsonPath = new URL("../../package.json", import.meta.url)
   try {
     Deno.statSync(packageJsonPath)
     const packageJson = Deno.readTextFileSync(packageJsonPath)


### PR DESCRIPTION
- Creates a `capi/loader` that just points to `ts-node/esm` so that users don't need to install `ts-node` themselves
- Fixes the sync command to default the server to a correctly versioned capi.dev url (before it defaulted to the unversioned `https://capi.dev/`)