### PR TITLE
chore: add base tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ts-jest": "^27.1.4",
         "tslib": "^2.4.0",
         "typescript": "^4.6.4",
+        "vite-tsconfig-paths": "^4.2.0",
         "vitest": "^0.34.1"
       }
     },
@@ -3161,6 +3162,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5820,6 +5827,26 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
+      "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
@@ -6029,6 +6056,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ts-jest": "^27.1.4",
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
+    "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.34.1"
   },
   "lint-staged": {

--- a/packages/substrate-bindings/tsconfig-build.json
+++ b/packages/substrate-bindings/tsconfig-build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests"],
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
+  "include": ["src"]
 }

--- a/packages/substrate-bindings/tsconfig-build.json
+++ b/packages/substrate-bindings/tsconfig-build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/tests"]
+  "exclude": ["tests"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/substrate-bindings/tsconfig.json
+++ b/packages/substrate-bindings/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
 }

--- a/packages/substrate-bindings/tsconfig.json
+++ b/packages/substrate-bindings/tsconfig.json
@@ -1,29 +1,4 @@
 {
-  "include": ["src"],
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["DOM", "DOM.Iterable", "esnext"],
-    "importHelpers": true,
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./src",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
-    "esModuleInterop": true
-  }
+  "extends": "../../tsconfig.base",
+  "include": ["src"]
 }

--- a/packages/substrate-bindings/tsconfig.json
+++ b/packages/substrate-bindings/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"],
+  "include": ["src", "tests"],
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {

--- a/packages/substrate-client/tsconfig-build.json
+++ b/packages/substrate-client/tsconfig-build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests"],
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
+  "include": ["src"]
 }

--- a/packages/substrate-client/tsconfig-build.json
+++ b/packages/substrate-client/tsconfig-build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.*"]
+  "exclude": ["tests"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/substrate-client/tsconfig.json
+++ b/packages/substrate-client/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
 }

--- a/packages/substrate-client/tsconfig.json
+++ b/packages/substrate-client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"],
+  "include": ["src", "tests"],
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {

--- a/packages/substrate-client/tsconfig.json
+++ b/packages/substrate-client/tsconfig.json
@@ -1,29 +1,4 @@
 {
-  "include": ["src"],
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "importHelpers": true,
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./src",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
-    "esModuleInterop": true
-  }
+  "extends": "../../tsconfig.base",
+  "include": ["src"]
 }

--- a/packages/substrate-codecs/tests/AccountId.spec.ts
+++ b/packages/substrate-codecs/tests/AccountId.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest"
 import { bytesToHex } from "@noble/hashes/utils"
 
-import { AccountId } from "../src/AccountId"
+import { AccountId } from "@/AccountId"
 
 test.each([
   [

--- a/packages/substrate-codecs/tsconfig-build.json
+++ b/packages/substrate-codecs/tsconfig-build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests"],
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
+  "include": ["src"]
 }

--- a/packages/substrate-codecs/tsconfig-build.json
+++ b/packages/substrate-codecs/tsconfig-build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/tests"]
+  "exclude": ["tests"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/substrate-codecs/tsconfig.json
+++ b/packages/substrate-codecs/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
 }

--- a/packages/substrate-codecs/tsconfig.json
+++ b/packages/substrate-codecs/tsconfig.json
@@ -1,29 +1,4 @@
 {
-  "include": ["src"],
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["DOM", "DOM.Iterable", "esnext"],
-    "importHelpers": true,
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./src",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
-    "esModuleInterop": true
-  }
+  "extends": "../../tsconfig.base",
+  "include": ["src"]
 }

--- a/packages/substrate-codecs/tsconfig.json
+++ b/packages/substrate-codecs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"],
+  "include": ["src", "tests"],
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {

--- a/packages/substrate-codegen/tsconfig-build.json
+++ b/packages/substrate-codegen/tsconfig-build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests"],
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
+  "include": ["src"]
 }

--- a/packages/substrate-codegen/tsconfig-build.json
+++ b/packages/substrate-codegen/tsconfig-build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/tests"]
+  "exclude": ["tests"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/substrate-codegen/tsconfig.json
+++ b/packages/substrate-codegen/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
 }

--- a/packages/substrate-codegen/tsconfig.json
+++ b/packages/substrate-codegen/tsconfig.json
@@ -1,29 +1,4 @@
 {
-  "include": ["src"],
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["DOM", "DOM.Iterable", "esnext"],
-    "importHelpers": true,
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./src",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
-    "esModuleInterop": true
-  }
+  "extends": "../../tsconfig.base",
+  "include": ["src"]
 }

--- a/packages/substrate-codegen/tsconfig.json
+++ b/packages/substrate-codegen/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base",
-  "include": ["src"],
+  "include": ["src", "tests"],
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "importHelpers": true,
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./src",
+    "paths": {
+      "*": ["src/*", "node_modules/*"]
+    },
+    "esModuleInterop": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,10 +18,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./src",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "esModuleInterop": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config"
+import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
   test: {
     include: ["**/*.spec.ts"],
   },
+  plugins: [tsconfigPaths()],
 })


### PR DESCRIPTION
Share a common `tsconfig.json` across workspace packages.

Note: all relative paths found in the base configuration file will be resolved relative to the configuration file they originated in (see [extends](https://www.typescriptlang.org/tsconfig#extends)).
For example
- `include`/`exclude`
- `compilerOptions`
  - `baseUrl`
  - `paths`