### PR TITLE
fix: add optional field handling to pjs compat

### DIFF
--- a/patterns/compat/pjs_sender.ts
+++ b/patterns/compat/pjs_sender.ts
@@ -88,6 +88,7 @@ const pjsExtraKeyMap: Record<string, KeyHandler> = {
     // pjs essentially spreads this into the extrinsic
     const visitor: $.CodecVisitor<$.Codec<any>> = new $.CodecVisitor<$.Codec<any>>()
       .add($.field, (_, key, value) => $.field(key, $pjs(value)))
+      .add($.optionalField, (_, key, value) => $.optionalField(key, $pjs(value)))
       .add($.object, (_, ...fields) => $.object(...fields.map((x) => visitor.visit(x))))
     return visitor.visit(value)
   },


### PR DESCRIPTION
A follow up to https://github.com/paritytech/capi/pull/1105
unfortunately the nft collection creation still wasn't working on gamma 1 of capi
code was breaking on assetId field, which is part of ChargeAssetTxPayment

this fixes the problem, though I'm not sure if a similar handler should also be added to
https://github.com/paritytech/capi/blob/main/patterns/compat/pjs_sender.ts#L62
and
https://github.com/paritytech/capi/blob/main/patterns/compat/pjs_sender.ts#L75