### PR TITLE
chore: fellowship identities derived read example

### DIFF
--- a/examples/read/fellowship_identities.eg.ts
+++ b/examples/read/fellowship_identities.eg.ts
@@ -1,0 +1,26 @@
+/**
+ * @title Read Polkadot Identities of Fellowship Members
+ * @description Read the collectives chain fellowship member public keys.
+ * Then use those keys to read their identities on Polkadot.
+ */
+
+import { collectives } from "@capi/collectives"
+import { $registration, polkadot } from "@capi/polkadot"
+import { $, ArrayRune } from "capi"
+
+/// Reference the total number of members.
+const limit = collectives.FellowshipCollective.MemberCount.value(0)
+
+/// Reference the `Members` map keys.
+const members = collectives.FellowshipCollective.Members.keys({ limit })
+
+/// For each member, retrieve the associated `Registration` (or `undefined`)
+/// from Polkadot's Identity pallet storage.
+const memberIdentities = await members
+  .into(ArrayRune)
+  .mapArray((member) => polkadot.Identity.IdentityOf.value(member))
+  .run()
+
+/// Ensure the result is as expected.
+console.log(memberIdentities)
+$.assert($.array($.option($registration)), memberIdentities)

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@capi/": "http://localhost:4646/d5de72ca4087cd41/"
+    "@capi/": "http://localhost:4646/ed956cd5bde67584/"
   },
   "scopes": {
     "examples/": {

--- a/nets.ts
+++ b/nets.ts
@@ -59,3 +59,7 @@ export const rococoDevXcmStatemine = rococoDevXcm.parachain({
   chain: "statemine-local",
   id: 1000,
 })
+
+export const collectives = net.ws({
+  url: "wss://collectives.api.onfinality.io/public-ws",
+})

--- a/words.txt
+++ b/words.txt
@@ -48,6 +48,7 @@ multihash
 multisigs
 noninteractive
 offchain
+onfinality
 parachain
 parachains
 paritydb


### PR DESCRIPTION
An example that makes use of Polkadot and the Collectives parachain.