### PR TITLE
chore: move tests to `tests` folder

### DIFF
--- a/packages/substrate-bindings/tests/hashes/blake2.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/blake2.spec.ts
@@ -1,7 +1,7 @@
 import { fc, test } from "@fast-check/vitest"
 import { expect } from "vitest"
 import { mergeUint8 } from "@unstoppablejs/utils"
-import { Blake2128, Blake2256, Blake2128Concat } from "./blake2"
+import { Blake2128, Blake2256, Blake2128Concat } from "@/hashes/blake2"
 import { blake2b } from "@noble/hashes/blake2b"
 
 test.prop([fc.uint8Array()])("Blake2256", (input) => {

--- a/packages/substrate-bindings/tests/hashes/h64.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/h64.spec.ts
@@ -1,6 +1,6 @@
 import { fc, test } from "@fast-check/vitest"
 import { expect } from "vitest"
-import { h64 } from "./h64"
+import { h64 } from "@/hashes/h64"
 import { xxhash64 } from "hash-wasm"
 import { hexToBigint } from "bigint-conversion"
 

--- a/packages/substrate-bindings/tests/hashes/identity.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/identity.spec.ts
@@ -1,6 +1,6 @@
 import { fc, test } from "@fast-check/vitest"
 import { expect } from "vitest"
-import { Identity } from "./identity"
+import { Identity } from "@/hashes/identity"
 
 test.prop([fc.uint8Array()])("identity", async (input) => {
   expect(Identity(input)).toStrictEqual(input)

--- a/packages/substrate-bindings/tests/hashes/twoX.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/twoX.spec.ts
@@ -15,11 +15,11 @@ test.prop([fc.uint8Array(), fc.tuple(fc.bigUintN(64), fc.bigUintN(64))])(
   "Twox128",
   async (input, bytes) => {
     let count = 0
-    vi.doMock("./h64", () => ({
+    vi.doMock("@/hashes/h64", () => ({
       h64: (_: Uint8Array) => bytes[count++],
     }))
 
-    const { Twox128 } = await import(`./twoX?${Date.now()}`)
+    const { Twox128 } = await import(`@/hashes/twoX?${Date.now()}`)
 
     const expected = new Uint8Array(16)
     setBytes(bytes, expected)
@@ -33,11 +33,11 @@ test.prop([
   fc.tuple(fc.bigUintN(64), fc.bigUintN(64), fc.bigUintN(64), fc.bigUintN(64)),
 ])("Twox256", async (input, bytes) => {
   let count = 0
-  vi.doMock("./h64", () => ({
+  vi.doMock("@/hashes/h64", () => ({
     h64: (_: Uint8Array) => bytes[count++],
   }))
 
-  const { Twox256 } = await import(`./twoX?${Date.now()}`)
+  const { Twox256 } = await import(`@/hashes/twoX?${Date.now()}`)
 
   const expected = new Uint8Array(32)
   setBytes(bytes, expected)
@@ -48,11 +48,11 @@ test.prop([
 test.prop([fc.uint8Array(), fc.bigUintN(64)])(
   "Twox64Concat",
   async (input, hash) => {
-    vi.doMock("./h64", () => ({
+    vi.doMock("@/hashes/h64", () => ({
       h64: (_: Uint8Array) => hash,
     }))
 
-    const { Twox64Concat } = await import(`./twoX?${Date.now()}`)
+    const { Twox64Concat } = await import(`@/hashes/twoX?${Date.now()}`)
 
     const expected = mergeUint8(u64.enc(hash), input)
 

--- a/packages/substrate-bindings/tests/storage.spec.ts
+++ b/packages/substrate-bindings/tests/storage.spec.ts
@@ -2,17 +2,17 @@ import { fc, it } from "@fast-check/vitest"
 import { expect, describe, vi } from "vitest"
 import { mergeUint8, toHex } from "@unstoppablejs/utils"
 import { _void, str, u32 } from "@unstoppablejs/substrate-codecs"
-import { EncoderWithHash } from "./storage"
+import { EncoderWithHash } from "@/storage"
 
 describe("storage", () => {
   it.prop([fc.uint8Array(), fc.string(), fc.string()])(
     "should only encode the palette item when no custom encoders are specified",
     async (hash, pallet, name) => {
-      vi.doMock("./hashes", () => ({
+      vi.doMock("@/hashes", () => ({
         Twox128: (_: Uint8Array) => hash,
       }))
 
-      const { Storage } = await import(`./storage?${Date.now()}`)
+      const { Storage } = await import(`@/storage?${Date.now()}`)
 
       const FooStorage = Storage(pallet)
       const FooBarStorage = FooStorage(name, _void.dec)
@@ -27,11 +27,11 @@ describe("storage", () => {
     fc.stringMatching(/^[1-9A-HJ-NP-Za-km-z]{47}$/),
     fc.integer({ min: 0 }),
   ])("should encode with custom encoders", async (hash, validator, era) => {
-    vi.doMock("./hashes", () => ({
+    vi.doMock("@/hashes", () => ({
       Twox128: (_: Uint8Array) => hash,
     }))
 
-    const { Storage } = await import(`./storage?${Date.now()}`)
+    const { Storage } = await import(`@/storage?${Date.now()}`)
 
     const FooStorage = Storage("foo")
     const barArgs: [EncoderWithHash<string>, EncoderWithHash<number>] = [
@@ -50,7 +50,7 @@ describe("storage", () => {
   it.prop([fc.uint8Array(), fc.anything()])(
     "should use supplied decoder",
     async (input, anything) => {
-      const { Storage } = await import("./storage")
+      const { Storage } = await import("@/storage")
       const FooStorage = Storage("foo")
       const FooBarStorage = FooStorage("bar", (_) => anything)
 


### PR DESCRIPTION
The `substrate-codecs` package has the tests inside the tests folder, while the `substrate-bindings` package has the tests besides the files that are being tested. This PR just makes things consistent. I don't have very strong opinions about which approach is best, but I'm starting to like this approach better than the other one...