### PR TITLE
chore: rename `transactionStatuses` method and allow no return

### DIFF
--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -17,15 +17,15 @@ export class ExtrinsicStatusRune<out C extends Chain, out U1, out U2>
       .into(ExtrinsicStatusRune, this.chain, this.parent)
   }
 
-  transactionStatuses(isTerminal: (txStatus: known.TransactionStatus) => boolean) {
+  status(isTerminal: (status: known.TransactionStatus) => boolean | void) {
     return this
       .into(OrthoRune)
-      .orthoMap((events) => events.into(ValueRune).filter(isTerminal))
+      .orthoMap((events) => events.into(ValueRune).filter((status) => !!isTerminal(status)))
       .flatSingular()
   }
 
   inBlock() {
-    return this.transactionStatuses((status) =>
+    return this.status((status) =>
       known.TransactionStatus.isTerminal(status)
       || (typeof status !== "string" ? !!status.inBlock : false)
     )
@@ -37,7 +37,7 @@ export class ExtrinsicStatusRune<out C extends Chain, out U1, out U2>
   }
 
   finalized() {
-    return this.transactionStatuses(known.TransactionStatus.isTerminal)
+    return this.status(known.TransactionStatus.isTerminal)
       .map((status) =>
         typeof status !== "string" && status.finalized
           ? status.finalized


### PR DESCRIPTION
Allows one to easily use their own callback with `ExtrinsicStatusRune`

```ts
westendDev.Balances
  .transfer({
    value: 12345n,
    dest: billy.address,
  })
  .signed(signature({ sender: alexa }))
  .sent()
  .status((x) => {
    console.log(x)
  })
  .run()
```

One potential foot gun: it's up to the user to terminate the subscription by returning `true` (for `isTerminal`). Thoughts @statictype @peetzweg?

Btw, this is now possible:

```ts
import { westendDev } from "@capi/westend-dev"
import { createDevUsers } from "capi"
import { signature } from "capi/patterns/signature/polkadot"

const { alexa, billy } = await createDevUsers()

const sent = westendDev.Balances
  .transfer({
    value: 12345n,
    dest: billy.address,
  })
  .signed(signature({ sender: alexa }))
  .sent()

sent.inBlock().run().then((hash) => console.log("In block", hash))

sent.finalizedEvents().run().then((hash) => console.log("Finalized events", hash))

sent.status((x) => {
  console.log(x)
  return typeof x === "string" && !!x.finalized
}).run()
```