### PR TITLE
fix: node compatibility docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,9 @@ interactions without compromising either performance or ease of use.
 npm i capi
 ```
 
-> Note: Capi depends on the standard Web Crypto API (Node 20.3.1 and above). See
+> Note: Capi depends on the standard
+> [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
+> (**Node 20.3.1** and above). See
 > [shimming instructions](https://docs.capi.dev/setup/#web-crypto-api).
 
 <details>

--- a/Readme.md
+++ b/Readme.md
@@ -17,9 +17,18 @@ interactions without compromising either performance or ease of use.
 npm i capi
 ```
 
-> Note: The minimum supported Node version is 20, as we require the
+> Note: The minimum supported Node version is 20.3.1. We prioritize browser
+> support, and thus we require the
 > [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
-> be accessible from `globalThis.crypto` for the sake of browser compatibility.
+> to be accessible from `globalThis.crypto`. Node versions 18 and below only
+> expose this api from `require("node:crypto").webcrypto`.
+>
+> If you need to use Capi with a lower version of Node, you can shim
+> `globalThis.crypto`:
+>
+> ```ts
+> globalThis.crypto = require("node:crypto").webcrypto
+> ```
 
 <details>
 <summary>Deno Equivalent</summary>

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ npm i capi
 
 > Note: Capi depends on the standard
 > [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
-> (**Node 20.3.1** and above). See
+> (**Node 20.3.1 and above**). See
 > [shimming instructions](https://docs.capi.dev/setup/#web-crypto-api).
 
 <details>

--- a/Readme.md
+++ b/Readme.md
@@ -20,8 +20,8 @@ npm i capi
 > Note: The minimum supported Node version is 20.3.1. We prioritize browser
 > support, and thus we require the
 > [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
-> to be accessible from `globalThis.crypto`. Node versions 18 and below only
-> expose this api from `require("node:crypto").webcrypto`.
+> to be accessible from `globalThis.crypto`. Node version 18 exposes this api
+> from `require("node:crypto").webcrypto`.
 >
 > If you need to use Capi with a lower version of Node, you can shim
 > `globalThis.crypto`:

--- a/Readme.md
+++ b/Readme.md
@@ -17,18 +17,8 @@ interactions without compromising either performance or ease of use.
 npm i capi
 ```
 
-> Note: The minimum supported Node version is 20.3.1. We prioritize browser
-> support, and thus we require the
-> [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
-> to be accessible from `globalThis.crypto`. Node version 18 exposes this api
-> from `require("node:crypto").webcrypto`.
->
-> If you need to use Capi with a lower version of Node, you can shim
-> `globalThis.crypto`:
->
-> ```ts
-> globalThis.crypto = require("node:crypto").webcrypto
-> ```
+> Note: Capi depends on the standard Web Crypto API (Node 20.3.1 and above). See
+> [shimming instructions](https://docs.capi.dev/setup/#web-crypto-api).
 
 <details>
 <summary>Deno Equivalent</summary>

--- a/words.txt
+++ b/words.txt
@@ -85,6 +85,7 @@ twox
 unfollow
 unhandle
 vadimcn
+webcrypto
 westend
 westmint
 xcmp


### PR DESCRIPTION
#1163

Omitted "and below", since if we go below node version 14 this api doesn't exist.