### PR TITLE
feat: add `ready` method to `ExtrinsicStatusRune` + processing stages example

### DIFF
--- a/examples/tx/processing_stages.eg.ts
+++ b/examples/tx/processing_stages.eg.ts
@@ -1,0 +1,26 @@
+/**
+ * @title Handling Different Extrinsic Statuses
+ * @description Get promises corresponding to specific extrinsic statuses.
+ * This is useful for tracking an extrinsic's submission lifecycle.
+ */
+
+import { westendDev } from "@capi/westend-dev"
+import { createDevUsers } from "capi"
+import { signature } from "capi/patterns/signature/polkadot"
+
+/// Create two dev users. Alexa will send the funds to Billy.
+const { alexa, billy } = await createDevUsers()
+
+// Create and submit the transaction.
+const sent = westendDev.Balances
+  .transfer({
+    value: 12345n,
+    dest: billy.address,
+  })
+  .signed(signature({ sender: alexa }))
+  .sent()
+
+/// Attach callbacks to the pending status-specific promises.
+sent.ready().run().then(() => console.log(`Ready`))
+sent.inBlock().run().then((hash) => console.log(`In block ${hash}`))
+sent.finalized().run().then((hash) => console.log(`Finalized ${hash}`))

--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -28,8 +28,8 @@ export class ExtrinsicStatusRune<out C extends Chain, out U1, out U2>
     return this.transactionStatuses((status) =>
       known.TransactionStatus.isTerminal(status) || status === "ready"
     )
-      .map((status) => status === "ready" || new NeverInBlockError())
-      .unhandle(is(NeverInBlockError))
+      .map((status) => status === "ready" || new NeverReadyError())
+      .unhandle(is(NeverReadyError))
   }
 
   inBlock() {
@@ -87,5 +87,6 @@ export class ExtrinsicStatusRune<out C extends Chain, out U1, out U2>
   }
 }
 
+export class NeverReadyError extends Error {}
 export class NeverInBlockError extends Error {}
 export class NeverFinalizedError extends Error {}

--- a/fluent/ExtrinsicStatusRune.ts
+++ b/fluent/ExtrinsicStatusRune.ts
@@ -24,6 +24,14 @@ export class ExtrinsicStatusRune<out C extends Chain, out U1, out U2>
       .flatSingular()
   }
 
+  ready() {
+    return this.transactionStatuses((status) =>
+      known.TransactionStatus.isTerminal(status) || status === "ready"
+    )
+      .map((status) => status === "ready" || new NeverInBlockError())
+      .unhandle(is(NeverInBlockError))
+  }
+
   inBlock() {
     return this.transactionStatuses((status) =>
       known.TransactionStatus.isTerminal(status)


### PR DESCRIPTION
@SaltyCucumber

Allows one to attain a promise, which upon `ready` resolves to `true` (or unhandles with a `NeverReadyError`).

```ts
const sent = westendDev.Balances
  .transfer({
    value: 12345n,
    dest: billy.address,
  })
  .signed(signature({ sender: alexa }))
  .sent()

/// Attach callbacks to the pending status-specific promises.
sent.ready().run().then(() => console.log(`Ready`))
sent.inBlock().run().then((hash) => console.log(`In block ${hash}`))
sent.finalized().run().then((hash) => console.log(`Finalized ${hash}`))
```