### PR TITLE
refactor: substrate bindings 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
-  "name": "unstoppablejs",
+  "name": "capi",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "capi",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "devDependencies": {
+        "dprint": "^0.40.2",
         "esbuild": "^0.14.38",
         "husky": ">=6",
         "lint-staged": "^12.4.1",
@@ -612,6 +614,84 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@dprint/darwin-arm64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.40.2.tgz",
+      "integrity": "sha512-qharMFhxpNq9brgvHLbqzzAgVgPWSHLfzNLwWWhKcGOUUDUIilfAo3SlvOz6w4nQiIifLpYZOvZqK7Lpf9mSSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@dprint/darwin-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.40.2.tgz",
+      "integrity": "sha512-FPDdOTVr1JfqtLBTCvqlihWslTy3LBUoi3H1gaqIazCKMj2dB9voFWkBiMT+REMHDrlVsoSpFAfsliNr/y7HPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@dprint/linux-arm64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.40.2.tgz",
+      "integrity": "sha512-GmUWfKwEwXA+onvewX9hEJSMcd9V184+uRbEhI5tG28tBP9+IjQhrY7jCjxPvaZA+EvzNPnAy5D1wbJdlNLBNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@dprint/linux-x64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.40.2.tgz",
+      "integrity": "sha512-vMHAHdsOY+2thieSWbIrIioDfPgvipwUgd0MZUWOqycTrXU6kLyi2B+5J/2Jc+QO3CiLIbumQd2FH/0vB1eWqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@dprint/linux-x64-musl": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.40.2.tgz",
+      "integrity": "sha512-nFSbDWd9ORyOhJ7a+RmE39WbuPoQ3OQutIgfAmfikiu/wENzEwxxv4QJ7aFnBaoZb0wuVEEpXShr8vY4p0exkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@dprint/win32-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.40.2.tgz",
+      "integrity": "sha512-qF4VCQzFTZYD61lbQqXLU/IwUTbLK22CancO+uVtXmZRoKU9GaVjcBhMUB7URxsa8rvxWHhHT6ldillI/aOWCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.14.54",
@@ -1227,6 +1307,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1890,6 +1982,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/dprint": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.40.2.tgz",
+      "integrity": "sha512-3LdyUV0itEW59UPtsRA2StOWOu8FyOW+BgvJpH/tACRHKi0z5gaQnvSxdS3mbG7dgtEhdRnGg6JoiQyGib6NTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "dprint": "bin.js"
+      },
+      "optionalDependencies": {
+        "@dprint/darwin-arm64": "0.40.2",
+        "@dprint/darwin-x64": "0.40.2",
+        "@dprint/linux-arm64-glibc": "0.40.2",
+        "@dprint/linux-x64-glibc": "0.40.2",
+        "@dprint/linux-x64-musl": "0.40.2",
+        "@dprint/win32-x64": "0.40.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2468,6 +2578,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fp-ts": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.1.tgz",
+      "integrity": "sha512-by7U5W8dkIzcvDofUcO42yl9JbnHTEDBrzu3pt5fKT+Z4Oy85I21K80EYJYdjQGC2qum4Vo55Ag57iiIK4FYuA=="
+    },
+    "node_modules/fp-ts-std": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/fp-ts-std/-/fp-ts-std-0.17.1.tgz",
+      "integrity": "sha512-4XFd6W1vQtY/npwhMiWIXiwDg9DfAdlAYmyxmA6ANJTw/RSjqnRZ97zc9yHoYjbKF3ba/GVP54JfR0W7cV9w6w==",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.16.0",
+        "monocle-ts": "^2.3.0",
+        "newtype-ts": "^0.3.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -4087,6 +4215,15 @@
         "node": "*"
       }
     },
+    "node_modules/monocle-ts": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
+      "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
+      "peer": true,
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4099,6 +4236,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/newtype-ts": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
+      "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
+      "peer": true,
+      "peerDependencies": {
+        "fp-ts": "^2.0.0",
+        "monocle-ts": "^2.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5047,12 +5194,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.1.0.tgz",
+      "integrity": "sha512-VJGJVepayd8OWavP+rgXt4i3bfLk+tSomTV7r4mca2XD/oTCWnkJlNkpXavkxdmtU2aKdAmFGeHvoQutOVHCZg==",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5444,7 +5590,10 @@
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "@unstoppablejs/substrate-codecs": "0.0.0-experimental-1519a4ce-142b-4667-bc73-f8913a6dcd50",
-        "@unstoppablejs/utils": "^1.1.0"
+        "@unstoppablejs/utils": "^1.1.0",
+        "fp-ts": "^2.16.1",
+        "fp-ts-std": "^0.17.1",
+        "type-fest": "^4.1.0"
       }
     },
     "packages/substrate-bindings/node_modules/@unstoppablejs/utils": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "capi",
   "private": true,
   "license": "MIT",
   "workspaces": [
@@ -17,6 +18,7 @@
     "trailingComma": "all"
   },
   "devDependencies": {
+    "dprint": "^0.40.2",
     "esbuild": "^0.14.38",
     "husky": ">=6",
     "lint-staged": "^12.4.1",

--- a/packages/substrate-bindings/dprint.json
+++ b/packages/substrate-bindings/dprint.json
@@ -1,0 +1,21 @@
+{
+  "incremental": true,
+  "indentWidth": 2,
+  "lineWidth": 80,
+  "typescript": {
+    "trailingCommas": "onlyMultiLine",
+    "quoteProps": "asNeeded",
+    "arrowFunction.useParentheses": "force",
+    "semiColons": "asi"
+  },
+  "markdown": {
+    "textWrap": "always"
+  },
+  "includes": ["**.{json,md,ts}"],
+  "excludes": ["dist", "package-lock.json"],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.84.4.wasm",
+    "https://plugins.dprint.dev/json-0.17.2.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm"
+  ]
+}

--- a/packages/substrate-bindings/package.json
+++ b/packages/substrate-bindings/package.json
@@ -33,18 +33,16 @@
     "build:cjs:prod": "esbuild src/index.ts --bundle --external:@noble/hashes --external:@unstoppablejs/* --outfile=./dist/substrate-bindings.cjs.cjs.production.min.js --target=es2020 --format=cjs --minify --sourcemap",
     "build:ts": "tsc -p ./tsconfig-build.json --outDir ./dist --skipLibCheck --emitDeclarationOnly && rm -rf ./dist/internal",
     "test": "echo 'No tests'",
-    "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
-    "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "lint": "dprint check",
+    "format": "dprint fmt",
     "prepack": "npm run build"
-  },
-  "prettier": {
-    "printWidth": 80,
-    "semi": false,
-    "trailingComma": "all"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.1",
     "@unstoppablejs/substrate-codecs": "0.0.0-experimental-1519a4ce-142b-4667-bc73-f8913a6dcd50",
-    "@unstoppablejs/utils": "^1.1.0"
+    "@unstoppablejs/utils": "^1.1.0",
+    "fp-ts-std": "^0.17.1",
+    "fp-ts": "^2.16.1",
+    "type-fest": "^4.1.0"
   }
 }

--- a/packages/substrate-bindings/src/hashes/blake2.ts
+++ b/packages/substrate-bindings/src/hashes/blake2.ts
@@ -1,11 +1,14 @@
-import { mergeUint8 } from "@unstoppablejs/utils"
 import { blake2b } from "@noble/hashes/blake2b"
+import { mergeUint8 } from "@unstoppablejs/utils"
+import { Endomorphism } from "fp-ts/lib/Endomorphism"
 
 const len32 = { dkLen: 32 }
-export const Blake2256 = (encoded: Uint8Array) => blake2b(encoded, len32)
+export const Blake2256: Endomorphism<Uint8Array> = (encoded) =>
+  blake2b(encoded, len32)
 
 const len16 = { dkLen: 16 }
-export const Blake2128 = (encoded: Uint8Array) => blake2b(encoded, len16)
+export const Blake2128: Endomorphism<Uint8Array> = (encoded) =>
+  blake2b(encoded, len16)
 
-export const Blake2128Concat = (encoded: Uint8Array) =>
+export const Blake2128Concat: Endomorphism<Uint8Array> = (encoded) =>
   mergeUint8(Blake2128(encoded), encoded)

--- a/packages/substrate-bindings/src/hashes/identity.ts
+++ b/packages/substrate-bindings/src/hashes/identity.ts
@@ -1,1 +1,4 @@
-export const Identity = (encoded: Uint8Array): Uint8Array => encoded
+import { Endomorphism } from "fp-ts/lib/Endomorphism"
+import { identity } from "fp-ts/lib/function"
+
+export const Identity: Endomorphism<Uint8Array> = identity

--- a/packages/substrate-bindings/src/hashes/twoX.ts
+++ b/packages/substrate-bindings/src/hashes/twoX.ts
@@ -1,28 +1,29 @@
-import { mergeUint8 } from "@unstoppablejs/utils"
 import { u64 } from "@unstoppablejs/substrate-codecs"
-import { h64 } from "./h64"
+import { mergeUint8 } from "@unstoppablejs/utils"
+import { Endomorphism } from "fp-ts/lib/Endomorphism"
+import { xxh64 } from "./xxh64"
 
-export const Twox128 = (input: Uint8Array): Uint8Array => {
+export const Twox128: Endomorphism<Uint8Array> = (input) => {
   const result = new Uint8Array(16)
   const dv = new DataView(result.buffer)
 
-  dv.setBigUint64(0, h64(input), true)
-  dv.setBigUint64(8, h64(input, 1n), true)
+  dv.setBigUint64(0, xxh64(input), true)
+  dv.setBigUint64(8, xxh64(input, 1n), true)
 
   return result
 }
 
-export const Twox256 = (input: Uint8Array): Uint8Array => {
+export const Twox256: Endomorphism<Uint8Array> = (input) => {
   const result = new Uint8Array(32)
   const dv = new DataView(result.buffer)
 
-  dv.setBigUint64(0, h64(input), true)
-  dv.setBigUint64(8, h64(input, 1n), true)
-  dv.setBigUint64(16, h64(input, 2n), true)
-  dv.setBigUint64(24, h64(input, 3n), true)
+  dv.setBigUint64(0, xxh64(input), true)
+  dv.setBigUint64(8, xxh64(input, 1n), true)
+  dv.setBigUint64(16, xxh64(input, 2n), true)
+  dv.setBigUint64(24, xxh64(input, 3n), true)
 
   return result
 }
 
-export const Twox64Concat = (encoded: Uint8Array): Uint8Array =>
-  mergeUint8(u64.enc(h64(encoded)), encoded)
+export const Twox64Concat: Endomorphism<Uint8Array> = (encoded) =>
+  mergeUint8(u64.enc(xxh64(encoded)), encoded)

--- a/packages/substrate-bindings/src/hashes/xxh64.ts
+++ b/packages/substrate-bindings/src/hashes/xxh64.ts
@@ -28,7 +28,7 @@ const PRIME64_3 = 1609587929392839161n
 const PRIME64_4 = 9650029242287828579n
 const PRIME64_5 = 2870177450012600261n
 
-export function h64(input: Uint8Array, seed: bigint = 0n) {
+export function xxh64(input: Uint8Array, seed: bigint = 0n) {
   let v1 = add(add(seed, PRIME64_1), PRIME64_2)
   let v2 = add(seed, PRIME64_2)
   let v3 = seed
@@ -36,7 +36,6 @@ export function h64(input: Uint8Array, seed: bigint = 0n) {
   let totalLen = input.length
   let memsize = 0
   let memory: Uint8Array | null = null
-
   ;(function update() {
     let p = 0
     let bEnd = p + totalLen

--- a/packages/substrate-bindings/src/storage.ts
+++ b/packages/substrate-bindings/src/storage.ts
@@ -1,11 +1,17 @@
-import { mergeUint8, toHex, utf16StrToUtf8Bytes } from "@unstoppablejs/utils"
 import { Decoder, Encoder } from "@unstoppablejs/substrate-codecs"
+import { mergeUint8, toHex, utf16StrToUtf8Bytes } from "@unstoppablejs/utils"
+import { Endomorphism } from "fp-ts/lib/Endomorphism"
+import { flow } from "fp-ts/lib/function"
+import { SetReturnType } from "type-fest"
 import { Twox128 } from "./hashes"
 
-type EncoderWithHash<T> = [Encoder<T>, (input: Uint8Array) => Uint8Array]
+export type EncoderWithHash<T> = [Encoder<T>, Endomorphism<Uint8Array>]
+export type StorageCodec<OT, T> = {
+  enc: SetReturnType<Encoder<OT>, string>
+  dec: Decoder<T>
+}
 
 export const Storage = (pallet: string) => {
-  const palledEncoded = Twox128(utf16StrToUtf8Bytes(pallet))
   return <
     T,
     A extends Array<EncoderWithHash<any>>,
@@ -16,27 +22,21 @@ export const Storage = (pallet: string) => {
     name: string,
     dec: Decoder<T>,
     ...encoders: [...A]
-  ): {
-    enc: (...args: OT) => string
-    dec: Decoder<T>
-  } => {
+  ): StorageCodec<OT, T> => {
     const palletItemEncoded = mergeUint8(
-      palledEncoded,
+      Twox128(utf16StrToUtf8Bytes(pallet)),
       Twox128(utf16StrToUtf8Bytes(name)),
     )
-    const fns = encoders.map(
-      ([enc, hash]) =>
-        (val: any) =>
-          hash(enc(val)),
-    )
-
-    const enc = (...args: OT): string =>
-      toHex(
-        mergeUint8(palletItemEncoded, ...args.map((val, idx) => fns[idx](val))),
-      )
+    const fns = encoders.map(([enc, hash]) => flow(enc, hash))
 
     return {
-      enc,
+      enc: (...args) =>
+        toHex(
+          mergeUint8(
+            palletItemEncoded,
+            ...args.map((val, idx) => fns[idx](val)),
+          ),
+        ),
       dec,
     }
   }


### PR DESCRIPTION
minor refactor to make things look a bit prettier. not married to any of these changes, so feel free to comment.

- uses dprint instead of prettier b/c its annoying how prettier forces everything to ident or move to newline in a certain way
- adds some type level (type-fest) and functional utility libraries (fp-ts)