### PR TITLE
chore: docs attached to frame codegen

### DIFF
--- a/codegen/TypeCodegen.ts
+++ b/codegen/TypeCodegen.ts
@@ -10,6 +10,7 @@ import {
 import { $era, $null, ChainError } from "../scale_info/mod.ts"
 import { stringifyKey, stringifyPropertyAccess } from "../util/mod.ts"
 import { CodecCodegen } from "./CodecCodegen.ts"
+import { formatDocComment } from "./common.ts"
 
 export class TypeCodegen {
   constructor(readonly codecCodegen: CodecCodegen, readonly types: Record<string, $.AnyCodec>) {
@@ -290,10 +291,4 @@ export ${isTypes ? `namespace ${name}` : `const ${name} =`} {
       `,
     )
   }
-}
-
-function formatDocComment(docs: string) {
-  if (!docs) return ""
-  if (!docs.includes("\n")) return `/** ${docs} */`
-  return `/**\n${docs.replace(/^/gm, " * ")}\n*/`
 }

--- a/codegen/common.ts
+++ b/codegen/common.ts
@@ -1,0 +1,5 @@
+export function formatDocComment(docs: string) {
+  if (!docs) return ""
+  if (!docs.includes("\n")) return `/** ${docs} */`
+  return `/**\n${docs.replace(/^/gm, " * ")}\n*/`
+}

--- a/codegen/frameCodegen.ts
+++ b/codegen/frameCodegen.ts
@@ -2,6 +2,7 @@ import { hex } from "../crypto/mod.ts"
 import * as $ from "../deps/scale.ts"
 import { FrameMetadata } from "../frame_metadata/mod.ts"
 import { CodecCodegen } from "./CodecCodegen.ts"
+import { formatDocComment } from "./common.ts"
 import { TypeCodegen } from "./TypeCodegen.ts"
 
 export function frameCodegen(
@@ -52,14 +53,18 @@ export function frameCodegen(
     const palletStatements: string[] = []
 
     for (const storage of Object.values(pallet.storage)) {
-      palletDeclarationStatements.push(
-        `${storage.name}: C.StorageRune<${chainIdent}, "${pallet.name}", "${storage.name}", never>`,
-      )
+      palletDeclarationStatements.push(`
+        ${formatDocComment(storage.docs)}
+        ${storage.name}: C.StorageRune<${chainIdent}, "${pallet.name}", "${storage.name}", never>
+      `)
       palletStatements.push(`${storage.name} = this.storage("${storage.name}")`)
     }
 
     for (const constant of Object.values(pallet.constants)) {
-      palletDeclarationStatements.push(`${constant.name}: ${typeCodegen.native(constant.codec)}`)
+      palletDeclarationStatements.push(`
+        ${formatDocComment(constant.docs)}
+        ${constant.name}: ${typeCodegen.native(constant.codec)}
+      `)
       palletStatements.push(
         `${constant.name} = ${codecCodegen.print(constant.codec)}.decode(C.hex.decode("${
           hex.encode(constant.value)


### PR DESCRIPTION
- [x] storage
- [x] constants
- [ ] call data factories

---

Do we care about docs being attached to guards, codecs, non-call-data factories etc.?