### PR TITLE
fix: ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm ci
       - name: Run lint
         run: npm run lint
-      - name: Run tests
-        run: npm run test
       - name: Build
         run: npm run build
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
Build needs to happen before tests, otherwise packages that dependent on other packages cannot run.