### PR TITLE
substrate-bindings: unpolished `descriptors`

### DIFF
--- a/packages/substrate-bindings/src/descriptors.ts
+++ b/packages/substrate-bindings/src/descriptors.ts
@@ -1,0 +1,108 @@
+// It should NOT be exported.
+interface DescriptorBase {
+  type: "storage" | "event" | "tx" | "const"
+  pallet: string
+  name: string
+  checksum: string
+}
+
+// @ts-ignore
+export interface StorageDescriptor<Keys extends Array<any>, O>
+  extends DescriptorBase {
+  type: "storage"
+}
+
+// @ts-ignore
+export interface ConstantDescriptor<Payload> extends DescriptorBase {
+  type: "const"
+}
+
+export interface EventDescriptor<
+  Name extends string,
+  // @ts-ignore
+  Payload,
+> extends DescriptorBase {
+  type: "event"
+  name: Name
+}
+
+export interface CallDescriptor<
+  // @ts-ignore
+  Args extends Array<any>,
+  Events extends Array<EventDescriptor<any, any>>,
+  Errors extends Array<string>,
+> extends DescriptorBase {
+  type: "tx"
+  events: Events
+  errors: Errors
+}
+
+export type Descriptor =
+  | StorageDescriptor<any, any>
+  | EventDescriptor<any, any>
+  | CallDescriptor<any, any, any>
+  | ConstantDescriptor<any>
+
+export type EventToObject<E extends EventDescriptor<any, any>> =
+  E extends EventDescriptor<infer K, infer V> ? { type: K; value: V } : unknown
+
+export type UnionizeTupleEvents<E extends Array<EventDescriptor<any, any>>> =
+  E extends Array<infer Ev>
+    ? Ev extends EventDescriptor<any, any>
+      ? EventToObject<Ev>
+      : unknown
+    : unknown
+
+export type CallDescriptorArgs<D extends CallDescriptor<any, any, any>> =
+  D extends CallDescriptor<infer A, any, any> ? A : []
+
+export type CallDescriptorEvents<D extends CallDescriptor<any, any, any>> =
+  D extends CallDescriptor<any, infer E, any> ? E : []
+
+export type CallDescriptorErrors<D extends CallDescriptor<any, any, any>> =
+  D extends CallDescriptor<any, any, infer E>
+    ? E extends Array<infer IE>
+      ? IE
+      : []
+    : []
+
+export type CallFunction<D extends CallDescriptor<any, any, any>> = (
+  ...args: CallDescriptorArgs<D>
+) => Promise<
+  | {
+      ok: true
+      events: Array<UnionizeTupleEvents<CallDescriptorEvents<D>>>
+    }
+  | { ok: false; error: CallDescriptorErrors<D> }
+>
+
+/* TRY IT OUT:
+
+type FooEvent = EventDescriptor<"foo", string>
+type BarEvent = EventDescriptor<"bar", number>
+type BazEvent = EventDescriptor<"baz", boolean>
+
+type RawEvents = [FooEvent, BarEvent, BazEvent]
+
+type PossibleErrors = ["WrongFoo", "UnnexpectedBar", "NotEnoughBaz", "WTF"]
+
+type MyTxDescriptor = CallDescriptor<
+  [account: string, era: number],
+  RawEvents,
+  PossibleErrors
+>
+
+export const myTx: CallFunction<MyTxDescriptor> = (() => {}) as any
+
+const result = await myTx('account', 2)
+
+if (result.ok) {
+  result.events.find(e => e.type === 'baz' && e.value)
+} else {
+  if (result.error === 'WTF') {
+    console.log("I knew it")
+  } else {
+    console.log(result.error)
+  }
+}
+*/

--- a/packages/substrate-bindings/src/descriptors.ts
+++ b/packages/substrate-bindings/src/descriptors.ts
@@ -1,50 +1,170 @@
-// It should NOT be exported.
-interface DescriptorBase {
-  type: "storage" | "event" | "tx" | "const"
-  pallet: string
-  name: string
-  checksum: string
-}
+type Tuple<T> = readonly [T, ...T[]]
 
-// @ts-ignore
-export interface StorageDescriptor<Keys extends Array<any>, O>
-  extends DescriptorBase {
-  type: "storage"
-}
-
-// @ts-ignore
-export interface ConstantDescriptor<Payload> extends DescriptorBase {
-  type: "const"
-}
-
-export interface EventDescriptor<
-  Name extends string,
-  // @ts-ignore
-  Payload,
-> extends DescriptorBase {
-  type: "event"
+export interface DescriptorCommon<Pallet extends string, Name extends string> {
+  checksum: bigint
+  pallet: Pallet
   name: Name
 }
 
-export interface CallDescriptor<
-  // @ts-ignore
-  Args extends Array<any>,
-  Events extends Array<EventDescriptor<any, any>>,
-  Errors extends Array<string>,
-> extends DescriptorBase {
+// @ts-ignore
+export interface ArgsWithPayloadCodec<Args extends Array<any>, O> {}
+
+export interface StorageDescriptor<
+  Common extends DescriptorCommon<string, string>,
+  Codecs extends ArgsWithPayloadCodec<any, any>,
+> {
+  type: "storage"
+  props: Common
+  codecs: Codecs
+}
+
+export interface ConstantDescriptor<
+  Common extends DescriptorCommon<string, string>,
+  Codecs,
+> {
+  type: "const"
+  props: Common
+  codecs: Codecs
+}
+
+export interface EventDescriptor<
+  Common extends DescriptorCommon<string, string>,
+  Codecs,
+> {
+  type: "event"
+  props: Common
+  codecs: Codecs
+}
+
+export interface ErrorDescriptor<
+  Common extends DescriptorCommon<string, string>,
+  Codecs,
+> {
+  type: "error"
+  props: Common
+  codecs: Codecs
+}
+
+export interface TxDescriptor<
+  Common extends DescriptorCommon<string, string>,
+  Codecs extends Array<any>,
+  Events extends Tuple<EventDescriptor<any, any>>,
+  Errors extends Tuple<ErrorDescriptor<any, any>>,
+> {
   type: "tx"
+  props: Common
+  codecs: Codecs
   events: Events
   errors: Errors
 }
 
 export type Descriptor =
-  | StorageDescriptor<any, any>
+  | ConstantDescriptor<any, any>
   | EventDescriptor<any, any>
-  | CallDescriptor<any, any, any>
-  | ConstantDescriptor<any>
+  | StorageDescriptor<any, any>
+  | ErrorDescriptor<any, any>
+  | TxDescriptor<any, any, any, any>
 
-export type EventToObject<E extends EventDescriptor<any, any>> =
-  E extends EventDescriptor<infer K, infer V> ? { type: K; value: V } : unknown
+export const createCommonDescriptor = <
+  Pallet extends string,
+  Name extends string,
+>(
+  checksum: bigint,
+  pallet: Pallet,
+  name: Name,
+): DescriptorCommon<Pallet, Name> => ({
+  checksum,
+  pallet,
+  name,
+})
+
+export const getDescriptorCreator = <
+  Type extends "const" | "event" | "error",
+  Pallet extends string,
+  Name extends string,
+  Codecs,
+>(
+  type: Type,
+  checksum: bigint,
+  pallet: Pallet,
+  name: Name,
+  codecs: Codecs,
+): Type extends "const"
+  ? ConstantDescriptor<DescriptorCommon<Pallet, Name>, Codecs>
+  : Type extends "event"
+  ? EventDescriptor<DescriptorCommon<Pallet, Name>, Codecs>
+  : ErrorDescriptor<DescriptorCommon<Pallet, Name>, Codecs> =>
+  ({
+    type,
+    props: { checksum, pallet, name },
+    codecs,
+  }) as any
+
+export const getPalletCreator = <Pallet extends string>(pallet: Pallet) => {
+  const getPayloadDescriptor = <
+    Type extends "const" | "event" | "error",
+    Name extends string,
+    Codecs,
+  >(
+    type: Type,
+    checksum: bigint,
+    name: Name,
+    codecs: Codecs,
+  ): Type extends "const"
+    ? ConstantDescriptor<DescriptorCommon<Pallet, Name>, Codecs>
+    : Type extends "event"
+    ? EventDescriptor<DescriptorCommon<Pallet, Name>, Codecs>
+    : ErrorDescriptor<DescriptorCommon<Pallet, Name>, Codecs> =>
+    ({
+      type,
+      props: { checksum, pallet, name },
+      codecs,
+    }) as any
+
+  const getStorageDescriptor = <
+    Name extends string,
+    Codecs extends ArgsWithPayloadCodec<Array<any>, any>,
+  >(
+    checksum: bigint,
+    name: Name,
+    codecs: Codecs,
+  ): StorageDescriptor<DescriptorCommon<Pallet, Name>, Codecs> => ({
+    type: "storage",
+    props: { checksum, pallet, name },
+    codecs,
+  })
+
+  const getTxDescriptor = <
+    Name extends string,
+    Codecs extends Array<any>,
+    Events extends Tuple<EventDescriptor<any, any>>,
+    Errors extends Tuple<ErrorDescriptor<any, any>>,
+  >(
+    checksum: bigint,
+    name: Name,
+    events: Events,
+    errors: Errors,
+    codecs: Codecs,
+  ): TxDescriptor<DescriptorCommon<Pallet, Name>, Codecs, Events, Errors> => ({
+    type: "tx",
+    props: { checksum, pallet, name },
+    codecs,
+    events,
+    errors,
+  })
+
+  return {
+    getPayloadDescriptor,
+    getStorageDescriptor,
+    getTxDescriptor,
+  }
+}
+
+export type EventToObject<
+  E extends EventDescriptor<DescriptorCommon<any, string>, any>,
+> = E extends EventDescriptor<DescriptorCommon<any, infer K>, infer V>
+  ? { type: K; value: V }
+  : unknown
 
 export type UnionizeTupleEvents<E extends Array<EventDescriptor<any, any>>> =
   E extends Array<infer Ev>
@@ -53,54 +173,98 @@ export type UnionizeTupleEvents<E extends Array<EventDescriptor<any, any>>> =
       : unknown
     : unknown
 
-export type CallDescriptorArgs<D extends CallDescriptor<any, any, any>> =
-  D extends CallDescriptor<infer A, any, any> ? A : []
+export type TxDescriptorArgs<D extends TxDescriptor<any, any, any, any>> =
+  D extends TxDescriptor<any, infer A, any, any> ? A : []
 
-export type CallDescriptorEvents<D extends CallDescriptor<any, any, any>> =
-  D extends CallDescriptor<any, infer E, any> ? E : []
+export type TxDescriptorEvents<D extends TxDescriptor<any, any, any, any>> =
+  D extends TxDescriptor<any, any, infer E, any> ? E : []
 
-export type CallDescriptorErrors<D extends CallDescriptor<any, any, any>> =
-  D extends CallDescriptor<any, any, infer E>
-    ? E extends Array<infer IE>
-      ? IE
+export type TxDescriptorErrors<D extends TxDescriptor<any, any, any, any>> =
+  D extends TxDescriptor<any, any, any, infer Errors>
+    ? Errors extends Tuple<ErrorDescriptor<any, any>>
+      ? {
+          [K in keyof Errors]: Errors[K] extends ErrorDescriptor<
+            DescriptorCommon<any, infer Type>,
+            infer Value
+          >
+            ? { type: Type; value: Value }
+            : unknown
+        }[keyof Errors extends number ? keyof Errors : never]
       : []
     : []
 
-export type CallFunction<D extends CallDescriptor<any, any, any>> = (
-  ...args: CallDescriptorArgs<D>
+export type TxFunction<D extends TxDescriptor<any, any, any, any>> = (
+  ...args: TxDescriptorArgs<D>
 ) => Promise<
   | {
       ok: true
-      events: Array<UnionizeTupleEvents<CallDescriptorEvents<D>>>
+      events: Array<UnionizeTupleEvents<TxDescriptorEvents<D>>>
     }
-  | { ok: false; error: CallDescriptorErrors<D> }
+  | { ok: false; error: TxDescriptorErrors<D> }
 >
 
-/* TRY IT OUT:
+/* try it out!
 
-type FooEvent = EventDescriptor<"foo", string>
-type BarEvent = EventDescriptor<"bar", number>
-type BazEvent = EventDescriptor<"baz", boolean>
+const myPalletCreator = getPalletCreator("MyPallet")
+const fooEvent = myPalletCreator.getPayloadDescriptor(
+  "event",
+  0n,
+  "foo",
+  {} as string,
+)
+const barEvent = myPalletCreator.getPayloadDescriptor(
+  "event",
+  0n,
+  "bar",
+  {} as number,
+)
+const bazEvent = myPalletCreator.getPayloadDescriptor(
+  "event",
+  0n,
+  "baz",
+  {} as boolean,
+)
 
-type RawEvents = [FooEvent, BarEvent, BazEvent]
+const wrongFoo = myPalletCreator.getPayloadDescriptor(
+  "error",
+  0n,
+  "WTF",
+  {} as unknown as void,
+)
 
-type PossibleErrors = ["WrongFoo", "UnnexpectedBar", "NotEnoughBaz", "WTF"]
+const unnexpectedBar = myPalletCreator.getPayloadDescriptor(
+  "error",
+  0n,
+  "unnexpectedBar",
+  {} as number,
+)
 
-type MyTxDescriptor = CallDescriptor<
-  [account: string, era: number],
-  RawEvents,
-  PossibleErrors
->
+const notEnoughBaz = myPalletCreator.getPayloadDescriptor(
+  "error",
+  0n,
+  "notEnoughBaz",
+  {} as number,
+)
 
-export const myTx: CallFunction<MyTxDescriptor> = (() => {}) as any
+const myTxDescriptor = myPalletCreator.getTxDescriptor(
+  1n,
+  "myTx",
+  [fooEvent, bazEvent, barEvent],
+  [unnexpectedBar, notEnoughBaz, wrongFoo],
+  {} as [name: string, value: number],
+)
 
-const result = await myTx('account', 2)
+export const myTx: TxFunction<typeof myTxDescriptor> = (() => {}) as any
+
+const result = await myTx("account", 2)
 
 if (result.ok) {
-  result.events.find(e => e.type === 'baz' && e.value)
+  result.events.find((e) => e.type === "foo" && e.value)
 } else {
-  if (result.error === 'WTF') {
-    console.log("I knew it")
+  if (result.error.type === "unnexpectedBar") {
+    let someNumber = 0
+    someNumber += result.error.value // notice that through type-inference we know that `value` is a number
+    console.log("I knew it", someNumber)
   } else {
     console.log(result.error)
   }

--- a/packages/substrate-bindings/src/index.ts
+++ b/packages/substrate-bindings/src/index.ts
@@ -1,3 +1,4 @@
 export * from "@unstoppablejs/substrate-codecs"
 export * from "./hashes"
 export * from "./storage"
+export * from "./descriptors"


### PR DESCRIPTION
I've been going on and on about "descriptors" and how they're the magic behind the "capi-client". I get the feeling I might've confused you a bit. My bad.

![image](https://github.com/paritytech/capi/assets/8620144/961b01c7-364b-4623-a600-143176fbc224)

So, here's the deal. I'm opening this PR with the basic types of these descriptors. I've thrown in some type-helpers too, so you can see their potential for creating some cool APIs.

While I'm pretty sure about the core descriptor types (`StorageDescriptor`, `EventDescriptor`, `CallDescriptor`, and `ConstantDescriptor`), a lot of stuff in this PR is still being ironed out. Plus, we need more type-helpers.

Why this PR? Two reasons:
1. I wanted to show you what these descriptor types look like, clear up any confusion.
2. I'm dropping another PR soon about the `codegen` updates for these "descriptors", so it'd be cool if you got a hang of these types by then.

So, if you are cool with this, then let's get this PR merged ASAP so that you can also play and get familiar with these types.

PS: the "try it out" comment will be moved to the `experiments` package that's coming soon.