### PR TITLE
chore: no longer require ts to be installed for `nets.js`

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -112,6 +112,10 @@ await Promise.all([
         name: "ws",
         version: "8.13.0",
       },
+      "./deps/ts_node.ts": {
+        name: "ts-node",
+        version: "10.9.1",
+      },
       "./deps/shims/shim-deno.ts": "@deno/shim-deno",
       "./deps/shims/ts-node-esm.ts": "ts-node/esm",
       "node:net": "node:net",
@@ -150,12 +154,6 @@ await Promise.all([
     path.join(capiOutDir, "src/rune/_empty.d.ts"),
     path.join(capiOutDir, "types/rune/_empty.d.ts"),
     { overwrite: true },
-  ),
-  editFile(
-    path.join(capiOutDir, "esm/main.js"),
-    (content) =>
-      content
-        .replace(/^#!.+/, "#!/usr/bin/env -S node --loader capi/loader"),
   ),
   editFile(
     path.join(capiOutDir, "esm/_dnt.shims.js"),

--- a/cli/resolveNets.ts
+++ b/cli/resolveNets.ts
@@ -6,6 +6,13 @@ const $nets = $.record($.instance(NetSpec as new() => NetSpec, $.tuple(), () => 
 
 export async function resolveNets(maybeNetsPath?: string): Promise<Record<string, NetSpec>> {
   const resolvedNetsPath = await resolveNetsPath(maybeNetsPath)
+  if (resolvedNetsPath.endsWith(".ts")) {
+    ;(await import("../deps/ts_node.ts")).register({
+      compilerOptions: {
+        module: "Node16",
+      },
+    })
+  }
   const nets = await import(path.toFileUrl(resolvedNetsPath).toString())
   $.assert($nets, nets)
   for (const key in nets) nets[key]!.name = key

--- a/deps/ts_node.ts
+++ b/deps/ts_node.ts
@@ -1,0 +1,1 @@
+export function register(_options: { compilerOptions: { module: "Node16" } }) {}


### PR DESCRIPTION
Alleviates the pain point of needing to install TypeScript in the case of using `nets.js`.