### PR TITLE
polkadot-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,5 @@
 node_modules
 coverage
 .cache
-packages/substrate-bindings/dist/**
-packages/substrate-client/dist/**
-packages/substrate-codegen/dist/**
-packages/utils/dist/**
-experiments/dist/**
+packages/**/dist/**
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ coverage
 packages/substrate-bindings/dist/**
 packages/substrate-client/dist/**
 packages/substrate-codegen/dist/**
+packages/utils/dist/**
 experiments/dist/**
 .vscode

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Capi
+# polkadot-api
 
-Docs: coming soon!
+Docs: coming soon(ish)!

--- a/experiments/package.json
+++ b/experiments/package.json
@@ -23,7 +23,7 @@
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",
-    "@unstoppablejs/utils": "^1.1.0"
+    "@polkadot-api/utils": "workspace:*"
   },
   "prettier": {
     "printWidth": 80,

--- a/experiments/package.json
+++ b/experiments/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@substrate/connect": "^0.7.31",
     "@unstoppablejs/sc-provider": "^0.2.0",
-    "@unstoppablejs/substrate-bindings": "workspace:*",
-    "@unstoppablejs/substrate-client": "workspace:*",
-    "@unstoppablejs/substrate-codegen": "workspace:*",
+    "@polkadot-api/substrate-bindings": "workspace:*",
+    "@polkadot-api/substrate-client": "workspace:*",
+    "@polkadot-api/substrate-codegen": "workspace:*",
     "@unstoppablejs/utils": "^1.1.0"
   },
   "prettier": {

--- a/experiments/package.json
+++ b/experiments/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@substrate/connect": "^0.7.31",
-    "@unstoppablejs/sc-provider": "^0.2.0",
+    "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",

--- a/experiments/src/PolkadotProvider.ts
+++ b/experiments/src/PolkadotProvider.ts
@@ -1,4 +1,4 @@
-import { SubstrateClient } from "@unstoppablejs/substrate-client"
+import { SubstrateClient } from "@polkadot-api/substrate-client"
 
 type Callback<T> = (value: T) => void
 type UnsubscribeFn = () => void

--- a/experiments/src/all-nominators.ts
+++ b/experiments/src/all-nominators.ts
@@ -1,5 +1,4 @@
-import { WellKnownChain } from "@substrate/connect"
-import { ScProvider } from "@unstoppablejs/sc-provider"
+import { ScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
 import { createClient } from "@polkadot-api/substrate-client"
 
 const smProvider = ScProvider(

--- a/experiments/src/all-nominators.ts
+++ b/experiments/src/all-nominators.ts
@@ -1,6 +1,6 @@
 import { WellKnownChain } from "@substrate/connect"
 import { ScProvider } from "@unstoppablejs/sc-provider"
-import { createClient } from "@unstoppablejs/substrate-client"
+import { createClient } from "@polkadot-api/substrate-client"
 
 const smProvider = ScProvider(
   WellKnownChain.polkadot /* {

--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -1,5 +1,8 @@
-import { WellKnownChain } from "@substrate/connect"
-import { ScProvider } from "@unstoppablejs/sc-provider"
+import {
+  ScProvider,
+  WellKnownChain,
+  GetProvider,
+} from "@polkadot-api/sc-provider"
 import { createClient } from "@polkadot-api/substrate-client"
 import {
   compact,
@@ -15,22 +18,6 @@ const smProvider = ScProvider(
   },
 }*/,
 )
-
-export interface Provider {
-  send: (message: string) => void
-  open: () => void
-  close: () => void
-}
-export declare enum ProviderStatus {
-  ready = 0,
-  disconnected = 1,
-  halt = 2,
-}
-
-export declare type GetProvider = (
-  onMessage: (message: string) => void,
-  onStatus: (status: ProviderStatus) => void,
-) => Provider
 
 const withLogsProvider = (input: GetProvider): GetProvider => {
   return (onMsg, onStatus) => {

--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -1,12 +1,12 @@
 import { WellKnownChain } from "@substrate/connect"
 import { ScProvider } from "@unstoppablejs/sc-provider"
-import { createClient } from "@unstoppablejs/substrate-client"
+import { createClient } from "@polkadot-api/substrate-client"
 import {
   compact,
   metadata,
   CodecType,
   Tuple,
-} from "@unstoppablejs/substrate-bindings"
+} from "@polkadot-api/substrate-bindings"
 
 const smProvider = ScProvider(
   WellKnownChain.polkadot /*, {

--- a/experiments/src/main.ts
+++ b/experiments/src/main.ts
@@ -2,7 +2,7 @@ import {
   CodeDeclarations,
   getChecksumBuilder,
   getStaticBuilder,
-} from "@unstoppablejs/substrate-codegen"
+} from "@polkadot-api/substrate-codegen"
 import { getMetadata } from "./getMetadata"
 
 const metadata = await getMetadata()
@@ -46,9 +46,7 @@ const constDeclarations = [...variables.values()].map(
     };`,
 )
 constDeclarations.unshift(
-  `import {${[...imports].join(
-    ", ",
-  )}} from "@unstoppablejs/substrate-binding";`,
+  `import {${[...imports].join(", ")}} from "@polkadot-api/substrate-binding";`,
 )
 
 console.log(constDeclarations.join("\n\n"))

--- a/packages/cli/out.txt
+++ b/packages/cli/out.txt
@@ -1,9 +1,9 @@
 
-> @capi/cli@0.0.0 start
+> @polkadot-api/cli@0.0.0 start
 > npm run build && node --enable-source-maps ./build/main.js
 
 
-> @capi/cli@0.0.0 build
+> @polkadot-api/cli@0.0.0 build
 > esbuild --bundle src/main.ts --outdir=build --sourcemap --format=esm --platform=node --packages=external
 
 [smoldot] Smoldot v1.0.16

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",
-    "@unstoppablejs/utils": "^1.1.0",
+    "@polkadot-api/utils": "workspace:*",
     "as-table": "^1.0.55",
     "chalk": "^5.3.0",
     "commander": "^11.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@inquirer/prompts": "^3.0.2",
     "@substrate/connect": "^0.7.31",
-    "@unstoppablejs/sc-provider": "^0.2.0",
+    "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capi/cli",
+  "name": "@polkadot-api/cli",
   "version": "0.0.0",
   "license": "MIT",
   "sideEffects": true,
@@ -20,11 +20,10 @@
   "dependencies": {
     "@inquirer/prompts": "^3.0.2",
     "@substrate/connect": "^0.7.31",
-    "@unstoppablejs/client": "0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671",
     "@unstoppablejs/sc-provider": "^0.2.0",
-    "@unstoppablejs/substrate-bindings": "workspace:*",
-    "@unstoppablejs/substrate-client": "workspace:*",
-    "@unstoppablejs/substrate-codegen": "workspace:*",
+    "@polkadot-api/substrate-bindings": "workspace:*",
+    "@polkadot-api/substrate-client": "workspace:*",
+    "@polkadot-api/substrate-codegen": "workspace:*",
     "@unstoppablejs/utils": "^1.1.0",
     "as-table": "^1.0.55",
     "chalk": "^5.3.0",

--- a/packages/cli/src/guards.ts
+++ b/packages/cli/src/guards.ts
@@ -1,5 +1,5 @@
-import { LookupEntry } from "@unstoppablejs/substrate-codegen"
-import { CodecType, metadata } from "@unstoppablejs/substrate-bindings"
+import { LookupEntry } from "@polkadot-api/substrate-codegen"
+import { CodecType, metadata } from "@polkadot-api/substrate-bindings"
 
 type Metadata = CodecType<typeof metadata>["metadata"]
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -7,8 +7,8 @@ import {
   getChecksumBuilder,
   getLookupFn,
   getStaticBuilder,
-} from "@unstoppablejs/substrate-codegen"
-import { V14Lookup } from "@unstoppablejs/substrate-bindings"
+} from "@polkadot-api/substrate-codegen"
+import { V14Lookup } from "@polkadot-api/substrate-bindings"
 import { CheckboxData } from "./CheckboxData"
 import * as childProcess from "node:child_process"
 import { deferred } from "./deferred"
@@ -37,8 +37,8 @@ const ProgramArgs = z.object({
 type ProgramArgs = z.infer<typeof ProgramArgs>
 
 program
-  .name("capi")
-  .description("Capi CLI")
+  .name("polkadotApi")
+  .description("polkadot-api CLI")
   .option("-m, --metadataFile <path>", "path to scale encoded metadata file")
   .option("-i, --interactive", "whether to run in interactive mode", false)
 
@@ -247,7 +247,7 @@ while (!exit) {
 
       if (writeToPkgJSON) {
         writePkg.updatePackage(
-          JSON.parse(JSON.stringify({ capi: { descriptors: data } })),
+          JSON.parse(JSON.stringify({ polkadotApi: { descriptors: data } })),
         )
       } else {
         const outFile = await input({
@@ -263,17 +263,17 @@ while (!exit) {
       const descriptors = await (async () => {
         if (await fsExists("package.json")) {
           const pkgJSONSchema = z.object({
-            capi: z.object({ descriptors: descriptorSchema }).optional(),
+            polkadotApi: z.object({ descriptors: descriptorSchema }).optional(),
           })
 
-          const { capi } = await pkgJSONSchema.parseAsync(
+          const { polkadotApi } = await pkgJSONSchema.parseAsync(
             JSON.parse(
               await fs.readFile("package.json", { encoding: "utf-8" }),
             ),
           )
 
-          if (capi) {
-            return capi.descriptors
+          if (polkadotApi) {
+            return polkadotApi.descriptors
           }
         }
 
@@ -644,7 +644,7 @@ while (!exit) {
       constDeclarations.unshift(
         `import {${[...declarations.imports].join(
           ", ",
-        )}} from "@unstoppablejs/substrate-bindings"`,
+        )}} from "@polkadot-api/substrate-bindings"`,
       )
 
       await fs.mkdir("codegen", { recursive: true })
@@ -698,10 +698,10 @@ while (!exit) {
 
       descriptorCodegen += `import {${[
         ...new Set([...declarations.imports, ...descriptorImports]),
-      ].join(", ")}} from "@unstoppablejs/substrate-bindings"\n`
+      ].join(", ")}} from "@polkadot-api/substrate-bindings"\n`
       descriptorCodegen += `import type {${[...descriptorTypeImports].join(
         ", ",
-      )}} from "@unstoppablejs/substrate-bindings"\n`
+      )}} from "@polkadot-api/substrate-bindings"\n`
       descriptorCodegen += `import type {${[...declarations.variables.values()]
         .map((v) => v.id)
         .join(", ")}} from "./codegen"\n\n`

--- a/packages/cli/src/metadata.ts
+++ b/packages/cli/src/metadata.ts
@@ -1,5 +1,5 @@
 import { WellKnownChain } from "@substrate/connect"
-import { createClient } from "@unstoppablejs/substrate-client"
+import { createClient } from "@polkadot-api/substrate-client"
 import { GetProvider } from "@unstoppablejs/provider"
 import { deferred } from "./deferred"
 import { fromHex } from "@unstoppablejs/utils"
@@ -8,7 +8,7 @@ import {
   metadata as $metadata,
   CodecType,
   OpaqueCodec,
-} from "@unstoppablejs/substrate-bindings"
+} from "@polkadot-api/substrate-bindings"
 import { PROVIDER_WORKER_CODE } from "./smolldot-worker"
 import { Worker } from "node:worker_threads"
 import { Subject } from "rxjs"

--- a/packages/cli/src/metadata.ts
+++ b/packages/cli/src/metadata.ts
@@ -2,7 +2,7 @@ import { WellKnownChain } from "@substrate/connect"
 import { createClient } from "@polkadot-api/substrate-client"
 import { GetProvider } from "@unstoppablejs/provider"
 import { deferred } from "./deferred"
-import { fromHex } from "@unstoppablejs/utils"
+import { fromHex } from "@polkadot-api/utils"
 import * as fs from "node:fs/promises"
 import {
   metadata as $metadata,

--- a/packages/cli/src/metadata.ts
+++ b/packages/cli/src/metadata.ts
@@ -1,6 +1,6 @@
 import { WellKnownChain } from "@substrate/connect"
 import { createClient } from "@polkadot-api/substrate-client"
-import { GetProvider } from "@unstoppablejs/provider"
+import { GetProvider } from "@polkadot-api/json-rpc-provider"
 import { deferred } from "./deferred"
 import { fromHex } from "@polkadot-api/utils"
 import * as fs from "node:fs/promises"

--- a/packages/cli/src/smolldot-worker.ts
+++ b/packages/cli/src/smolldot-worker.ts
@@ -1,6 +1,6 @@
 export const PROVIDER_WORKER_CODE = `
 const { parentPort, workerData } = require("node:worker_threads")
-const { ScProvider } = require("@unstoppablejs/sc-provider")
+const { ScProvider } = require("@polkadot-api/sc-provider")
 const { z } = require("zod")
 
 const msgSchema = z.discriminatedUnion("type", [

--- a/packages/json-rpc-provider/README.md
+++ b/packages/json-rpc-provider/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/json-rpc-provider

--- a/packages/json-rpc-provider/package.json
+++ b/packages/json-rpc-provider/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@polkadot-api/substrate-client",
-  "version": "0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671",
+  "name": "@polkadot-api/json-rpc-provider",
+  "version": "1.0.0",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
@@ -13,7 +13,8 @@
       "node": {
         "production": {
           "require": "./dist/min/index.js"
-        }
+        },
+        "default": "./dist/index.js"
       },
       "module": "./dist/index.mjs",
       "import": "./dist/index.mjs",
@@ -31,8 +32,7 @@
   ],
   "scripts": {
     "build": "tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
-    "test": "vitest",
-    "coverage": "vitest run --coverage",
+    "test": "echo 'no tests'",
     "lint": "tsc --noEmit && prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"
@@ -41,10 +41,5 @@
     "printWidth": 80,
     "semi": false,
     "trailingComma": "all"
-  },
-  "devDependencies": {
-    "@polkadot-api/json-rpc-provider": "workspace:*",
-    "@polkadot-api/utils": "workspace:*",
-    "@vitest/coverage-v8": "^0.34.3"
   }
 }

--- a/packages/json-rpc-provider/src/index.ts
+++ b/packages/json-rpc-provider/src/index.ts
@@ -1,0 +1,12 @@
+export interface Provider {
+  send: (message: string) => void
+  open: () => void
+  close: () => void
+}
+
+export type ProviderStatus = "connected" | "disconnected" | "halt"
+
+export declare type GetProvider = (
+  onMessage: (message: string) => void,
+  onStatus: (status: ProviderStatus) => void,
+) => Provider

--- a/packages/json-rpc-provider/tsconfig.json
+++ b/packages/json-rpc-provider/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/packages/sc-provider/README.md
+++ b/packages/sc-provider/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/sc-provider

--- a/packages/sc-provider/package.json
+++ b/packages/sc-provider/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@polkadot-api/substrate-client",
-  "version": "0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671",
+  "name": "@polkadot-api/sc-provider",
+  "version": "1.0.0",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
@@ -13,7 +13,8 @@
       "node": {
         "production": {
           "require": "./dist/min/index.js"
-        }
+        },
+        "default": "./dist/index.js"
       },
       "module": "./dist/index.mjs",
       "import": "./dist/index.mjs",
@@ -31,8 +32,7 @@
   ],
   "scripts": {
     "build": "tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
-    "test": "vitest",
-    "coverage": "vitest run --coverage",
+    "test": "echo 'no tests'",
     "lint": "tsc --noEmit && prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"
@@ -42,9 +42,10 @@
     "semi": false,
     "trailingComma": "all"
   },
+  "dependencies": {
+    "@substrate/connect": "^0.7.31"
+  },
   "devDependencies": {
-    "@polkadot-api/json-rpc-provider": "workspace:*",
-    "@polkadot-api/utils": "workspace:*",
-    "@vitest/coverage-v8": "^0.34.3"
+    "@polkadot-api/json-rpc-provider": "workspace:*"
   }
 }

--- a/packages/sc-provider/src/index.ts
+++ b/packages/sc-provider/src/index.ts
@@ -1,0 +1,82 @@
+import type {
+  GetProvider,
+  Provider,
+  ProviderStatus,
+} from "@polkadot-api/json-rpc-provider"
+import type { ScClient, Chain, Config } from "@substrate/connect"
+import { WellKnownChain, createScClient } from "@substrate/connect"
+
+export { WellKnownChain }
+export type { GetProvider, Provider, ProviderStatus }
+
+export const wellKnownChains = new Set(Object.values(WellKnownChain))
+
+const customCreateScClient = (...args: Parameters<typeof createScClient>) => {
+  const client = createScClient(...args)
+
+  let pending: Promise<any> | null = null
+  const addWellKnownChain = async (
+    ...args: Parameters<(typeof client)["addWellKnownChain"]>
+  ) => {
+    if (pending) await pending
+    const result = client.addWellKnownChain(...args)
+    pending = result
+    return result
+  }
+
+  const addChain = async (...args: Parameters<(typeof client)["addChain"]>) => {
+    if (pending) await pending
+    const result = client.addChain(...args)
+    pending = result
+    return result
+  }
+
+  return { addChain, addWellKnownChain }
+}
+
+let client: ScClient
+
+export const ScProvider = (
+  input: WellKnownChain | string,
+  config?: Config,
+): GetProvider => {
+  client ??= customCreateScClient(config)
+
+  return (onMessage, onStatus): Provider => {
+    let chain: Chain | null = null
+    let pending = false
+
+    const open = () => {
+      if (chain || pending) return
+
+      pending = true
+      ;(wellKnownChains.has(input as any)
+        ? client.addWellKnownChain(input as WellKnownChain, onMessage)
+        : client.addChain(input, onMessage)
+      )
+        .then((_chain) => {
+          chain = _chain
+          onStatus("connected")
+        })
+        .catch((e) => {
+          console.warn("There was a problem adding the Chain")
+          console.error(e)
+          onStatus("halt")
+        })
+        .finally(() => {
+          pending = false
+        })
+    }
+
+    const close = () => {
+      chain?.remove()
+      chain = null
+    }
+
+    const send = (msg: string) => {
+      chain!.sendJsonRpc(msg)
+    }
+
+    return { open, close, send }
+  }
+}

--- a/packages/sc-provider/tsconfig.json
+++ b/packages/sc-provider/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/packages/substrate-bindings/README.md
+++ b/packages/substrate-bindings/README.md
@@ -1,1 +1,1 @@
-# @unstoppablejs/substrate-bindings
+# @polkadot-api/substrate-bindings

--- a/packages/substrate-bindings/package.json
+++ b/packages/substrate-bindings/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@unstoppablejs/substrate-bindings",
+  "name": "@polkadot-api/substrate-bindings",
   "version": "0.0.0-experimental-1519a4ce-142b-4667-bc73-f8913a6dcd50",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unstoppablejs/unstoppablejs.git"
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/substrate-bindings/package.json
+++ b/packages/substrate-bindings/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@noble/hashes": "^1.3.1",
     "@scure/base": "^1.1.1",
-    "@unstoppablejs/utils": "^1.1.0",
+    "@polkadot-api/utils": "workspace:*",
     "scale-ts": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/substrate-bindings/src/codecs/Hex.ts
+++ b/packages/substrate-bindings/src/codecs/Hex.ts
@@ -1,4 +1,4 @@
-import { fromHex, toHex } from "@unstoppablejs/utils"
+import { fromHex, toHex } from "@polkadot-api/utils"
 import { Bytes, Codec, Decoder, Encoder, createCodec } from "scale-ts"
 
 export type HexString = string & { __hexString: unknown }

--- a/packages/substrate-bindings/src/extrinsics/README.md
+++ b/packages/substrate-bindings/src/extrinsics/README.md
@@ -147,7 +147,7 @@ const $extra = Struct({
 })
 ```
 
-The extrinsic mortality is a mechanism which ensures that an extrinsic is only valid within a certain period. It could be 1-byte for inmortal and 2-byte for mortal extrinsics.  
+The extrinsic mortality is a mechanism which ensures that an extrinsic is only valid within a certain period. It could be 1-byte for inmortal and 2-byte for mortal extrinsics.
 Mortal extrinsics encode 2 values
 
 - `period`, which should be a power of `2` and greater or equal to `4`
@@ -234,9 +234,9 @@ In Substrate, an [`UncheckedExtrinsic`](https://github.com/paritytech/substrate/
 
 The concrete types to create the codecs for an `UncheckedExtrinsic` are chain specific and described in the chain [metadata](https://spec.polkadot.network/sect-metadata#sect-rtm-extrinsic-metadata).
 
-This is important because different Substrate chains may have different extrinsic shapes.  
-For example, the `UncheckedExtrinsic` in Polkadot and AssetHub are slightly different when it comes to tips.  
-In Polkadot, tips are paid with the native asset; and, in AssetHub, tips can be paid in the native asset or with another asset.  
+This is important because different Substrate chains may have different extrinsic shapes.
+For example, the `UncheckedExtrinsic` in Polkadot and AssetHub are slightly different when it comes to tips.
+In Polkadot, tips are paid with the native asset; and, in AssetHub, tips can be paid in the native asset or with another asset.
 For more details check
 
 - Polkadot [`UncheckedExtrinsic`](https://github.com/paritytech/polkadot/blob/7458cbda04aecb672a65be99e2a57e1724dca10c/runtime/polkadot/src/lib.rs#L1522-L1524) [`SignedExtra`](https://github.com/paritytech/polkadot/blob/7458cbda04aecb672a65be99e2a57e1724dca10c/runtime/polkadot/src/lib.rs#L1461-L1472) [`ChargeTransactionPayment`](https://github.com/paritytech/substrate/blob/51b2f0ed6af8dd4facb18f1a489e192fd0673f7b/frame/transaction-payment/src/lib.rs#L665-L677)
@@ -296,8 +296,8 @@ For more details, see [Substrate Quering Storage](https://docs.substrate.io/lear
 For example, to compute the `System.Number` storage key
 
 ```ts
-import { twoX128 } from "@unstoppablejs/substrate-bindings"
-import { mergeUint8, toHex } from "@unstoppablejs/utils"
+import { twoX128 } from "@polkadot-api/substrate-bindings"
+import { mergeUint8, toHex } from "@polkaddot-api/utils"
 
 const systemKey = toHex(twoX128(new TextEncoder().encode("System")))
 const numberKey = toHex(twoX128(new TextEncoder().encode("Number")))
@@ -321,8 +321,8 @@ For example, to compute the `System.Account(AccountId32)` storage key
 import { blake2b } from "@noble/hashes/blake2b"
 import { Keyring } from "@polkadot/keyring"
 import { cryptoWaitReady } from "@polkadot/util-crypto"
-import { twoX128 } from "@unstoppablejs/substrate-bindings"
-import { mergeUint8, toHex } from "@unstoppablejs/utils"
+import { twoX128 } from "@polkadot-api/substrate-bindings"
+import { mergeUint8, toHex } from "@polkadot-api/utils"
 
 await cryptoWaitReady()
 

--- a/packages/substrate-bindings/src/hashes/blake2.ts
+++ b/packages/substrate-bindings/src/hashes/blake2.ts
@@ -1,4 +1,4 @@
-import { mergeUint8 } from "@unstoppablejs/utils"
+import { mergeUint8 } from "@polkadot-api/utils"
 import { blake2b } from "@noble/hashes/blake2b"
 
 const len32 = { dkLen: 32 }

--- a/packages/substrate-bindings/src/hashes/twoX.ts
+++ b/packages/substrate-bindings/src/hashes/twoX.ts
@@ -1,4 +1,4 @@
-import { mergeUint8 } from "@unstoppablejs/utils"
+import { mergeUint8 } from "@polkadot-api/utils"
 import { u64 } from "scale-ts"
 import { h64 } from "./h64"
 

--- a/packages/substrate-bindings/src/storage.ts
+++ b/packages/substrate-bindings/src/storage.ts
@@ -1,4 +1,4 @@
-import { mergeUint8, toHex, utf16StrToUtf8Bytes } from "@unstoppablejs/utils"
+import { mergeUint8, toHex, utf16StrToUtf8Bytes } from "@polkadot-api/utils"
 import { Codec, Decoder } from "scale-ts"
 import { Blake2128Concat, Identity, Twox128, Twox64Concat } from "./hashes"
 

--- a/packages/substrate-bindings/tests/hashes/blake2.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/blake2.spec.ts
@@ -1,6 +1,6 @@
 import { fc, test } from "@fast-check/vitest"
 import { expect } from "vitest"
-import { mergeUint8 } from "@unstoppablejs/utils"
+import { mergeUint8 } from "@polkadot-api/utils"
 import { Blake2128, Blake2256, Blake2128Concat } from "@/hashes/blake2"
 import { blake2b } from "@noble/hashes/blake2b"
 

--- a/packages/substrate-bindings/tests/hashes/twoX.spec.ts
+++ b/packages/substrate-bindings/tests/hashes/twoX.spec.ts
@@ -1,6 +1,6 @@
 import { fc, test } from "@fast-check/vitest"
 import { u64 } from "@/."
-import { mergeUint8 } from "@unstoppablejs/utils"
+import { mergeUint8 } from "@polkadot-api/utils"
 import { expect, vi } from "vitest"
 
 function setBytes(bytes: bigint[], out: Uint8Array) {

--- a/packages/substrate-bindings/tests/storage.spec.ts
+++ b/packages/substrate-bindings/tests/storage.spec.ts
@@ -1,6 +1,6 @@
 import { fc, it } from "@fast-check/vitest"
 import { expect, describe, vi } from "vitest"
-import { mergeUint8, toHex } from "@unstoppablejs/utils"
+import { mergeUint8, toHex } from "@polkadot-api/utils"
 import { EncoderWithHash, _void, str, u32 } from "@/."
 
 describe("storage", () => {

--- a/packages/substrate-client/README.md
+++ b/packages/substrate-client/README.md
@@ -1,1 +1,1 @@
-# @unstoppablejs/substrate-client
+# @polkadot-api/substrate-client

--- a/packages/substrate-client/package.json
+++ b/packages/substrate-client/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@unstoppablejs/substrate-client",
+  "name": "@polkadot-api/substrate-client",
   "version": "0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unstoppablejs/unstoppablejs.git"
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/substrate-client/src/client/createClient.ts
+++ b/packages/substrate-client/src/client/createClient.ts
@@ -1,8 +1,8 @@
 import {
   type GetProvider,
   type Provider,
-  ProviderStatus,
-} from "@unstoppablejs/provider"
+  type ProviderStatus,
+} from "@polkadot-api/json-rpc-provider"
 import { UnsubscribeFn } from "../common-types"
 import { RpcError, IRpcError } from "./RpcError"
 import { getSubscriptionsManager, Subscriber } from "@/internal-utils"
@@ -35,7 +35,7 @@ export const createClient = (gProvider: GetProvider): Client => {
 
   const queuedRequests = new Map<number, Parameters<ClientRequest<any, any>>>()
   let provider: Provider | null = null
-  let state: ProviderStatus = ProviderStatus.disconnected
+  let state: ProviderStatus = "disconnected"
 
   const send = (
     id: number,
@@ -93,7 +93,7 @@ export const createClient = (gProvider: GetProvider): Client => {
   }
 
   function onStatusChange(e: ProviderStatus) {
-    if (e === ProviderStatus.ready) {
+    if (e === "connected") {
       queuedRequests.forEach((args, id) => {
         process(id, ...args)
       })
@@ -133,7 +133,7 @@ export const createClient = (gProvider: GetProvider): Client => {
     if (!provider) throw new Error("Not connected")
     const id = nextId++
 
-    if (state === ProviderStatus.ready) {
+    if (state === "connected") {
       process(id, method, params, cb)
     } else {
       queuedRequests.set(id, [method, params, cb])

--- a/packages/substrate-client/src/index.ts
+++ b/packages/substrate-client/src/index.ts
@@ -1,4 +1,8 @@
-import { GetProvider } from "@unstoppablejs/provider"
+import {
+  type GetProvider,
+  type Provider,
+  type ProviderStatus,
+} from "@polkadot-api/json-rpc-provider"
 import { getTransaction } from "./transaction/transaction"
 import { getChainHead } from "./chainhead"
 import {
@@ -9,6 +13,8 @@ import {
 import type { ChainHead } from "./chainhead"
 import type { Transaction } from "./transaction/types"
 import { UnsubscribeFn } from "./common-types"
+
+export type { GetProvider, Provider, ProviderStatus }
 
 export type * from "./common-types"
 export type * from "./client"

--- a/packages/substrate-client/tests/fixtures.ts
+++ b/packages/substrate-client/tests/fixtures.ts
@@ -1,4 +1,4 @@
-import type { GetProvider } from "@unstoppablejs/provider"
+import type { GetProvider } from "@polkadot-api/json-rpc-provider"
 import { FollowResponse, IRpcError, createClient } from "@/."
 import { vi } from "vitest"
 
@@ -22,7 +22,7 @@ export const createTestClient = () => {
         receivedMessages.push(msg)
       },
       open() {
-        _onStatus(0)
+        _onStatus("connected")
       },
       close() {},
     }

--- a/packages/substrate-client/tests/storage.spec.ts
+++ b/packages/substrate-client/tests/storage.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest"
 import { test, fc } from "@fast-check/vitest"
 import { setupChainHeadOperationSubscription } from "./fixtures"
-import { toHex } from "@unstoppablejs/utils"
+import { toHex } from "@polkadot-api/utils"
 import { pipe } from "./utils"
 
 describe.each([true, false])("storage correctness", (mergeItems) => {

--- a/packages/substrate-codegen/README.md
+++ b/packages/substrate-codegen/README.md
@@ -1,1 +1,1 @@
-# @unstoppablejs/substrate-codegen
+# @polkadot-api/substrate-codegen

--- a/packages/substrate-codegen/package.json
+++ b/packages/substrate-codegen/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@unstoppablejs/substrate-codegen",
+  "name": "@polkadot-api/substrate-codegen",
   "version": "0.0.0-experimental-1519a4ce-142b-4667-bc73-f8913a6dcd50",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unstoppablejs/unstoppablejs.git"
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
   },
   "license": "MIT",
   "sideEffects": false,
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@unstoppablejs/utils": "^1.1.0",
-    "@unstoppablejs/substrate-bindings": "workspace:*"
+    "@polkadot-api/substrate-bindings": "workspace:*"
   }
 }

--- a/packages/substrate-codegen/package.json
+++ b/packages/substrate-codegen/package.json
@@ -42,7 +42,6 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@unstoppablejs/utils": "^1.1.0",
     "@polkadot-api/substrate-bindings": "workspace:*"
   }
 }

--- a/packages/substrate-codegen/src/checksum-builder.ts
+++ b/packages/substrate-codegen/src/checksum-builder.ts
@@ -1,5 +1,5 @@
-import type { StringRecord, V14 } from "@unstoppablejs/substrate-bindings"
-import { h64 } from "@unstoppablejs/substrate-bindings"
+import type { StringRecord, V14 } from "@polkadot-api/substrate-bindings"
+import { h64 } from "@polkadot-api/substrate-bindings"
 import {
   EnumVar,
   LookupEntry,

--- a/packages/substrate-codegen/src/dynamic-builder.ts
+++ b/packages/substrate-codegen/src/dynamic-builder.ts
@@ -1,11 +1,7 @@
-import type {
-  Codec,
-  StringRecord,
-  V14,
-} from "@unstoppablejs/substrate-bindings"
+import type { Codec, StringRecord, V14 } from "@polkadot-api/substrate-bindings"
 import type { LookupEntry } from "./lookups"
 import { getLookupFn } from "./lookups"
-import * as scale from "@unstoppablejs/substrate-bindings"
+import * as scale from "@polkadot-api/substrate-bindings"
 
 const _bytes = scale.Bytes()
 

--- a/packages/substrate-codegen/src/lookups.ts
+++ b/packages/substrate-codegen/src/lookups.ts
@@ -1,4 +1,4 @@
-import type { StringRecord, V14Lookup } from "@unstoppablejs/substrate-bindings"
+import type { StringRecord, V14Lookup } from "@polkadot-api/substrate-bindings"
 
 export type VoidVar = { type: "primitive"; value: "_void" }
 const voidVar: VoidVar = { type: "primitive", value: "_void" }

--- a/packages/substrate-codegen/src/static-builder.ts
+++ b/packages/substrate-codegen/src/static-builder.ts
@@ -1,4 +1,4 @@
-import { StringRecord, V14 } from "@unstoppablejs/substrate-bindings"
+import { StringRecord, V14 } from "@polkadot-api/substrate-bindings"
 import { LookupEntry, getLookupFn } from "./lookups"
 
 export interface Variable {

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@polkadot-api/substrate-client",
-  "version": "0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671",
+  "name": "@polkadot-api/utils",
+  "version": "0.0.0-experimental-1519a4ce-142b-4667-bc73-f8913a6dcd50",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
@@ -31,8 +31,7 @@
   ],
   "scripts": {
     "build": "tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
-    "test": "vitest",
-    "coverage": "vitest run --coverage",
+    "test": "echo 'no tests'",
     "lint": "tsc --noEmit && prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"
@@ -41,12 +40,5 @@
     "printWidth": 80,
     "semi": false,
     "trailingComma": "all"
-  },
-  "dependencies": {
-    "@unstoppablejs/provider": "^0.0.1"
-  },
-  "devDependencies": {
-    "@polkadot-api/utils": "workspace:*",
-    "@vitest/coverage-v8": "^0.34.3"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,8 @@
       "node": {
         "production": {
           "require": "./dist/min/index.js"
-        }
+        },
+        "default": "./dist/index.js"
       },
       "module": "./dist/index.mjs",
       "import": "./dist/index.mjs",

--- a/packages/utils/src/hex.ts
+++ b/packages/utils/src/hex.ts
@@ -1,0 +1,57 @@
+// https://jsben.ch/uWZw3
+const HEX_STR = "0123456789abcdef"
+export function toHex(bytes: Uint8Array): string {
+  const result = new Array<string>(bytes.length + 1)
+
+  result[0] = "0x"
+
+  for (let i = 0; i < bytes.length; ) {
+    const b = bytes[i++]
+    result[i] = HEX_STR[b >> 4] + HEX_STR[b & 15]
+  }
+
+  return result.join("")
+}
+
+// https://jsben.ch/URe1X
+const HEX_MAP: Record<string, number> = {
+  0: 0,
+  1: 1,
+  2: 2,
+  3: 3,
+  4: 4,
+  5: 5,
+  6: 6,
+  7: 7,
+  8: 8,
+  9: 9,
+  a: 10,
+  b: 11,
+  c: 12,
+  d: 13,
+  e: 14,
+  f: 15,
+  A: 10,
+  B: 11,
+  C: 12,
+  D: 13,
+  E: 14,
+  F: 15,
+}
+export function fromHex(hexString: string): Uint8Array {
+  const isOdd = hexString.length % 2
+  const base = (hexString[1] === "x" ? 2 : 0) + isOdd
+  const nBytes = (hexString.length - base) / 2 + isOdd
+  const bytes = new Uint8Array(nBytes)
+
+  if (isOdd) bytes[0] = 0 | HEX_MAP[hexString[2]]
+
+  for (let i = 0; i < nBytes; ) {
+    const idx = base + i * 2
+    const a = HEX_MAP[hexString[idx]]
+    const b = HEX_MAP[hexString[idx + 1]]
+    bytes[isOdd + i++] = (a << 4) | b
+  }
+
+  return bytes
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,6 @@
+export { fromHex, toHex } from "./hex"
+export { mapObject } from "./mapObject"
+export { mergeUint8 } from "./mergeUint8"
+export { noop } from "./noop"
+export { utf16StrToUtf8Bytes } from "./utf16StrToUtf8Bytes"
+export { utf8BytesToUtf16Str } from "./utf8BytesToUtf16Str"

--- a/packages/utils/src/mapObject.ts
+++ b/packages/utils/src/mapObject.ts
@@ -1,0 +1,15 @@
+export function mapObject<K extends string | number | symbol, I, O>(
+  input: Record<K, I>,
+  mapper: (i: I, k: K) => O,
+): Record<K, O>
+
+export function mapObject<K extends string | number | symbol, I, O>(
+  input: Record<K, I>,
+  mapper: (i: I, k?: K) => O,
+): Record<K, O> {
+  return Object.fromEntries(
+    Object.entries(input).map(
+      ([key, value]: any) => [key, mapper(value, key)] as const,
+    ),
+  ) as any
+}

--- a/packages/utils/src/mergeUint8.ts
+++ b/packages/utils/src/mergeUint8.ts
@@ -1,0 +1,12 @@
+export const mergeUint8 = (...inputs: Array<Uint8Array>): Uint8Array => {
+  const totalLen = inputs.reduce((acc, a) => acc + a.byteLength, 0)
+  const result = new Uint8Array(totalLen)
+
+  for (let idx = 0, at = 0; idx < inputs.length; idx++) {
+    const current = inputs[idx]
+    result.set(current, at)
+    at += current.byteLength
+  }
+
+  return result
+}

--- a/packages/utils/src/noop.ts
+++ b/packages/utils/src/noop.ts
@@ -1,0 +1,1 @@
+export const noop: () => void = Function.prototype as any

--- a/packages/utils/src/utf16StrToUtf8Bytes.ts
+++ b/packages/utils/src/utf16StrToUtf8Bytes.ts
@@ -1,0 +1,28 @@
+export function utf16StrToUtf8Bytes(str: string): Uint8Array {
+  const result = []
+  for (let i = 0; i < str.length; i++) {
+    let currentCode = str.charCodeAt(i)
+    if (currentCode < 0x80) result.push(currentCode)
+    else if (currentCode < 0x800) {
+      result.push(0xc0 | (currentCode >> 6), 0x80 | (currentCode & 0x3f))
+    } else if (currentCode > 0xd7ff && currentCode < 0xe000) {
+      currentCode =
+        0x10000 +
+        (((currentCode & 0x3ff) << 10) | (str.charCodeAt(++i) & 0x3ff))
+      result.push(
+        0xf0 | (currentCode >> 18),
+        0x80 | ((currentCode >> 12) & 0x3f),
+        0x80 | ((currentCode >> 6) & 0x3f),
+        0x80 | (currentCode & 0x3f),
+      )
+    } else {
+      result.push(
+        0xe0 | (currentCode >> 12),
+        0x80 | ((currentCode >> 6) & 0x3f),
+        0x80 | (currentCode & 0x3f),
+      )
+    }
+  }
+
+  return new Uint8Array(result)
+}

--- a/packages/utils/src/utf8BytesToUtf16Str.ts
+++ b/packages/utils/src/utf8BytesToUtf16Str.ts
@@ -1,0 +1,30 @@
+export function utf8BytesToUtf16Str(input: Uint8Array): string {
+  const result: number[] = []
+
+  for (let i = 0; i < input.length; i++) {
+    let current = input[i]
+    if (current < 0b1000_0000) {
+      result.push(current)
+    } else if (current < 0b1110_0000) {
+      result.push(((current & 0b0011_1111) << 6) | (input[++i] & 0b0011_1111))
+    } else if (current <= 0b1110_1110) {
+      result.push(
+        ((current & 0b0001_1111) << 12) |
+          ((input[++i] & 0b0011_1111) << 6) |
+          (input[++i] & 0b0011_1111),
+      )
+    } else {
+      const doubleCharCode =
+        (((current & 0b0000_1111) << 18) |
+          ((input[++i] & 0b0011_1111) << 12) |
+          ((input[++i] & 0b0011_1111) << 6) |
+          (input[++i] & 0b0011_1111)) -
+        0x10000
+
+      result.push((doubleCharCode >> 10) | 0xd800)
+      result.push((doubleCharCode & 0b0011_1111_1111) | 0xdc00)
+    }
+  }
+
+  return String.fromCharCode(...result)
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   experiments:
     dependencies:
+      '@polkadot-api/sc-provider':
+        specifier: workspace:*
+        version: link:../packages/sc-provider
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../packages/substrate-bindings
@@ -53,9 +56,6 @@ importers:
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
-      '@unstoppablejs/sc-provider':
-        specifier: ^0.2.0
-        version: 0.2.0(@substrate/connect@0.7.31)
     devDependencies:
       '@types/node':
         specifier: ^20.4.7
@@ -72,6 +72,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^3.0.2
         version: 3.1.1
+      '@polkadot-api/sc-provider':
+        specifier: workspace:*
+        version: link:../sc-provider
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../substrate-bindings
@@ -87,9 +90,6 @@ importers:
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
-      '@unstoppablejs/sc-provider':
-        specifier: ^0.2.0
-        version: 0.2.0(@substrate/connect@0.7.31)
       as-table:
         specifier: ^1.0.55
         version: 1.0.55
@@ -121,6 +121,18 @@ importers:
         specifier: ^3.22.2
         version: 3.22.2
 
+  packages/json-rpc-provider: {}
+
+  packages/sc-provider:
+    dependencies:
+      '@substrate/connect':
+        specifier: ^0.7.31
+        version: 0.7.31
+    devDependencies:
+      '@polkadot-api/json-rpc-provider':
+        specifier: workspace:*
+        version: link:../json-rpc-provider
+
   packages/substrate-bindings:
     dependencies:
       '@noble/hashes':
@@ -144,11 +156,10 @@ importers:
         version: 4.9.0
 
   packages/substrate-client:
-    dependencies:
-      '@unstoppablejs/provider':
-        specifier: ^0.0.1
-        version: 0.0.1
     devDependencies:
+      '@polkadot-api/json-rpc-provider':
+        specifier: workspace:*
+        version: link:../json-rpc-provider
       '@polkadot-api/utils':
         specifier: workspace:*
         version: link:../utils
@@ -650,19 +661,6 @@ packages:
 
   /@types/wrap-ansi@3.0.0:
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
-    dev: false
-
-  /@unstoppablejs/provider@0.0.1:
-    resolution: {integrity: sha512-MgSFu1zMljBwHnqCEJj0KoeJFpsPYpAna5fKIP1oaTjYDhDWTgilhGFX35IELriAW1/FycNymhgVDTdIFIuDsQ==}
-    dev: false
-
-  /@unstoppablejs/sc-provider@0.2.0(@substrate/connect@0.7.31):
-    resolution: {integrity: sha512-DERKNm6P5M2x5xl5Ym4RQHpNFnFOYSfaC4wkioxF/ZEEQ5taX4KpN/4eHIWh8KfkRzK+6ECbN9np+W9zEroeig==}
-    peerDependencies:
-      '@substrate/connect': '>=0.7.28'
-    dependencies:
-      '@substrate/connect': 0.7.31
-      '@unstoppablejs/provider': 0.0.1
     dev: false
 
   /@vitest/coverage-v8@0.34.4(vitest@0.34.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,21 +38,21 @@ importers:
 
   experiments:
     dependencies:
+      '@polkadot-api/substrate-bindings':
+        specifier: workspace:*
+        version: link:../packages/substrate-bindings
+      '@polkadot-api/substrate-client':
+        specifier: workspace:*
+        version: link:../packages/substrate-client
+      '@polkadot-api/substrate-codegen':
+        specifier: workspace:*
+        version: link:../packages/substrate-codegen
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
       '@unstoppablejs/sc-provider':
         specifier: ^0.2.0
         version: 0.2.0(@substrate/connect@0.7.31)
-      '@unstoppablejs/substrate-bindings':
-        specifier: workspace:*
-        version: link:../packages/substrate-bindings
-      '@unstoppablejs/substrate-client':
-        specifier: workspace:*
-        version: link:../packages/substrate-client
-      '@unstoppablejs/substrate-codegen':
-        specifier: workspace:*
-        version: link:../packages/substrate-codegen
       '@unstoppablejs/utils':
         specifier: ^1.1.0
         version: 1.1.0
@@ -72,24 +72,21 @@ importers:
       '@inquirer/prompts':
         specifier: ^3.0.2
         version: 3.1.1
+      '@polkadot-api/substrate-bindings':
+        specifier: workspace:*
+        version: link:../substrate-bindings
+      '@polkadot-api/substrate-client':
+        specifier: workspace:*
+        version: link:../substrate-client
+      '@polkadot-api/substrate-codegen':
+        specifier: workspace:*
+        version: link:../substrate-codegen
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
-      '@unstoppablejs/client':
-        specifier: 0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671
-        version: 0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671
       '@unstoppablejs/sc-provider':
         specifier: ^0.2.0
         version: 0.2.0(@substrate/connect@0.7.31)
-      '@unstoppablejs/substrate-bindings':
-        specifier: workspace:*
-        version: link:../substrate-bindings
-      '@unstoppablejs/substrate-client':
-        specifier: workspace:*
-        version: link:../substrate-client
-      '@unstoppablejs/substrate-codegen':
-        specifier: workspace:*
-        version: link:../substrate-codegen
       '@unstoppablejs/utils':
         specifier: ^1.1.0
         version: 1.1.0
@@ -161,7 +158,7 @@ importers:
 
   packages/substrate-codegen:
     dependencies:
-      '@unstoppablejs/substrate-bindings':
+      '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../substrate-bindings
       '@unstoppablejs/utils':
@@ -654,12 +651,6 @@ packages:
 
   /@types/wrap-ansi@3.0.0:
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
-    dev: false
-
-  /@unstoppablejs/client@0.0.0-experimental-d05a4674-ed4e-466d-bf47-213030678671:
-    resolution: {integrity: sha512-XVs0Us4dTGhVqVAVhXPuPoqvT3IBi2Kk9A2kjCrWuNzm1EU4XKENx+qLdS7jzQbw+DN8XRowxe7Nx1q0EA/4IQ==}
-    dependencies:
-      '@unstoppablejs/provider': 0.0.1
     dev: false
 
   /@unstoppablejs/provider@0.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,15 +47,15 @@ importers:
       '@polkadot-api/substrate-codegen':
         specifier: workspace:*
         version: link:../packages/substrate-codegen
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../packages/utils
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
       '@unstoppablejs/sc-provider':
         specifier: ^0.2.0
         version: 0.2.0(@substrate/connect@0.7.31)
-      '@unstoppablejs/utils':
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^20.4.7
@@ -81,15 +81,15 @@ importers:
       '@polkadot-api/substrate-codegen':
         specifier: workspace:*
         version: link:../substrate-codegen
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@substrate/connect':
         specifier: ^0.7.31
         version: 0.7.31
       '@unstoppablejs/sc-provider':
         specifier: ^0.2.0
         version: 0.2.0(@substrate/connect@0.7.31)
-      '@unstoppablejs/utils':
-        specifier: ^1.1.0
-        version: 1.1.0
       as-table:
         specifier: ^1.0.55
         version: 1.0.55
@@ -126,12 +126,12 @@ importers:
       '@noble/hashes':
         specifier: ^1.3.1
         version: 1.3.2
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@scure/base':
         specifier: ^1.1.1
         version: 1.1.3
-      '@unstoppablejs/utils':
-        specifier: ^1.1.0
-        version: 1.1.0
       scale-ts:
         specifier: ^1.4.0
         version: 1.4.1
@@ -149,9 +149,9 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
     devDependencies:
-      '@unstoppablejs/utils':
-        specifier: ^1.1.0
-        version: 1.1.0
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@vitest/coverage-v8':
         specifier: ^0.34.3
         version: 0.34.4(vitest@0.34.4)
@@ -161,9 +161,8 @@ importers:
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../substrate-bindings
-      '@unstoppablejs/utils':
-        specifier: ^1.1.0
-        version: 1.1.0
+
+  packages/utils: {}
 
 packages:
 
@@ -665,9 +664,6 @@ packages:
       '@substrate/connect': 0.7.31
       '@unstoppablejs/provider': 0.0.1
     dev: false
-
-  /@unstoppablejs/utils@1.1.0:
-    resolution: {integrity: sha512-/eye4a/vYlZ8I2s4jj6Mpwko6bKW4gIRGrEFYvj07UcauQjljlluXi24Q9Rct8BOary3Y2L5HJ3wjK66I1mUqA==}
 
   /@vitest/coverage-v8@0.34.4(vitest@0.34.4):
     resolution: {integrity: sha512-TZ5ghzhmg3COQqfBShL+zRQEInHmV9TSwghTdfkHpCTyTOr+rxo6x41vCNcVfWysWULtqtBVpY6YFNovxnESfA==}


### PR DESCRIPTION
There are still a few references left to the following unstoppablejs packages:

- "@unstoppablejs/provider"
- "@unstoppablejs/sc-provider"
- "@unstoppablejs/utils"

I will address that in a following up PR.

Once this gets merged, I will rename this repo to `polkadot-api` and "CAPI-old" back to "CAPI"

EDIT: in the end, I ended up addressing these things ^ in the same PR.