### PR TITLE
substrate-client: fix stop issue

### DIFF
--- a/packages/substrate-client/tests/chainHead.spec.ts
+++ b/packages/substrate-client/tests/chainHead.spec.ts
@@ -232,48 +232,29 @@ describe("chainHead", () => {
     )
   })
 
-  test("`stop` event triggers a `DisjointError` on all running pending operations", () => {
+  test("`stop` event triggers a `DisjointError` on all pending requests", () => {
     const {
+      header,
+      unpin,
       body,
       storage,
       call,
-      fixtures: { sendSubscription, sendMessage },
+      fixtures: { sendSubscription },
     } = setupChainHeadWithSubscription()
 
-    const bodyPromise = body("")
-    const storagePromise = storage("", { value: ["df"] }, null)
-    const callPromise = call("", "", "")
-
+    const allPromises = [
+      header(""),
+      unpin([""]),
+      body(""),
+      storage("", { value: ["df"] }, null),
+      call("", "", ""),
+    ]
     sendSubscription({
       result: { event: "stop" },
     })
 
-    sendMessage({
-      id: 3,
-      result: {
-        result: "started",
-        operationId: "operationStorage",
-      },
-    })
-    sendMessage({
-      id: 2,
-      result: {
-        result: "started",
-        operationId: "operationBody",
-      },
-    })
-    sendMessage({
-      id: 4,
-      result: {
-        result: "started",
-        operationId: "operationCall",
-      },
-    })
-
     return Promise.all(
-      [bodyPromise, storagePromise, callPromise].map((p) =>
-        expect(p).rejects.toEqual(new DisjointError()),
-      ),
+      allPromises.map((p) => expect(p).rejects.toEqual(new DisjointError())),
     )
   })
 


### PR DESCRIPTION
This issue on the JSON-RPC spec repo, made me realize that the `stop` event should immediately reject all ongoing operations and/or requests on the `chainHead` subscription. The current tests are testing that things get rejected right after getting the expected response from the server, but that's wrong and unnecessary. So this PR has 2 commints:

1. It alters the existing test to make sure that we don't wait for the responses once the `stop` event has occurred.
2. It fixes the code to make sure that the test passes.