### PR TITLE
fix: node support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -150,33 +150,32 @@ jobs:
             !target/**/db/full/*
             !target/**/paritydb/full/*
 
-  # TODO: https://github.com/paritytech/capi/issues/1096
-  # examples-node:
-  #   name: Examples (Node)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   needs: cache
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31 # v1.1.0
-  #       with:
-  #         deno-version: v1.33.3
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: ~/.cache/deno
-  #         key: cache-${{ env.CAPI_SHA }}
-  #     - run: deno run -A _tasks/use_remote.ts
-  #     - run: deno task dnt --server ${{ env.CAPI_SHA }} --examples
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: "20"
-  #     - run: deno task test:eg:node
-  #     - name: Archive target
-  #       uses: actions/upload-artifact@v3
-  #       if: failure() || cancelled()
-  #       with:
-  #         name: examples-node-target
-  #         path: |
-  #           target
-  #           !target/**/db/full/*
-  #           !target/**/paritydb/full/*
+  examples-node:
+    name: Examples (Node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: cache
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31 # v1.1.0
+        with:
+          deno-version: v1.33.3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/deno
+          key: cache-${{ env.CAPI_SHA }}
+      - run: deno run -A _tasks/use_remote.ts
+      - run: deno task dnt --server ${{ env.CAPI_SHA }} --examples
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: deno task test:eg:node
+      - name: Archive target
+        uses: actions/upload-artifact@v3
+        if: failure() || cancelled()
+        with:
+          name: examples-node-target
+          path: |
+            target
+            !target/**/db/full/*
+            !target/**/paritydb/full/*

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -1,5 +1,4 @@
 import { build, EntryPoint } from "../deps/dnt.ts"
-import { mapEntries } from "../deps/std/collections/map_entries.ts"
 import * as flags from "../deps/std/flags.ts"
 import * as fs from "../deps/std/fs.ts"
 import * as path from "../deps/std/path.ts"

--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -78,7 +78,7 @@ await Promise.all([
         "ts-node": "^10.9.1",
       },
       bin: {
-        capi: "./script/main.js",
+        capi: "./esm/main.js",
       },
     },
     compilerOptions: {
@@ -145,11 +145,11 @@ await Promise.all([
     test: false,
     typeCheck: false,
     declaration: "separate",
-    esModule: false,
+    scriptModule: false,
   }),
   fs.copy("LICENSE", path.join(capiOutDir, "LICENSE")),
   fs.copy("Readme.md", path.join(capiOutDir, "Readme.md")),
-  fs.copy("server/static/", path.join(capiOutDir, "script/server/static/")),
+  fs.copy("server/static/", path.join(capiOutDir, "esm/server/static/")),
 ])
 
 await Promise.all([
@@ -159,30 +159,16 @@ await Promise.all([
     { overwrite: true },
   ),
   editFile(
-    path.join(capiOutDir, "script/main.js"),
+    path.join(capiOutDir, "esm/main.js"),
     (content) =>
       content
         .replace(/^#!.+/, "#!/usr/bin/env -S node --loader capi/loader"),
   ),
   editFile(
-    path.join(capiOutDir, "script/_dnt.shims.js"),
+    path.join(capiOutDir, "esm/_dnt.shims.js"),
     (content) =>
       content
         .replace(/"@deno\/shim-deno"/g, `"./deps/shims/Deno.node.js"`),
-  ),
-  editFile(
-    path.join(capiOutDir, "script/cli/resolveNets.js"),
-    (content) =>
-      content
-        .replace(/\b_import\b/, "import"),
-  ),
-  editFile(
-    path.join(capiOutDir, "package.json"),
-    (content) => {
-      const pkg = JSON.parse(content)
-      pkg.exports = mapEntries(pkg.exports, ([k, v]: any) => [k, v.require])
-      return JSON.stringify(pkg, null, 2)
-    },
   ),
 ])
 

--- a/deps/shims/register-ts-node.node.ts
+++ b/deps/shims/register-ts-node.node.ts
@@ -1,5 +1,4 @@
 export async function register() {
-  await import(`ts-node/register`)
   // @ts-ignore Exposed by deps/shims/loader.node.ts
   await globalThis.__capi_enableTsLoader()
 }


### PR DESCRIPTION
CJS compat broke all of the patterns (as the codegen is ESM); moving back to ESM-only.

Also resolves #1096 